### PR TITLE
Rename iterations -> n_estimators; accept cat_features by column name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
   inference cost.
 - **`cat_features` as a constructor argument**, so `GridSearchCV`/`Pipeline` can
   carry it; a value passed to `fit` still overrides it.
+- **`cat_features` by column name.** Categoricals can now be marked by DataFrame
+  column name as well as integer position, or a mix — e.g.
+  `cat_features=["city", "brand"]`. Names are resolved against the DataFrame at fit.
 - **Input and hyperparameter validation.** Malformed constructor params (e.g.
-  non-positive `iterations`/`depth`, `depth` capped at 16 to avoid OOM, `lr > 0`,
+  non-positive `n_estimators`/`depth`, `depth` capped at 16 to avoid OOM, `lr > 0`,
   non-negative regularizers, `subsample`/`colsample` in `(0, 1]`,
   `cat_smoothing > 0`, known `loss`/`alpha`), `sample_weight` values (finite,
   non-negative, positive sum), `cat_features` indices, and `eval_set` shape now
@@ -37,6 +40,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
   columns at `predict` now raise instead of silently producing wrong predictions.
 
 ### Changed
+- **Renamed `iterations` → `n_estimators`** (BREAKING), matching the
+  LightGBM/XGBoost convention for the number of boosting rounds (trees). Update
+  any code that passed `iterations=...`.
 - **Regressor `depth` default is loss-adaptive.** `None` resolves to 6 for
   RMSE/MAE (behavior unchanged — predictions are bit-identical) and to 4 for
   `loss="Quantile"`, where deep leaves overfit the extreme-quantile tails.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to ChimeraBoost are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [0.11.0] - 2026-06-04
 ### Added
 - **Exact SHAP feature attributions** (`model.shap_values(X)`). Interventional
   TreeSHAP computed exactly — not approximated — by exploiting the oblivious tree

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # chimeraboost
 ### What if CatBoost was slightly worse, 12× faster, and all in Python?
 
-> ⚠️ **Project is in active development:** breaking changes should be expected.
-
 📖 **Documentation:** [bbstats.github.io/chimeraboost](https://bbstats.github.io/chimeraboost/)
 
 <center>

--- a/benchmarks/investigate_early_stopping.py
+++ b/benchmarks/investigate_early_stopping.py
@@ -34,16 +34,16 @@ def _datasets():
 
 # (label, kwargs).  None LR = library auto-default.
 CONFIGS = [
-    ("no-ES default (auto lr=0.04, 500 trees)", dict(iterations=500, early_stopping=False)),
-    ("ES default (auto lr=0.1, patience=10)",   dict(iterations=2000, early_stopping=True, early_stopping_rounds=10)),
+    ("no-ES default (auto lr=0.04, 500 trees)", dict(n_estimators=500, early_stopping=False)),
+    ("ES default (auto lr=0.1, patience=10)",   dict(n_estimators=2000, early_stopping=True, early_stopping_rounds=10)),
     # --- hold LR fixed at 0.1 to remove the auto-LR confound ---
-    ("no-ES  lr=0.1, 500 trees",                dict(iterations=500, early_stopping=False, learning_rate=0.1)),
-    ("ES     lr=0.1, patience=10",              dict(iterations=2000, early_stopping=True, early_stopping_rounds=10, learning_rate=0.1)),
-    ("ES     lr=0.1, patience=50",              dict(iterations=2000, early_stopping=True, early_stopping_rounds=50, learning_rate=0.1)),
-    ("ES     lr=0.1, patience=100",             dict(iterations=2000, early_stopping=True, early_stopping_rounds=100, learning_rate=0.1)),
+    ("no-ES  lr=0.1, 500 trees",                dict(n_estimators=500, early_stopping=False, learning_rate=0.1)),
+    ("ES     lr=0.1, patience=10",              dict(n_estimators=2000, early_stopping=True, early_stopping_rounds=10, learning_rate=0.1)),
+    ("ES     lr=0.1, patience=50",              dict(n_estimators=2000, early_stopping=True, early_stopping_rounds=50, learning_rate=0.1)),
+    ("ES     lr=0.1, patience=100",             dict(n_estimators=2000, early_stopping=True, early_stopping_rounds=100, learning_rate=0.1)),
     # --- hold LR fixed at 0.04 (the no-ES default) but turn ES on ---
-    ("no-ES  lr=0.04, 500 trees",               dict(iterations=500, early_stopping=False, learning_rate=0.04)),
-    ("ES     lr=0.04, patience=50",             dict(iterations=2000, early_stopping=True, early_stopping_rounds=50, learning_rate=0.04)),
+    ("no-ES  lr=0.04, 500 trees",               dict(n_estimators=500, early_stopping=False, learning_rate=0.04)),
+    ("ES     lr=0.04, patience=50",             dict(n_estimators=2000, early_stopping=True, early_stopping_rounds=50, learning_rate=0.04)),
 ]
 
 SEEDS = [0, 1, 2, 3, 4]
@@ -53,7 +53,7 @@ def run():
     data = _datasets()
     # warm numba
     Xw, yw = load_wine(return_X_y=True)
-    ChimeraBoostClassifier(iterations=20).fit(Xw, yw)
+    ChimeraBoostClassifier(n_estimators=20).fit(Xw, yw)
 
     for name, (kind, X, y) in data.items():
         higher_better = (kind == "clf")

--- a/benchmarks/knob_characterization.py
+++ b/benchmarks/knob_characterization.py
@@ -108,7 +108,7 @@ def _fit_eval(task, kw, Xtr, ytr, Xte, yte, cat, seed, threads):
     """Fit out-of-box (internal early-stop split) with kwargs `kw` (empty ==
     out-of-box baseline). Returns (metric, prediction_vector, n_trees)."""
     Est = ChimeraBoostRegressor if task == "regression" else ChimeraBoostClassifier
-    m = Est(iterations=rb.MAX_ITERS, early_stopping_rounds=rb.PATIENCE,
+    m = Est(n_estimators=rb.MAX_ITERS, early_stopping_rounds=rb.PATIENCE,
             random_state=seed, thread_count=threads, **kw)
     m.fit(Xtr, ytr, cat_features=cat)
     if task == "regression":

--- a/benchmarks/profile_fit.py
+++ b/benchmarks/profile_fit.py
@@ -91,7 +91,7 @@ def load(name):
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--dataset", default="adult", choices=list(DATASETS))
-    ap.add_argument("--iterations", type=int, default=500)
+    ap.add_argument("--n_estimators", type=int, default=500)
     ap.add_argument("--no-early-stopping", action="store_true")
     ap.add_argument("--top", type=int, default=25,
                     help="how many cProfile rows to print")
@@ -111,13 +111,13 @@ def main():
     # JIT warmup so first-iteration compile cost doesn't pollute the profile.
     print("Warmup (compiling numba kernels)...")
     warm_n = min(500, len(Xtr))
-    Est(iterations=5, random_state=0).fit(
+    Est(n_estimators=5, random_state=0).fit(
         Xtr[:warm_n], ytr[:warm_n], cat_features=cat_idx
     )
     _phase_times["build_tree"] = 0.0
 
     print("Profiling fit...")
-    kw = dict(iterations=args.iterations, random_state=0)
+    kw = dict(n_estimators=args.n_estimators, random_state=0)
     if not args.no_early_stopping:
         kw.update(early_stopping=True, early_stopping_rounds=50,
                   validation_fraction=0.15)

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -410,10 +410,10 @@ def _run_chimera(task, Xtr, ytr, Xte, yte, cat, threads, lr=None,
     # IMPORTANT: this measures OUT-OF-BOX DEFAULT behavior. We call fit(Xtr, ytr)
     # with NO explicit eval_set, so ChimeraBoost performs its own internal
     # early-stopping split (early_stopping=True, validation_fraction default) —
-    # exactly what a user gets from `ChimeraBoostX().fit(X, y)`. iterations and
+    # exactly what a user gets from `ChimeraBoostX().fit(X, y)`. n_estimators and
     # early_stopping_rounds come from the shared harness budget, which equals the
     # class defaults for the headline run, so the benchmark == the default.
-    m = Est(iterations=MAX_ITERS, early_stopping_rounds=PATIENCE,
+    m = Est(n_estimators=MAX_ITERS, early_stopping_rounds=PATIENCE,
             learning_rate=lr, depth=depth,
             subsample=subsample,
             cat_combinations=cat_combinations,
@@ -433,7 +433,7 @@ def _chimera_ens(n, task, Xtr, ytr, Xte, yte, cat, threads):
     """Shared implementation for all bagged-ChimeraBoost runners."""
     t = time.time()
     Est = ChimeraBoostRegressor if task == "regression" else ChimeraBoostClassifier
-    m = Est(iterations=MAX_ITERS, early_stopping=True, early_stopping_rounds=PATIENCE,
+    m = Est(n_estimators=MAX_ITERS, early_stopping=True, early_stopping_rounds=PATIENCE,
             n_ensembles=n, ensemble_n_jobs=1,
             thread_count=threads, random_state=0)
     m.fit(Xtr, ytr, cat_features=cat)
@@ -493,7 +493,7 @@ def _run_catboost(task, Xtr, ytr, Xte, yte, cat, threads):
     from catboost import CatBoostRegressor, CatBoostClassifier
     Xf, Xv, yf, yv = _val_split(Xtr, ytr, task, 0)
     t = time.time()
-    common = dict(iterations=MAX_ITERS, early_stopping_rounds=PATIENCE,
+    common = dict(n_estimators=MAX_ITERS, early_stopping_rounds=PATIENCE,
                   thread_count=threads or -1, verbose=False, random_seed=0)
     Est = CatBoostRegressor if task == "regression" else CatBoostClassifier
     m = Est(**common)

--- a/benchmarks/stage1_hs.py
+++ b/benchmarks/stage1_hs.py
@@ -59,7 +59,7 @@ def _run(make, est_cls, metric_name):
             X, y = make(rng)
             Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.25,
                                                   random_state=s)
-            m = est_cls(iterations=2000, hs_lambda=hl, random_state=s,
+            m = est_cls(n_estimators=2000, hs_lambda=hl, random_state=s,
                         thread_count=4)
             t0 = time.time()
             m.fit(Xtr, ytr)

--- a/benchmarks/stage1_leaf_estimation.py
+++ b/benchmarks/stage1_leaf_estimation.py
@@ -38,7 +38,7 @@ def _fit_chimera_brier(Xtr, ytr, Xte, yte, threads=None, **kw):
     but with overridable leaf-estimation kwargs. Returns the sum-convention
     Brier via the shared _compute_metrics, so it's comparable to the RUNNERS."""
     Xf, Xv, yf, yv = rb._val_split(Xtr, ytr, "binary", 0)
-    m = ChimeraBoostClassifier(iterations=rb.MAX_ITERS,
+    m = ChimeraBoostClassifier(n_estimators=rb.MAX_ITERS,
                                early_stopping_rounds=rb.PATIENCE,
                                depth=6, thread_count=threads, random_state=0, **kw)
     m.fit(Xf, yf, eval_set=(Xv, yv))

--- a/chimeraboost/booster.py
+++ b/chimeraboost/booster.py
@@ -51,7 +51,7 @@ def _apply_thread_count(thread_count):
     return n
 
 
-def _auto_learning_rate(n_samples, iterations, early_stopping):
+def _auto_learning_rate(n_samples, n_estimators, early_stopping):
     """Default learning rate when the user did not specify one.
 
     With early stopping, 0.1 (the field-standard default) lets early stopping
@@ -62,7 +62,7 @@ def _auto_learning_rate(n_samples, iterations, early_stopping):
     """
     if early_stopping:
         return 0.1
-    return float(np.clip(20.0 / max(iterations, 1), 0.03, 0.2))
+    return float(np.clip(20.0 / max(n_estimators, 1), 0.03, 0.2))
 
 
 class _EarlyStopper:
@@ -90,7 +90,7 @@ class _BaseBooster:
     `fit` and `predict_raw`.
     """
 
-    def __init__(self, iterations=500, learning_rate=None, depth=6,
+    def __init__(self, n_estimators=500, learning_rate=None, depth=6,
                  l2_leaf_reg=1.0, max_bins=128, subsample=1.0,
                  colsample=1.0, cat_smoothing=1.0, cat_n_permutations=4,
                  early_stopping_rounds=None, min_child_weight=1.0,
@@ -98,7 +98,7 @@ class _BaseBooster:
                  ordered_boosting=True, cat_combinations=False,
                  leaf_estimation_iterations=1, hs_lambda=0.0,
                  linear_leaves=False, linear_lambda=1.0):
-        self.iterations = int(iterations)
+        self.n_estimators = int(n_estimators)
         self.learning_rate = learning_rate
         self.depth = int(depth)
         self.l2_leaf_reg = float(l2_leaf_reg)
@@ -185,7 +185,7 @@ class _BaseBooster:
         if self.learning_rate is not None:
             return float(self.learning_rate)
         es = self.early_stopping_rounds is not None and eval_set is not None
-        return _auto_learning_rate(n_samples, self.iterations, es)
+        return _auto_learning_rate(n_samples, self.n_estimators, es)
 
     def _loo_update(self, tree, leaf, g, h):
         """Leave-one-out leaf step: each row's training update uses its leaf's
@@ -333,7 +333,7 @@ class GradientBoosting(_BaseBooster):
         stopper = _EarlyStopper(self.early_stopping_rounds)
         t0 = time.time()
 
-        for m in range(self.iterations):
+        for m in range(self.n_estimators):
             grad, hess = self.loss_.grad_hess(y, F)
             if w is not None:
                 grad, hess = grad * w, hess * w
@@ -398,7 +398,7 @@ class GradientBoosting(_BaseBooster):
                     self.trees_ = self.trees_[: stopper.best_iter + 1]
                     break
 
-            if self.verbose and (m % max(1, self.iterations // 10) == 0):
+            if self.verbose and (m % max(1, self.n_estimators // 10) == 0):
                 msg = f"[{m}] train {self.train_history_[-1]:.5f}"
                 if Fv is not None:
                     msg += f"  val {self.valid_history_[-1]:.5f}"
@@ -549,7 +549,7 @@ class MulticlassBoosting(_BaseBooster):
         stopper = _EarlyStopper(self.early_stopping_rounds)
         t0 = time.time()
 
-        for m in range(self.iterations):
+        for m in range(self.n_estimators):
             grad, hess = self.loss_.grad_hess(Y, F)   # (n, K) each
             if w is not None:
                 grad, hess = grad * w[:, None], hess * w[:, None]
@@ -591,7 +591,7 @@ class MulticlassBoosting(_BaseBooster):
                     self.trees_ = self.trees_[: stopper.best_iter + 1]
                     break
 
-            if self.verbose and (m % max(1, self.iterations // 10) == 0):
+            if self.verbose and (m % max(1, self.n_estimators // 10) == 0):
                 msg = f"[{m}] train {self.train_history_[-1]:.5f}"
                 if Fv is not None:
                     msg += f"  val {self.valid_history_[-1]:.5f}"

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -47,7 +47,7 @@ def _validate_hyperparams(estimator):
     validation -- never in ``__init__``). Without this, bad values either fail
     cryptically deep in numba (e.g. ``depth=-1`` -> "negative shift count"),
     silently produce a broken model (``learning_rate=-0.1`` diverges to garbage;
-    ``iterations=0`` builds an empty model), or OOM (``depth=30`` allocates a
+    ``n_estimators=0`` builds an empty model), or OOM (``depth=30`` allocates a
     2**30-leaf histogram). ``None`` is left to the documented per-parameter
     default resolution and is not rejected here.
     """
@@ -73,7 +73,7 @@ def _validate_hyperparams(estimator):
             raise ValueError(
                 f"{name} must be in {lb}{lo}, {hi}{rb}; got {v!r}.")
 
-    _pos_int("iterations")
+    _pos_int("n_estimators")
     _pos_int("cat_n_permutations")
     _pos_int("leaf_estimation_iterations")
     # depth: a depth-d tree allocates 2**d leaves in the histogram buffer, so an
@@ -116,6 +116,44 @@ def _resolve_cat_features(estimator, cat_features):
     if cat_features is not None:
         return cat_features
     return getattr(estimator, "cat_features", None)
+
+
+def _resolve_cat_feature_names(cat_features, X):
+    """Map any column *names* in ``cat_features`` to integer positions using X's
+    column metadata, leaving integer indices untouched.
+
+    Lets a user mark categoricals the same way LightGBM/CatBoost do -- either by
+    position (``cat_features=[0, 2]``) or by name (``cat_features=["city",
+    "brand"]``), or a mix. Names are resolved against the DataFrame columns at
+    fit time, so order changes are handled by the existing predict-time feature-
+    name check. Returns ``None`` unchanged; returns the original object when it
+    holds no strings (the downstream integer validation then applies)."""
+    if cat_features is None:
+        return None
+    try:
+        items = list(cat_features)
+    except TypeError:
+        return cat_features  # not iterable; let downstream validation report it
+    if not any(isinstance(c, str) for c in items):
+        return cat_features
+    names = _extract_feature_names(X)
+    if names is None:
+        raise ValueError(
+            "cat_features contains column names (strings), but X has no column "
+            "names to resolve them against; pass integer indices instead, or "
+            "fit on a DataFrame.")
+    name_to_idx = {n: i for i, n in enumerate(names)}
+    resolved = []
+    for c in items:
+        if isinstance(c, str):
+            if c not in name_to_idx:
+                raise ValueError(
+                    f"cat_features name {c!r} is not a column of X; columns are "
+                    f"{list(names)}.")
+            resolved.append(name_to_idx[c])
+        else:
+            resolved.append(c)
+    return resolved
 
 
 def _check_eval_set(eval_set, n_features):
@@ -582,9 +620,9 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
 
     Parameters
     ----------
-    iterations : int, default 2000
-        Maximum number of boosting rounds. With ``early_stopping`` on, this is an
-        upper bound and the best round is selected automatically.
+    n_estimators : int, default 2000
+        Maximum number of boosting rounds (trees). With ``early_stopping`` on,
+        this is an upper bound and the best round is selected automatically.
     learning_rate : float or None, default None
         Shrinkage applied to each tree. ``None`` resolves to 0.1 when early
         stopping is active.
@@ -653,10 +691,12 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         averages independent members fit on bootstrap resamples.
     ensemble_n_jobs : int, default 1
         Processes used to fit ensemble members; -1 uses all cores.
-    cat_features : list of int or None, default None
-        Default categorical column indices. Used when ``fit`` is called without
-        its own ``cat_features`` (the fit argument overrides). Provided as a
-        constructor argument so ``GridSearchCV``/``Pipeline`` can carry it.
+    cat_features : list of int or str, or None, default None
+        Default categorical columns, given as integer positions and/or column
+        names (names resolved against the DataFrame at fit). Used when ``fit`` is
+        called without its own ``cat_features`` (the fit argument overrides).
+        Provided as a constructor argument so ``GridSearchCV``/``Pipeline`` can
+        carry it.
 
     Attributes
     ----------
@@ -671,7 +711,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         Fitted members when ``n_ensembles > 1``, otherwise ``None``.
     """
 
-    def __init__(self, iterations=2000, learning_rate=None, depth=None,
+    def __init__(self, n_estimators=2000, learning_rate=None, depth=None,
                  l2_leaf_reg=1.0, max_bins=128, subsample=1.0, colsample=1.0,
                  cat_smoothing=1.0, cat_n_permutations=4,
                  early_stopping_rounds=None,
@@ -681,7 +721,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                  hs_lambda=0.0, linear_leaves=False, linear_lambda=1.0,
                  early_stopping=True, validation_fraction=0.2,
                  n_ensembles=None, ensemble_n_jobs=1, cat_features=None):
-        self.iterations = iterations
+        self.n_estimators = n_estimators
         self.learning_rate = learning_rate
         self.depth = depth
         self.l2_leaf_reg = l2_leaf_reg
@@ -717,8 +757,9 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         ----------
         X, y : array-like
             Training data.
-        cat_features : list of int or None
-            Column indices to treat as categoricals. Falls back to the
+        cat_features : list of int or str, or None
+            Columns to treat as categoricals, given as integer positions and/or
+            column names (names resolved against the DataFrame). Falls back to the
             ``cat_features`` constructor argument when not given here; passing it
             here overrides the constructor value. (The constructor form lets
             ``GridSearchCV``/``Pipeline`` carry it, which a fit-only kwarg can't.)
@@ -735,6 +776,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
             to the training set; the validation eval metric is always unweighted.
         """
         cat_features = _resolve_cat_features(self, cat_features)
+        cat_features = _resolve_cat_feature_names(cat_features, X)
         _validate_hyperparams(self)
         y = _validate_fit_input(self, X, y, cat_features, sample_weight,
                                 classification=False)
@@ -872,9 +914,9 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
 
     Parameters
     ----------
-    iterations : int, default 2000
-        Maximum number of boosting rounds. With ``early_stopping`` on, this is an
-        upper bound and the best round is selected automatically.
+    n_estimators : int, default 2000
+        Maximum number of boosting rounds (trees). With ``early_stopping`` on,
+        this is an upper bound and the best round is selected automatically.
     learning_rate : float or None, default None
         Shrinkage applied to each tree. ``None`` resolves to 0.1 when early
         stopping is active.
@@ -932,10 +974,12 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         soft-votes the calibrated probabilities of members fit on bootstraps.
     ensemble_n_jobs : int, default 1
         Processes used to fit ensemble members; -1 uses all cores.
-    cat_features : list of int or None, default None
-        Default categorical column indices. Used when ``fit`` is called without
-        its own ``cat_features`` (the fit argument overrides). Provided as a
-        constructor argument so ``GridSearchCV``/``Pipeline`` can carry it.
+    cat_features : list of int or str, or None, default None
+        Default categorical columns, given as integer positions and/or column
+        names (names resolved against the DataFrame at fit). Used when ``fit`` is
+        called without its own ``cat_features`` (the fit argument overrides).
+        Provided as a constructor argument so ``GridSearchCV``/``Pipeline`` can
+        carry it.
 
     Attributes
     ----------
@@ -953,7 +997,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         Fitted members when ``n_ensembles > 1``, otherwise ``None``.
     """
 
-    def __init__(self, iterations=2000, learning_rate=None, depth=6,
+    def __init__(self, n_estimators=2000, learning_rate=None, depth=6,
                  l2_leaf_reg=1.0, max_bins=128, subsample=1.0, colsample=1.0,
                  cat_smoothing=1.0, cat_n_permutations=4,
                  early_stopping_rounds=None,
@@ -963,7 +1007,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                  hs_lambda=0.0, linear_leaves=None, linear_lambda=1.0,
                  early_stopping=True, validation_fraction=0.2,
                  n_ensembles=None, ensemble_n_jobs=1, cat_features=None):
-        self.iterations = iterations
+        self.n_estimators = n_estimators
         self.learning_rate = learning_rate
         self.depth = depth
         self.l2_leaf_reg = l2_leaf_reg
@@ -997,8 +1041,9 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         ----------
         X, y : array-like
             Training data.
-        cat_features : list of int or None
-            Column indices to treat as categoricals. Falls back to the
+        cat_features : list of int or str, or None
+            Columns to treat as categoricals, given as integer positions and/or
+            column names (names resolved against the DataFrame). Falls back to the
             ``cat_features`` constructor argument when not given here; passing it
             here overrides the constructor value. (The constructor form lets
             ``GridSearchCV``/``Pipeline`` carry it, which a fit-only kwarg can't.)
@@ -1014,6 +1059,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
             to the training set; the validation eval metric is always unweighted.
         """
         cat_features = _resolve_cat_features(self, cat_features)
+        cat_features = _resolve_cat_feature_names(cat_features, X)
         _validate_hyperparams(self)
         y = _validate_fit_input(self, X, y, cat_features, sample_weight,
                                 classification=True)

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -42,7 +42,7 @@ Core design choices (all deliberate, all validated):
 | `ordered_boosting` (LOO) | False | False |
 | `leaf_estimation_iterations` | 1 | 3 |
 | `min_child_weight` | 1.0 | None → size-adaptive `_auto_min_child_weight(n)` |
-| `iterations` / patience | 2000 max, patience 50 | same |
+| `n_estimators` / patience | 2000 max, patience 50 | same |
 
 `_auto_min_child_weight(n) = clip((2000 − n)/1500, 0, 1)`: full veto (~1) below ~500
 training rows, 0 above ~2000. This is one of our most important defaults (see §4).

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,8 +1,8 @@
 # API reference
 
-Both estimators follow the scikit-learn interface: construct, `fit`, then
-`predict` / `predict_proba`. Constructor parameters are documented below; for
-guidance on which ones to change, see [Parameters](parameters.md).
+Both estimators are scikit-learn compatible, with `fit`, then
+`predict` / `predict_proba` methods. Parameters are documented below; for
+guidance on which ones to tweak, see [Parameters](parameters.md).
 
 ::: chimeraboost.ChimeraBoostRegressor
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,19 +1,16 @@
 # How it works
 
-The pieces behind the defaults, and why they are there.
-
 ## Oblivious trees
 
 Every node at a given depth splits on the same `(feature, threshold)`. A depth-`d` tree
 is therefore `d` splits, and a sample's leaf is a `d`-bit number: bit `k` is 1 when the
-sample exceeds the threshold at level `k`. Two consequences follow:
+sample exceeds the threshold at level `k`. This leads to:
 
 - **Speed.** Prediction is `d` comparisons and one array lookup. The whole forest is
   evaluated in a single numba pass parallelized over samples, so each sample loads its
   feature values once and walks every tree while they stay in cache.
 - **Regularization.** A tree has only `d` splits, shared across its level, which limits
-  how sharply it can carve the input space. This is much of why the defaults resist
-  overfitting without heavy tuning.
+  how sharply it can carve the input space.
 
 The trade-off is sharpness: a leaf-wise tree can isolate a local region in fewer splits
 than an oblivious tree, which matters on clean, high-signal data. Raising `depth` and
@@ -28,34 +25,32 @@ directly at fit and predict time — no imputation.
 
 ## Categorical features
 
-Categoricals are encoded with **ordered target statistics**, the CatBoost approach: each
+Categoricals are encoded with **ordered target statistics**, i.e. the CatBoost approach: each
 category is replaced by a running estimate of the target computed under a random ordering
 of the rows, so a row never sees its own label. Several orderings
 (`cat_n_permutations`, default 4) are averaged to cut variance, and rare categories are
-shrunk toward the global mean by `cat_smoothing`. Pass the column indices to
-`fit(..., cat_features=[...])`; everything else is automatic.
+shrunk toward the global mean by `cat_smoothing`. Pass the columns (by integer position or
+column name) to `fit(..., cat_features=[...])`; everything else is automatic.
 
 `cat_combinations=True` additionally builds all pairwise category-by-category features.
 
 ## Leaf values and linear leaves
 
-By default each leaf predicts a single constant — the regularized Newton step over the
-rows it contains. With `linear_leaves`, a leaf instead fits a small ridge **linear
-model** over the numeric features the tree split on, adding local slope where a constant
-underfits smooth structure. Leaves with too few rows fall back to a constant, so small
-data is protected. Linear leaves are on by default for binary classification and opt-in
-for regression.
+By default each leaf predicts a single constant value. With `linear_leaves`, a leaf
+instead fits a small ridge **linear model** over the numeric features the tree split on,
+adding local slope where a constant underfits smooth structure. Leaves with too few rows
+fall back to norma behavior to reduce overfitting small datasets. Linear leaves are on by
+default for binary classification, but off for regression.
 
 `hs_lambda` (hierarchical shrinkage) optionally pulls each leaf value toward its
-ancestors, hardest for deep or low-mass leaves — a regularizer applied as a cheap
-post-pass with no inference cost.
+ancestors' value.
 
 ## Probability calibration
 
 After fitting, the classifier scales its raw scores by a single temperature chosen on
-the validation split to minimize log loss. The scaling is monotonic, so `predict`, AUC,
-and accuracy are unchanged while `predict_proba` becomes better calibrated. The fitted
-value is exposed as `temperature_`.
+the validation split to minimize log loss. The scaling is monotonic, so AUC and accuracy
+are unchanged while probabilities (i.e. with `predict_proba`) becomes better calibrated.
+The fitted value is exposed as `temperature_`.
 
 ## Bagging and subsampling
 
@@ -67,6 +62,4 @@ unbiased, concentrating effort on the rows that still carry signal.
 
 ## SHAP
 
-Because the trees are oblivious, exact interventional SHAP is cheap: a depth-`D` tree
-involves at most `D` distinct features, so the Shapley coalition game is enumerated
-directly rather than sampled. See [SHAP](shap.md) for details.
+See [SHAP](shap.md) for details.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,47 +2,27 @@
 
 ## Does it use the GPU?
 
-No. ChimeraBoost is CPU-only, compiled with numba and parallelized across cores. There
-is no CUDA dependency and no GPU build.
+No.
 
 ## How does it compare to CatBoost, LightGBM, and XGBoost?
 
-It targets the same problems with a different trade-off: roughly CatBoost-class accuracy
-at a fraction of the training time, and ahead of XGBoost and LightGBM defaults on both
-accuracy and speed on TabArena-Lite. The design borrows oblivious trees and ordered
-target statistics from CatBoost and histogram split-finding from LightGBM, implemented
-in pure Python. It is not trying to win the >10M-row distributed regime those libraries
-also serve.
+On defaults: roughly around LightGBM/XGBoost or better, and significantly faster than CatBoost.
+Setting n_ensembles=10 automatically ensembles the model through bagging, and gets accuracy
+and speed roughly = to CatBoost. Note that since TabArena uses ensembling, this improvement
+does not show up on those pareto chart results.
 
 ## Do I need to one-hot encode categoricals or impute missing values?
 
-No to both. Pass categorical column indices to `fit(..., cat_features=[...])` and they
-are handled with ordered target statistics. NaNs route to a dedicated bin at fit and
-predict time, so no imputation is needed.
+No.
 
-## Does column order matter when I predict on a DataFrame?
+Pass your categorical columns to `fit(..., cat_features=[...])`, by integer position or by column name.
+NaNs route to a dedicated bin at fit and predict time, so no imputation is needed.
 
-Yes. If you fit on a DataFrame (pandas or polars), the column **names and order** are
-recorded, and `predict` raises if the columns you pass don't match — reordered or renamed
-columns would otherwise produce silently-wrong predictions, since the model consumes
-columns positionally. Pass the same columns in the same order (or plain arrays on both
-sides). This mirrors scikit-learn's behavior.
 
-## What input does it reject, and how?
+## How can I make inference faster?
 
-Malformed input fails fast with a clear message rather than a cryptic crash or a silently
-broken model. A non-numeric column passed without `cat_features` names the offending
-column and points you at `cat_features`; out-of-range `cat_features` indices, bad
-`eval_set` shapes, non-finite or negative `sample_weight`, and out-of-range
-hyperparameters (e.g. negative `learning_rate`, `depth` outside `[1, 16]`) all raise
-`ValueError`. `inf` is rejected at both fit and predict; `NaN` is accepted as missing.
-
-## How do I make inference as fast as possible?
-
-Prediction is already fast (oblivious trees, a single fused forest pass). The one
-per-row check on the hot path is a finiteness scan that rejects `inf`. If you have
-already validated your serving data and want to skip it, use scikit-learn's global
-config — the same switch its own estimators honor:
+If you have already validated your serving data and want to skip it,
+use scikit's 'assume_finite'.
 
 ```python
 import sklearn
@@ -50,21 +30,6 @@ with sklearn.config_context(assume_finite=True):
     preds = model.predict(X)        # finiteness scan skipped
 ```
 
-## Is it deterministic?
-
-Yes, given a fixed `random_state` and `thread_count`. With multiple threads, the order
-of floating-point reductions can vary across runs or machines, producing tiny numerical
-differences; pin `thread_count` for bit-stable results.
-
-## How large a dataset can it handle?
-
-It is built for in-memory, cache-resident data and is comfortable into the hundreds of
-thousands to low millions of rows. It is not a distributed or out-of-core system.
-
-## Can I get probability estimates?
-
-Yes — `predict_proba` returns probabilities that are temperature-scaled on the
-validation split for calibration. See [calibration](concepts.md#probability-calibration).
 
 ## Why oblivious (symmetric) trees?
 
@@ -73,8 +38,7 @@ cost to per-tree sharpness. See [How it works](concepts.md#oblivious-trees).
 
 ## Does SHAP support multiclass?
 
-Not yet. `shap_values` works for regression and binary classification; multiclass raises
-`NotImplementedError`.
+Not yet.
 
 ## How do I save and load a model?
 
@@ -88,11 +52,9 @@ model = joblib.load("model.joblib")
 
 ## What exactly does it depend on?
 
-NumPy, numba, scikit-learn, SciPy, and pandas. No C or C++ extensions, and no build
-toolchain — the whole library is Python.
+NumPy, numba, scikit-learn, SciPy, and pandas.
 
 ## How do I tune it?
 
-Most problems need no tuning. When they do, reach for `depth` (raise to 8–10 for large,
-interaction-heavy regression) and `n_ensembles` (variance reduction) first. See
-[Parameters](parameters.md).
+First reach for `depth` (raise to 8–10 for large, interaction-heavy regression) or
+`n_ensembles` (variance reduction) first. See [Parameters](parameters.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,15 +1,12 @@
 # Getting started
 
-A regression model and a classification model, end to end, on datasets that ship with
-scikit-learn — every block runs as written.
-
 ## Install
 
 ```bash
 pip install chimeraboost
 ```
 
-Python 3.9 or newer. The only dependencies are NumPy, numba, scikit-learn, SciPy, and pandas.
+(Python 3.9 or newer)
 
 ## Regression
 
@@ -32,7 +29,7 @@ ChimeraBoostRegressor(random_state=0)
 56.82
 ```
 
-The bare constructor early-stops on an internal validation split and keeps the best round:
+Number of trees selected:
 
 ```pycon
 >>> reg.best_iteration_

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -1,102 +1,97 @@
 # Parameters
 
-Every constructor option for `ChimeraBoostRegressor` and `ChimeraBoostClassifier`,
-grouped by what it controls, with both defaults shown where they differ. The defaults
-are the benchmarked configuration, so most problems need no tuning. The **Tune?**
-column flags the few worth reaching for; in practice that is usually just `depth`,
-`n_ensembles`, and `random_state`.
-
-For exact types and the auto-generated reference, see the [API reference](api.md).
+For more detail, see [API reference](api.md).
 
 ## Core boosting
 
-| Parameter | Default | Tune? | Effect |
-|---|---|:--:|---|
-| `iterations` | `2000` | rarely | Maximum boosting rounds. With early stopping on, an upper bound rather than a target. |
-| `learning_rate` | `None` (auto) | rarely | Per-tree shrinkage. `None` resolves to 0.1 with early stopping. Lower trades more trees for slightly better fit. |
-| `depth` | `None`→auto | **yes** | Tree depth (a depth-d tree is d splits). The regressor's `None` resolves to 6 for squared/absolute error and 4 for `loss="Quantile"` (deep leaves overfit the tail quantile). Conservative by default; raise to 8–10 for large, interaction-heavy regression. |
-| `l2_leaf_reg` | `1.0` | rarely | L2 penalty on leaf values. Higher is smoother. |
-| `min_child_weight` | `1.0` (reg) / `None`→auto (clf) | rarely | Minimum hessian mass on each side of a split. The classifier's `None` is size-adaptive: full veto below ~500 rows, off above ~2000. |
-| `leaf_estimation_iterations` | `1` (reg) / `3` (clf) | rarely | Extra Newton refinement steps per leaf. Helps logloss; little effect on squared error. |
+| Parameter | Default | Effect |
+|---|---|---|
+| `n_estimators` | `2000` | Maximum boosting rounds (trees). |
+| `learning_rate` | `None` (auto) | Per-tree shrinkage. `None` resolves to 0.1 with early stopping. Lower trades more trees for slightly better fit. |
+| `depth` | `None`→auto | Tree depth (a depth-d tree is d splits). Defaults to to 6 for squared/absolute error and 4 for `loss="Quantile"` (deep leaves overfit the tail quantile). Conservative by default; raise to 8–10 for large, interaction-heavy regression. |
+| `l2_leaf_reg` | `1.0` | L2 penalty on leaf values. Higher is smoother. |
+| `min_child_weight` | `1.0` (reg) / `None`→auto (clf) | Minimum hessian mass on each side of a split. The classifier's `None` is size-adaptive: gradates off when below 500 rows, gradates off when above 2000. |
+| `leaf_estimation_iterations` | `1` (reg) / `3` (clf) | Extra Newton refinement steps per leaf. Likely more important to tune in classification tasks. |
 
 ## Binning
 
-| Parameter | Default | Tune? | Effect |
-|---|---|:--:|---|
-| `max_bins` | `128` | no | Histogram bins per numeric feature. Raising it overfits noise and slows builds without generalizing. |
+| Parameter | Default | Effect |
+|---|---|---|
+| `max_bins` | `128` | Histogram bins per numeric feature. Raising it can improve fit in some scenarios. |
 
 ## Row and column sampling
 
-| Parameter | Default | Tune? | Effect |
-|---|---|:--:|---|
-| `subsample` | `1.0` | optional | Row fraction per tree. Below 1.0, uses Minimum Variance Sampling (gradient-weighted, unbiased). |
-| `colsample` | `1.0` | optional | Feature fraction eligible per tree. |
+| Parameter | Default | Effect |
+|---|---|---|
+| `subsample` | `1.0` | Row fraction per tree. Below 1.0, uses Minimum Variance Sampling (gradient-weighted, unbiased). |
+| `colsample` | `1.0` | Feature fraction eligible per tree. |
 
 ## Categorical features
 
-| Parameter | Default | Tune? | Effect |
-|---|---|:--:|---|
-| `cat_smoothing` | `1.0` | rarely | Prior strength for ordered target statistics; higher shrinks rare categories toward the global mean. Must be `> 0` (a Bayesian pseudocount; `0` is rejected). |
-| `cat_n_permutations` | `4` | no | Random orderings averaged by the ordered target encoder. |
-| `cat_combinations` | `False` | optional | Add all pairwise category-by-category features. Helps mostly-categorical data, can crowd out numerics on mixed data. |
+| Parameter | Default | Effect |
+|---|---|---|
+| `cat_smoothing` | `1.0` | Prior strength for ordered target statistics; higher shrinks rare categories toward the global mean. Must be `> 0`. |
+| `cat_n_permutations` | `4` | Random orderings averaged by the ordered target encoder. |
+| `cat_combinations` | `False` | Add all pairwise category-by-category features. Helps mostly-categorical data, can crowd out numerics on mixed data. |
 
 Which columns are categorical can be passed either to `fit(..., cat_features=[...])` or as the
-`cat_features` constructor argument. The constructor form lets `GridSearchCV`/`Pipeline` carry
-it; a value passed to `fit` overrides the constructor one.
+`cat_features` to your ChimeraBoostRegressor/ChimeraBoostClassifier arguments depending on your use case.
+Columns may be named by integer position or by column name (resolved against the DataFrame), or a
+mix — e.g. `cat_features=["city", "brand"]` or `cat_features=[0, 3]`.
 
 ## Loss (regressor only)
 
-| Parameter | Default | Tune? | Effect |
-|---|---|:--:|---|
-| `loss` | `"RMSE"` | task | `"RMSE"`, `"MAE"` (median), or `"Quantile"`. |
-| `alpha` | `0.5` | task | Quantile level for `loss="Quantile"`. |
+| Parameter | Default | Effect |
+|---|---|---|
+| `loss` | `"RMSE"` | `"RMSE"`, `"MAE"` (median), or `"Quantile"`. |
+| `alpha` | `0.5` | Quantile level for `loss="Quantile"`. |
 
 The classifier picks its loss automatically: binary logloss for 2 classes, softmax for 3+.
 
 ## Leaf models
 
-| Parameter | Default | Tune? | Effect |
-|---|---|:--:|---|
-| `linear_leaves` | `False` (reg) / `None`→auto (clf) | optional | Fit a ridge linear model per leaf over the numeric split features instead of a constant. On by default for binary classification; falls back to constant below ~1000 rows. Not available with MAE/Quantile or multiclass. |
-| `linear_lambda` | `1.0` | optional | Ridge penalty on per-leaf slopes; larger is closer to a constant. |
-| `hs_lambda` | `0.0` | optional | Hierarchical shrinkage: above 0, leaf values are pulled toward their ancestors, hardest for deep or low-mass leaves. |
+| Parameter | Default | Effect |
+|---|---|---|
+| `linear_leaves` | `False` (reg) / `None`→auto (clf) | Fit a ridge linear model per leaf over the numeric split features instead of a constant. On by default for binary classification; falls back to constant below ~1000 rows. Not available with MAE/Quantile or multiclass. |
+| `linear_lambda` | `1.0` | Ridge penalty on per-leaf slopes; larger is closer to a constant. |
+| `hs_lambda` | `0.0` | Hierarchical shrinkage: above 0, leaf values are pulled toward their ancestors, hardest for deep or low-mass leaves. |
 
 ## Ordered boosting
 
-| Parameter | Default | Tune? | Effect |
-|---|---|:--:|---|
-| `ordered_boosting` | `False` | no | Leave-one-out leaf training step. Off by default; mutually exclusive with `leaf_estimation_iterations` in the booster. Tends to *hurt* accuracy here (the plain Newton path plus leaf refinement wins broadly), so leave it off unless you have a specific reason. |
+| Parameter | Default | Effect |
+|---|---|---|
+| `ordered_boosting` | `False` | Leave-one-out leaf training step. Off by default; mutually exclusive with `leaf_estimation_iterations` in the booster. |
 
 ## Early stopping
 
-| Parameter | Default | Tune? | Effect |
-|---|---|:--:|---|
-| `early_stopping` | `True` | rarely | Hold out a validation split and stop on a plateau. Set `False` to build a fixed `iterations` trees. |
-| `early_stopping_rounds` | `None`→`50` | rarely | Patience when early stopping is active. |
-| `validation_fraction` | `0.2` | rarely | Held-out fraction (stratified for classifiers). Ignored when `eval_set` is passed to `fit`. |
+| Parameter | Default | Effect |
+|---|---|---|
+| `early_stopping` | `True` | Hold out a validation split and stop on a plateau. Set `False` to build a fixed `n_estimators` trees. |
+| `early_stopping_rounds` | `None`→`50` | Patience when early stopping is active. |
+| `validation_fraction` | `0.2` | Held-out fraction (stratified for classifiers). Ignored when `eval_set` is passed to `fit`. |
 
 See [Recipes → early stopping](recipes.md#early-stopping) for `eval_set` and `groups`.
 
 ## Bagging
 
-| Parameter | Default | Tune? | Effect |
-|---|---|:--:|---|
-| `n_ensembles` | `None` | **yes** | `None`/`1` is a single model; `≥2` averages members fit on bootstrap resamples. Reduces variance. |
-| `ensemble_n_jobs` | `1` | optional | Processes used to fit members; `-1` uses all cores. |
+| Parameter | Default | Effect |
+|---|---|---|
+| `n_ensembles` | `None` | `None`/`1` is a single model; `≥2` averages members fit on bootstrap resamples. Reduces variance. |
+| `ensemble_n_jobs` | `1` | Processes used to fit members; `-1` uses all cores. |
 
 ## System
 
-| Parameter | Default | Tune? | Effect |
-|---|---|:--:|---|
-| `thread_count` | `None` | optional | numba threads. `None`/`-1` uses all cores. Affects determinism of floating-point reductions. |
-| `random_state` | `None` | **yes** | Seed (deterministic for a fixed `thread_count`). |
-| `verbose` | `False` | optional | Print per-round metrics. |
+| Parameter | Default | Effect |
+|---|---|---|
+| `thread_count` | `None` | numba threads. `None`/`-1` uses all cores. Affects determinism of floating-point reductions. |
+| `random_state` | `None` | Seed (deterministic for a fixed `thread_count`). |
+| `verbose` | `False` | Print per-round metrics. |
 
 ## `fit()` arguments
 
 | Argument | Effect |
 |---|---|
-| `cat_features` | Column indices to treat as categorical. |
+| `cat_features` | Columns to treat as categorical, by integer position and/or column name. |
 | `eval_set` | `(X_val, y_val)` validation set; overrides the internal split. |
 | `groups` | Group labels; keeps each group entirely in train or validation when auto-splitting. |
 | `sample_weight` | Per-sample training weights (normalized to mean 1). |

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,6 +1,6 @@
 # Recipes
 
-Worked examples for common tasks. Every snippet assumes:
+FIRST:
 
 ```python
 import numpy as np
@@ -22,14 +22,18 @@ A plain `fit(X, y)` early-stops on an internal holdout — see [Early stopping](
 
 ## Categorical features
 
-Pass the column indices of your categoricals as `cat_features`. They are encoded with
-ordered target statistics (CatBoost-style), so there is no one-hot or `LabelEncoder`
-step. Categorical columns can be strings or objects; the rest of the matrix stays numeric.
+Pass your categoricals as `cat_features`, by integer position or — for a DataFrame — by
+column name (or a mix of both). They are encoded with ordered target statistics
+(CatBoost-style), so there is no one-hot or `LabelEncoder` step. Categorical columns can be
+strings or objects; the rest of the matrix stays numeric.
 
 ```python
 # columns 0 and 3 are categorical (e.g. "city", "device_type")
 clf = ChimeraBoostClassifier(random_state=0)
 clf.fit(X, y, cat_features=[0, 3])
+
+# equivalently, by name when X is a DataFrame
+clf.fit(df, y, cat_features=["city", "device_type"])
 ```
 
 For mostly-categorical data, `cat_combinations=True` adds all pairwise category-by-category
@@ -64,7 +68,7 @@ Quantile models default to a shallower tree (`depth=4`) than the squared-error
 default (`depth=6`): an extreme conditional quantile is estimated from the points in
 each leaf, so deep, sparse leaves overfit the tails and the predicted quantiles
 collapse toward the median on held-out data. If your intervals still look too narrow,
-go shallower (`depth=3`); if they look too wide, raise `depth` and add more `iterations`.
+go shallower (`depth=3`); if they look too wide, raise `depth` and add more `n_estimators`.
 As with any tree-based quantile model, held-out coverage is approximate, not exact.
 
 ## Multiclass classification
@@ -125,7 +129,7 @@ m.fit(X_train, y_train, eval_set=(X_val, y_val))
 m.fit(X_train, y_train, groups=subject_ids)
 
 # fixed number of trees, no stopping
-m = ChimeraBoostRegressor(early_stopping=False, iterations=500, random_state=0)
+m = ChimeraBoostRegressor(early_stopping=False, n_estimators=500, random_state=0)
 m.fit(X_train, y_train)
 ```
 
@@ -177,8 +181,9 @@ search.fit(X, y)
 print(search.best_params_)
 ```
 
-To pass `cat_features` through a search, set it once on the estimator via a small
-wrapper or use a `Pipeline` whose final step is the booster.
+To pass `cat_features` through a search, set it on the constructor —
+`ChimeraBoostClassifier(cat_features=["city", "brand"])` — so the meta-estimator
+carries it (a fit-only kwarg can't be).
 
 ## Save and load a model
 

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -12,7 +12,7 @@ X, y = load_breast_cancer(return_X_y=True)
 Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.2, random_state=0, stratify=y)
 
 clf = ChimeraBoostClassifier(
-    iterations=1000,
+    n_estimators=1000,
     early_stopping_rounds=50,
     random_state=0,
 )
@@ -42,7 +42,7 @@ X[:, 2] = age
 X[:, 3] = usage
 Xtr, Xte, ytr, yte = train_test_split(X, churn, test_size=0.25, random_state=1)
 
-clf = ChimeraBoostClassifier(iterations=400, random_state=1)
+clf = ChimeraBoostClassifier(n_estimators=400, random_state=1)
 clf.fit(Xtr, ytr, cat_features=[0, 1])   # columns 0 and 1 are categorical
 auc = roc_auc_score(yte, clf.predict_proba(Xte)[:, 1])
 print(f"mixed cat+num  AUC={auc:.4f}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chimeraboost"
-version = "0.10.0"
+version = "0.11.0"
 description = "CatBoost-inspired gradient boosting in pure Python with a numba backend"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_chimeraboost.py
+++ b/tests/test_chimeraboost.py
@@ -12,7 +12,7 @@ from chimeraboost import ChimeraBoostRegressor, ChimeraBoostClassifier
 def test_regressor_beats_mean_baseline():
     X, y = load_diabetes(return_X_y=True)
     Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.2, random_state=0)
-    m = ChimeraBoostRegressor(iterations=300, random_state=0).fit(Xtr, ytr)
+    m = ChimeraBoostRegressor(n_estimators=300, random_state=0).fit(Xtr, ytr)
     rmse = np.sqrt(mean_squared_error(yte, m.predict(Xte)))
     baseline = np.sqrt(mean_squared_error(yte, np.full_like(yte, ytr.mean())))
     # diabetes is tiny and noisy; this is a single split, so the bound is loose
@@ -27,7 +27,7 @@ def test_classifier_high_auc():
     Xtr, Xte, ytr, yte = train_test_split(
         X, y, test_size=0.2, random_state=0, stratify=y
     )
-    m = ChimeraBoostClassifier(iterations=300, random_state=0).fit(Xtr, ytr)
+    m = ChimeraBoostClassifier(n_estimators=300, random_state=0).fit(Xtr, ytr)
     auc = roc_auc_score(yte, m.predict_proba(Xte)[:, 1])
     assert auc > 0.97
     proba = m.predict_proba(Xte)
@@ -49,7 +49,7 @@ def test_ordered_ts_resists_leakage():
     Xtr, Xte, ytr, yte = train_test_split(
         X, y, test_size=0.3, random_state=1, stratify=y
     )
-    m = ChimeraBoostClassifier(iterations=200, random_state=1)
+    m = ChimeraBoostClassifier(n_estimators=200, random_state=1)
     m.fit(Xtr, ytr, cat_features=[0])
     tr = roc_auc_score(ytr, m.predict_proba(Xtr)[:, 1])
     te = roc_auc_score(yte, m.predict_proba(Xte)[:, 1])
@@ -63,7 +63,7 @@ def test_early_stopping_trims_trees():
         X, y, test_size=0.3, random_state=0, stratify=y
     )
     m = ChimeraBoostClassifier(
-        iterations=1000, early_stopping_rounds=20, random_state=0
+        n_estimators=1000, early_stopping_rounds=20, random_state=0
     )
     m.fit(Xtr, ytr, eval_set=(Xte, yte))
     assert m.best_iteration_ < 1000
@@ -78,7 +78,7 @@ def test_handles_nan_and_unseen_categories():
     num[rng.random(n) < 0.1, 0] = np.nan
     X[:, 1:] = num
     y = ((num[:, 1] > 0) | (rng.random(n) < 0.3)).astype(int)
-    m = ChimeraBoostClassifier(iterations=80, random_state=0)
+    m = ChimeraBoostClassifier(n_estimators=80, random_state=0)
     m.fit(X, y, cat_features=[0])
     Xnew = np.array([["c_UNSEEN", np.nan, 0.5], ["c3", 1.0, -0.5]], dtype=object)
     p = m.predict_proba(Xnew)
@@ -88,7 +88,7 @@ def test_handles_nan_and_unseen_categories():
 
 def test_explicit_lr_overrides_auto():
     X, y = load_diabetes(return_X_y=True)
-    m = ChimeraBoostRegressor(iterations=50, learning_rate=0.123).fit(X, y)
+    m = ChimeraBoostRegressor(n_estimators=50, learning_rate=0.123).fit(X, y)
     assert m.model_.lr_ == 0.123
 
 
@@ -99,7 +99,7 @@ def test_multiclass_accuracy():
         Xtr, Xte, ytr, yte = train_test_split(
             X, y, test_size=0.25, random_state=0, stratify=y
         )
-        m = ChimeraBoostClassifier(iterations=200, random_state=0).fit(Xtr, ytr)
+        m = ChimeraBoostClassifier(n_estimators=200, random_state=0).fit(Xtr, ytr)
         assert m.n_classes_ == 3
         proba = m.predict_proba(Xte)
         assert proba.shape == (len(yte), 3)
@@ -118,7 +118,7 @@ def test_multiclass_preserves_string_labels_and_categoricals():
     X[:, 0] = region
     X[:, 1:] = x
     Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.25, random_state=1)
-    m = ChimeraBoostClassifier(iterations=150, random_state=1)
+    m = ChimeraBoostClassifier(n_estimators=150, random_state=1)
     m.fit(Xtr, ytr, cat_features=[0])
     assert set(m.classes_) == {"low", "mid", "high"}
     assert set(np.unique(m.predict(Xte))).issubset({"low", "mid", "high"})
@@ -131,7 +131,7 @@ def test_feature_importances():
     noise = rng.normal(size=(n, 4))
     y = (strong + 0.1 * rng.normal(size=n) > 0).astype(int)
     X = np.column_stack([strong, noise])
-    m = ChimeraBoostClassifier(iterations=100, random_state=0).fit(X, y)
+    m = ChimeraBoostClassifier(n_estimators=100, random_state=0).fit(X, y)
     imp = m.feature_importances_
     assert imp.shape == (5,)
     assert abs(imp.sum() - 1.0) < 1e-6
@@ -142,8 +142,8 @@ def test_mae_loss_beats_rmse_on_mae_metric():
     from sklearn.metrics import mean_absolute_error
     X, y = load_diabetes(return_X_y=True)
     Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.2, random_state=42)
-    mae = ChimeraBoostRegressor(iterations=300, loss="MAE", random_state=0).fit(Xtr, ytr)
-    rmse = ChimeraBoostRegressor(iterations=300, loss="RMSE", random_state=0).fit(Xtr, ytr)
+    mae = ChimeraBoostRegressor(n_estimators=300, loss="MAE", random_state=0).fit(Xtr, ytr)
+    rmse = ChimeraBoostRegressor(n_estimators=300, loss="RMSE", random_state=0).fit(Xtr, ytr)
     assert (mean_absolute_error(yte, mae.predict(Xte))
             <= mean_absolute_error(yte, rmse.predict(Xte)) + 1.0)
 
@@ -155,10 +155,10 @@ def test_quantile_calibration_on_large_data():
     y = 2 * X[:, 0] + rng.normal(0, 1, n)
     Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.3, random_state=0)
     # Early stopping prevents overfitting the training quantiles, improving test calibration.
-    qlo = ChimeraBoostRegressor(iterations=2000, depth=4, loss="Quantile",
+    qlo = ChimeraBoostRegressor(n_estimators=2000, depth=4, loss="Quantile",
                                 alpha=0.1, early_stopping=True,
                                 early_stopping_rounds=50, random_state=0).fit(Xtr, ytr)
-    qhi = ChimeraBoostRegressor(iterations=2000, depth=4, loss="Quantile",
+    qhi = ChimeraBoostRegressor(n_estimators=2000, depth=4, loss="Quantile",
                                 alpha=0.9, early_stopping=True,
                                 early_stopping_rounds=50, random_state=0).fit(Xtr, ytr)
     cov = np.mean((yte >= qlo.predict(Xte)) & (yte <= qhi.predict(Xte)))
@@ -169,7 +169,7 @@ def test_quantile_calibration_on_large_data():
 def test_staged_predict_matches_final():
     X, y = load_diabetes(return_X_y=True)
     Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.2, random_state=0)
-    r = ChimeraBoostRegressor(iterations=50, random_state=0).fit(Xtr, ytr)
+    r = ChimeraBoostRegressor(n_estimators=50, random_state=0).fit(Xtr, ytr)
     stages = list(r.staged_predict(Xte))
     assert len(stages) == r.best_iteration_
     assert np.allclose(stages[-1], r.predict(Xte))
@@ -180,7 +180,7 @@ def test_colsample_runs_and_keeps_accuracy():
     Xtr, Xte, ytr, yte = train_test_split(
         X, y, test_size=0.2, random_state=0, stratify=y
     )
-    m = ChimeraBoostClassifier(iterations=150, colsample=0.5,
+    m = ChimeraBoostClassifier(n_estimators=150, colsample=0.5,
                                random_state=0).fit(Xtr, ytr)
     assert roc_auc_score(yte, m.predict_proba(Xte)[:, 1]) > 0.97
 
@@ -188,21 +188,21 @@ def test_colsample_runs_and_keeps_accuracy():
 def test_thread_count_records_effective_threads():
     import numba
     X, y = load_breast_cancer(return_X_y=True)
-    m = ChimeraBoostClassifier(iterations=30, thread_count=1, random_state=0).fit(X, y)
+    m = ChimeraBoostClassifier(n_estimators=30, thread_count=1, random_state=0).fit(X, y)
     assert m.model_.n_threads_ == 1
     # None -> all detected cores
-    m2 = ChimeraBoostClassifier(iterations=30, thread_count=None, random_state=0).fit(X, y)
+    m2 = ChimeraBoostClassifier(n_estimators=30, thread_count=None, random_state=0).fit(X, y)
     assert m2.model_.n_threads_ == numba.config.NUMBA_NUM_THREADS
     # over-request is clamped, never exceeds detected cores
-    m3 = ChimeraBoostClassifier(iterations=30, thread_count=9999, random_state=0).fit(X, y)
+    m3 = ChimeraBoostClassifier(n_estimators=30, thread_count=9999, random_state=0).fit(X, y)
     assert m3.model_.n_threads_ <= numba.config.NUMBA_NUM_THREADS
 
 
 def test_thread_count_does_not_change_predictions():
     X, y = load_diabetes(return_X_y=True)
     Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.2, random_state=0)
-    a = ChimeraBoostRegressor(iterations=80, thread_count=1, random_state=0).fit(Xtr, ytr)
-    b = ChimeraBoostRegressor(iterations=80, thread_count=None, random_state=0).fit(Xtr, ytr)
+    a = ChimeraBoostRegressor(n_estimators=80, thread_count=1, random_state=0).fit(Xtr, ytr)
+    b = ChimeraBoostRegressor(n_estimators=80, thread_count=None, random_state=0).fit(Xtr, ytr)
     # histogram sums are deterministic regardless of thread count
     assert np.allclose(a.predict(Xte), b.predict(Xte))
 
@@ -227,7 +227,7 @@ def test_min_child_weight_regularizes_sparse_leaves():
     Xf, Xv, yf, yv = train_test_split(Xtr, ytr, test_size=0.2, random_state=0)
 
     def rmse_at(depth, mcw):
-        m = ChimeraBoostRegressor(iterations=1500, depth=depth,
+        m = ChimeraBoostRegressor(n_estimators=1500, depth=depth,
                                   min_child_weight=mcw, early_stopping_rounds=50,
                                   random_state=0).fit(Xf, yf, eval_set=(Xv, yv))
         return np.sqrt(np.mean((yte - m.predict(Xte)) ** 2))
@@ -245,7 +245,7 @@ def test_min_child_weight_regularizes_sparse_leaves():
 def test_min_child_weight_param_plumbing():
     from sklearn.datasets import load_breast_cancer
     X, y = load_breast_cancer(return_X_y=True)
-    m = ChimeraBoostClassifier(iterations=50, min_child_weight=30,
+    m = ChimeraBoostClassifier(n_estimators=50, min_child_weight=30,
                                random_state=0).fit(X, y)
     assert m.model_.min_child_weight == 30.0
 
@@ -295,8 +295,8 @@ def test_sample_weight_uniform_equals_no_weight_rmse():
     X, y = load_diabetes(return_X_y=True)
     Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.2, random_state=0)
     w = np.ones(len(ytr))
-    m_none = ChimeraBoostRegressor(iterations=80, random_state=0).fit(Xtr, ytr)
-    m_ones = ChimeraBoostRegressor(iterations=80, random_state=0).fit(
+    m_none = ChimeraBoostRegressor(n_estimators=80, random_state=0).fit(Xtr, ytr)
+    m_ones = ChimeraBoostRegressor(n_estimators=80, random_state=0).fit(
         Xtr, ytr, sample_weight=w
     )
     assert np.array_equal(m_none.predict(Xte), m_ones.predict(Xte))
@@ -309,8 +309,8 @@ def test_sample_weight_uniform_equals_no_weight_logloss():
         X, y, test_size=0.2, random_state=0, stratify=y
     )
     w = np.ones(len(ytr))
-    m_none = ChimeraBoostClassifier(iterations=80, random_state=0).fit(Xtr, ytr)
-    m_ones = ChimeraBoostClassifier(iterations=80, random_state=0).fit(
+    m_none = ChimeraBoostClassifier(n_estimators=80, random_state=0).fit(Xtr, ytr)
+    m_ones = ChimeraBoostClassifier(n_estimators=80, random_state=0).fit(
         Xtr, ytr, sample_weight=w
     )
     assert np.array_equal(m_none.predict_proba(Xte), m_ones.predict_proba(Xte))
@@ -324,8 +324,8 @@ def test_sample_weight_uniform_equals_no_weight_multiclass():
         X, y, test_size=0.25, random_state=0, stratify=y
     )
     w = np.ones(len(ytr))
-    m_none = ChimeraBoostClassifier(iterations=80, random_state=0).fit(Xtr, ytr)
-    m_ones = ChimeraBoostClassifier(iterations=80, random_state=0).fit(
+    m_none = ChimeraBoostClassifier(n_estimators=80, random_state=0).fit(Xtr, ytr)
+    m_ones = ChimeraBoostClassifier(n_estimators=80, random_state=0).fit(
         Xtr, ytr, sample_weight=w
     )
     assert np.array_equal(m_none.predict_proba(Xte), m_ones.predict_proba(Xte))
@@ -344,11 +344,11 @@ def test_sample_weight_shifts_predictions():
     w_high = np.where(ytr >= np.median(ytr), 5.0, 1.0)
     w_low  = np.where(ytr <  np.median(ytr), 5.0, 1.0)
 
-    m_base = ChimeraBoostRegressor(iterations=150, random_state=0).fit(Xtr, ytr)
-    m_high = ChimeraBoostRegressor(iterations=150, random_state=0).fit(
+    m_base = ChimeraBoostRegressor(n_estimators=150, random_state=0).fit(Xtr, ytr)
+    m_high = ChimeraBoostRegressor(n_estimators=150, random_state=0).fit(
         Xtr, ytr, sample_weight=w_high
     )
-    m_low  = ChimeraBoostRegressor(iterations=150, random_state=0).fit(
+    m_low  = ChimeraBoostRegressor(n_estimators=150, random_state=0).fit(
         Xtr, ytr, sample_weight=w_low
     )
     mean_base = m_base.predict(Xte).mean()
@@ -366,7 +366,7 @@ def test_sample_weight_early_stopping_slices_correctly():
     rng = np.random.default_rng(7)
     w = rng.uniform(0.5, 2.0, len(y))
     m = ChimeraBoostClassifier(
-        iterations=500, early_stopping=True, validation_fraction=0.15,
+        n_estimators=500, early_stopping=True, validation_fraction=0.15,
         early_stopping_rounds=20, random_state=0
     ).fit(X, y, sample_weight=w)
     assert m.best_iteration_ < 500
@@ -394,7 +394,7 @@ def test_groups_kept_intact_in_early_stopping_split():
     assert set(groups[tr]).isdisjoint(set(groups[va]))
 
     # End-to-end: early stopping + groups fits and predicts the right shape.
-    m = ChimeraBoostClassifier(iterations=200, early_stopping=True,
+    m = ChimeraBoostClassifier(n_estimators=200, early_stopping=True,
                                validation_fraction=0.2, early_stopping_rounds=15,
                                random_state=0).fit(X, y_cls, groups=groups)
     assert m.predict(X).shape == (n,)
@@ -403,10 +403,10 @@ def test_groups_kept_intact_in_early_stopping_split():
 def test_bagging_none_matches_single_model():
     """n_ensembles=None and =1 must be the plain single model, bit-identical."""
     X, y = load_diabetes(return_X_y=True)
-    base = ChimeraBoostRegressor(iterations=80, random_state=0).fit(X, y)
-    none_ = ChimeraBoostRegressor(iterations=80, random_state=0,
+    base = ChimeraBoostRegressor(n_estimators=80, random_state=0).fit(X, y)
+    none_ = ChimeraBoostRegressor(n_estimators=80, random_state=0,
                                   n_ensembles=None).fit(X, y)
-    one = ChimeraBoostRegressor(iterations=80, random_state=0,
+    one = ChimeraBoostRegressor(n_estimators=80, random_state=0,
                                 n_ensembles=1).fit(X, y)
     assert base.estimators_ is None and one.estimators_ is None
     assert np.array_equal(base.predict(X), none_.predict(X))
@@ -421,7 +421,7 @@ def test_bagging_regressor_runs_and_averages_members():
     X, y = make_regression(n_samples=1500, n_features=15, noise=25.0,
                            random_state=0)
     Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.25, random_state=0)
-    bag = ChimeraBoostRegressor(iterations=150, random_state=0,
+    bag = ChimeraBoostRegressor(n_estimators=150, random_state=0,
                                 n_ensembles=8).fit(Xtr, ytr)
     assert len(bag.estimators_) == 8
     # The ensemble prediction is the average of its members.
@@ -438,7 +438,7 @@ def test_bagging_classifier_multiclass_proba():
     preserved class labels."""
     from sklearn.datasets import load_wine
     X, y = load_wine(return_X_y=True)
-    clf = ChimeraBoostClassifier(iterations=120, random_state=0,
+    clf = ChimeraBoostClassifier(n_estimators=120, random_state=0,
                                  n_ensembles=8).fit(X, y)
     assert len(clf.estimators_) == 8
     proba = clf.predict_proba(X)
@@ -453,9 +453,9 @@ def test_bagging_parallel_matches_sequential():
     seeded, so predictions must be identical to the sequential fit."""
     from sklearn.datasets import load_wine
     X, y = load_wine(return_X_y=True)
-    seq = ChimeraBoostClassifier(iterations=80, random_state=3,
+    seq = ChimeraBoostClassifier(n_estimators=80, random_state=3,
                                  n_ensembles=4, ensemble_n_jobs=1).fit(X, y)
-    par = ChimeraBoostClassifier(iterations=80, random_state=3,
+    par = ChimeraBoostClassifier(n_estimators=80, random_state=3,
                                  n_ensembles=4, ensemble_n_jobs=2).fit(X, y)
     assert np.allclose(seq.predict_proba(X), par.predict_proba(X))
 
@@ -470,7 +470,7 @@ def test_bagging_with_categoricals():
     X[:, 1] = rng.normal(size=n)
     X[:, 2] = rng.choice(["x", "y"], n)
     y = ((X[:, 0] == "a").astype(int) ^ (X[:, 2] == "x").astype(int))
-    clf = ChimeraBoostClassifier(iterations=100, random_state=0,
+    clf = ChimeraBoostClassifier(n_estimators=100, random_state=0,
                                  n_ensembles=5).fit(X, y, cat_features=[0, 2])
     proba = clf.predict_proba(X)
     assert proba.shape == (n, 2)
@@ -484,7 +484,7 @@ def test_empty_tree_stops_boosting_early():
     # One informative feature, aggressive min_child_weight -> splits run out fast.
     X = np.array([[0.0]] * 60 + [[1.0]] * 60)
     y = np.array([0.0] * 60 + [1.0] * 60)
-    m = ChimeraBoostRegressor(iterations=1000, min_child_weight=30,
+    m = ChimeraBoostRegressor(n_estimators=1000, min_child_weight=30,
                               random_state=0).fit(X, y)
     assert len(m.model_.trees_) < 1000
 
@@ -508,14 +508,14 @@ def test_predict_before_fit_raises_not_fitted(Est):
 
 def test_feature_count_mismatch_raises():
     X, yr, _ = _Xy()
-    m = ChimeraBoostRegressor(iterations=10, random_state=0).fit(X, yr)
+    m = ChimeraBoostRegressor(n_estimators=10, random_state=0).fit(X, yr)
     with pytest.raises(ValueError, match="features"):
         m.predict(np.random.default_rng(1).normal(size=(5, 7)))
 
 
 def test_fit_input_validation_messages():
     X, yr, _ = _Xy()
-    R = ChimeraBoostRegressor(iterations=10, random_state=0)
+    R = ChimeraBoostRegressor(n_estimators=10, random_state=0)
     with pytest.raises(ValueError, match="2D"):
         R.fit(X[:, 0], yr)                      # 1-D X
     with pytest.raises(ValueError, match="inconsistent lengths"):
@@ -533,17 +533,17 @@ def test_fit_input_validation_messages():
 def test_nan_in_X_is_accepted_as_missing():
     X, yr, _ = _Xy()
     Xn = X.copy(); Xn[::5, 0] = np.nan
-    m = ChimeraBoostRegressor(iterations=20, random_state=0).fit(Xn, yr)
+    m = ChimeraBoostRegressor(n_estimators=20, random_state=0).fit(Xn, yr)
     assert np.isfinite(m.predict(Xn)).all()     # NaN handled, not rejected
 
 
 def test_n_features_in_and_feature_names_in():
     pd = pytest.importorskip("pandas")
     X, yr, _ = _Xy()
-    m = ChimeraBoostRegressor(iterations=10, random_state=0).fit(X, yr)
+    m = ChimeraBoostRegressor(n_estimators=10, random_state=0).fit(X, yr)
     assert m.n_features_in_ == 4
     df = pd.DataFrame(X, columns=list("abcd"))
-    m2 = ChimeraBoostRegressor(iterations=10, random_state=0).fit(df, yr)
+    m2 = ChimeraBoostRegressor(n_estimators=10, random_state=0).fit(df, yr)
     assert list(m2.feature_names_in_) == list("abcd")
 
 
@@ -551,18 +551,18 @@ def test_column_vector_y_is_raveled_with_warning():
     from sklearn.exceptions import DataConversionWarning
     X, yr, _ = _Xy()
     with pytest.warns(DataConversionWarning):
-        m = ChimeraBoostRegressor(iterations=10, random_state=0).fit(X, yr.reshape(-1, 1))
+        m = ChimeraBoostRegressor(n_estimators=10, random_state=0).fit(X, yr.reshape(-1, 1))
     assert m.predict(X).shape == (40,)
 
 
 def test_continuous_target_to_classifier_raises():
     X, yr, _ = _Xy()
     with pytest.raises(ValueError, match="[Uu]nknown label|continuous"):
-        ChimeraBoostClassifier(iterations=10, random_state=0).fit(X, yr)
+        ChimeraBoostClassifier(n_estimators=10, random_state=0).fit(X, yr)
 
 
 @pytest.mark.parametrize("params, match", [
-    (dict(iterations=0), "iterations"),
+    (dict(n_estimators=0), "n_estimators"),
     (dict(depth=0), "depth"),
     (dict(depth=30), "depth"),
     (dict(learning_rate=-0.1), "learning_rate"),
@@ -591,30 +591,30 @@ def test_sample_weight_value_validation():
     X, yr, _ = _Xy()
     n = X.shape[0]
     with pytest.raises(ValueError, match="NaN or infinity"):
-        ChimeraBoostRegressor(iterations=10).fit(X, yr, sample_weight=np.full(n, np.nan))
+        ChimeraBoostRegressor(n_estimators=10).fit(X, yr, sample_weight=np.full(n, np.nan))
     with pytest.raises(ValueError, match="non-negative"):
-        ChimeraBoostRegressor(iterations=10).fit(X, yr, sample_weight=-np.ones(n))
+        ChimeraBoostRegressor(n_estimators=10).fit(X, yr, sample_weight=-np.ones(n))
     with pytest.raises(ValueError, match="sums to zero"):
-        ChimeraBoostRegressor(iterations=10).fit(X, yr, sample_weight=np.zeros(n))
+        ChimeraBoostRegressor(n_estimators=10).fit(X, yr, sample_weight=np.zeros(n))
 
 
 def test_cat_features_index_validation():
     X, _, yc = _Xy()                       # 4 numeric columns
     with pytest.raises(ValueError, match="out of range"):
-        ChimeraBoostClassifier(iterations=10).fit(X, yc, cat_features=[9])
+        ChimeraBoostClassifier(n_estimators=10).fit(X, yc, cat_features=[9])
     with pytest.raises(ValueError, match="out of range"):
-        ChimeraBoostClassifier(iterations=10).fit(X, yc, cat_features=[-1])
+        ChimeraBoostClassifier(n_estimators=10).fit(X, yc, cat_features=[-1])
     with pytest.raises(ValueError, match="duplicate"):
-        ChimeraBoostClassifier(iterations=10).fit(X, yc, cat_features=[1, 1])
+        ChimeraBoostClassifier(n_estimators=10).fit(X, yc, cat_features=[1, 1])
 
 
 def test_eval_set_shape_validation():
     X, yr, _ = _Xy()
     Xt, yt, Xv, yv = X[:30], yr[:30], X[30:], yr[30:]
     with pytest.raises(ValueError, match="features"):
-        ChimeraBoostRegressor(iterations=10).fit(Xt, yt, eval_set=(Xv[:, :2], yv))
+        ChimeraBoostRegressor(n_estimators=10).fit(Xt, yt, eval_set=(Xv[:, :2], yv))
     with pytest.raises(ValueError, match="inconsistent lengths"):
-        ChimeraBoostRegressor(iterations=10).fit(Xt, yt, eval_set=(Xv, yv[:3]))
+        ChimeraBoostRegressor(n_estimators=10).fit(Xt, yt, eval_set=(Xv, yv[:3]))
 
 
 def test_nonnumeric_column_error_names_the_column():
@@ -623,10 +623,10 @@ def test_nonnumeric_column_error_names_the_column():
     df = pd.DataFrame(X, columns=list("abcd"))
     df["g"] = np.random.default_rng(0).choice(list("XY"), len(df))
     with pytest.raises(ValueError, match="cat_features"):
-        ChimeraBoostClassifier(iterations=10).fit(df, yc)
+        ChimeraBoostClassifier(n_estimators=10).fit(df, yc)
     # The friendly message names the offending column.
     try:
-        ChimeraBoostClassifier(iterations=10).fit(df, yc)
+        ChimeraBoostClassifier(n_estimators=10).fit(df, yc)
     except ValueError as e:
         assert "'g'" in str(e)
 
@@ -637,7 +637,7 @@ def test_predict_enforces_feature_names(Est):
     X, yr, yc = _Xy()
     y = yr if Est is ChimeraBoostRegressor else yc
     df = pd.DataFrame(X, columns=list("abcd"))
-    m = Est(iterations=20, random_state=0).fit(df, y)
+    m = Est(n_estimators=20, random_state=0).fit(df, y)
     # Same order -> fine.
     m.predict(df.iloc[:3])
     # Reordered columns -> raise (would otherwise be silently wrong).
@@ -655,7 +655,7 @@ def test_predict_enforces_feature_names(Est):
 def test_inf_rejected_at_predict(Est):
     X, yr, yc = _Xy()
     y = yr if Est is ChimeraBoostRegressor else yc
-    m = Est(iterations=20, random_state=0).fit(X, y)
+    m = Est(n_estimators=20, random_state=0).fit(X, y)
     Xinf = X[:1].copy(); Xinf[0, 0] = np.inf
     with pytest.raises(ValueError, match="infinity"):
         m.predict(Xinf)
@@ -668,9 +668,9 @@ def test_inf_rejected_at_predict(Est):
 def test_linear_leaves_warns_when_dropped_for_mae_quantile():
     X, yr, _ = _Xy()
     with pytest.warns(UserWarning, match="linear_leaves"):
-        ChimeraBoostRegressor(iterations=20, loss="MAE", linear_leaves=True).fit(X, yr)
+        ChimeraBoostRegressor(n_estimators=20, loss="MAE", linear_leaves=True).fit(X, yr)
     with pytest.warns(UserWarning, match="linear_leaves"):
-        ChimeraBoostRegressor(iterations=20, loss="Quantile", alpha=0.5,
+        ChimeraBoostRegressor(n_estimators=20, loss="Quantile", alpha=0.5,
                               linear_leaves=True).fit(X, yr)
 
 
@@ -687,25 +687,61 @@ def test_cat_features_constructor_param():
     X = np.empty((n, 2), dtype=object); X[:, 0] = city; X[:, 1] = age
 
     # Constructor cat_features is used when fit gets none.
-    m = ChimeraBoostClassifier(iterations=40, random_state=0,
+    m = ChimeraBoostClassifier(n_estimators=40, random_state=0,
                                cat_features=[0]).fit(X, y)
     assert (m.predict(X) == y).mean() > 0.9
     # It survives clone and a meta-estimator (the whole point).
     assert clone(m).get_params()["cat_features"] == [0]
-    gs = GridSearchCV(ChimeraBoostClassifier(iterations=30, random_state=0,
+    gs = GridSearchCV(ChimeraBoostClassifier(n_estimators=30, random_state=0,
                                              cat_features=[0]), {"depth": [3, 6]}, cv=3)
     gs.fit(X, y)                                   # would crash if cat col hit float cast
     # The fit argument overrides, without mutating the stored constructor value.
-    m2 = ChimeraBoostClassifier(iterations=20, random_state=0, cat_features=[1])
+    m2 = ChimeraBoostClassifier(n_estimators=20, random_state=0, cat_features=[1])
     m2.fit(X, y, cat_features=[0])
     assert m2.cat_features == [1]
+
+
+def test_cat_features_by_column_name():
+    """Categoricals can be marked by DataFrame column name (resolved to the same
+    positions as integer indices), as a fit arg, a constructor arg, or a mix."""
+    pd = pytest.importorskip("pandas")
+    rng = np.random.default_rng(0)
+    n = 600
+    df = pd.DataFrame({
+        "city": rng.choice(["NYC", "SF", "LA"], n),
+        "age": rng.normal(40, 10, n),
+        "plan": rng.choice(["free", "pro"], n),
+    })
+    y = ((df["city"] == "SF") | (df["age"] > 45)).astype(int).to_numpy()
+
+    by_name = ChimeraBoostClassifier(n_estimators=40, random_state=0).fit(
+        df, y, cat_features=["city", "plan"])
+    by_index = ChimeraBoostClassifier(n_estimators=40, random_state=0).fit(
+        df, y, cat_features=[0, 2])
+    # Names resolve to the same columns -> identical predictions.
+    assert np.array_equal(by_name.predict(df), by_index.predict(df))
+    # A mix of names and positions works too.
+    mixed = ChimeraBoostClassifier(n_estimators=40, random_state=0).fit(
+        df, y, cat_features=["city", 2])
+    assert np.array_equal(mixed.predict(df), by_index.predict(df))
+    # Names also work via the constructor (for GridSearchCV/Pipeline).
+    by_ctor = ChimeraBoostClassifier(n_estimators=40, random_state=0,
+                                     cat_features=["city", "plan"]).fit(df, y)
+    assert np.array_equal(by_ctor.predict(df), by_index.predict(df))
+
+    # An unknown name, or names without column metadata, raise clearly.
+    with pytest.raises(ValueError, match="not a column"):
+        ChimeraBoostClassifier(n_estimators=10).fit(df, y, cat_features=["nope"])
+    with pytest.raises(ValueError, match="no column names"):
+        ChimeraBoostClassifier(n_estimators=10).fit(
+            df.to_numpy(dtype=object), y, cat_features=["city"])
 
 
 def test_pyarrow_feature_names_not_polluted_by_data():
     pa = pytest.importorskip("pyarrow")
     X, _, yc = _Xy()
     tbl = pa.table({c: X[:, i] for i, c in enumerate("abcd")})
-    m = ChimeraBoostClassifier(iterations=10, random_state=0).fit(tbl, yc)
+    m = ChimeraBoostClassifier(n_estimators=10, random_state=0).fit(tbl, yc)
     # .columns is column DATA in pyarrow; names must come from .column_names.
     assert list(m.feature_names_in_) == list("abcd")
     assert m.n_features_in_ == 4
@@ -718,8 +754,8 @@ def test_masked_array_rejected(Est):
     Xm = np.ma.array(X, mask=np.zeros_like(X, dtype=bool))
     Xm[0, 0] = np.ma.masked
     with pytest.raises(TypeError, match="[Mm]asked"):
-        Est(iterations=10).fit(Xm, y)
-    m = Est(iterations=10, random_state=0).fit(X, y)
+        Est(n_estimators=10).fit(Xm, y)
+    m = Est(n_estimators=10, random_state=0).fit(X, y)
     with pytest.raises(TypeError, match="[Mm]asked"):
         m.predict(Xm)
 
@@ -729,13 +765,13 @@ def test_quantile_depth_default_is_loss_adaptive():
     because deep oblivious leaves overfit the tail quantile -- predicted
     quantiles otherwise collapse toward the median on held-out data."""
     X, yr, _ = _Xy()
-    assert ChimeraBoostRegressor(iterations=10, random_state=0).fit(X, yr).model_.depth == 6
-    assert ChimeraBoostRegressor(iterations=10, loss="MAE", random_state=0).fit(X, yr).model_.depth == 6
-    mq = ChimeraBoostRegressor(iterations=10, loss="Quantile", alpha=0.9,
+    assert ChimeraBoostRegressor(n_estimators=10, random_state=0).fit(X, yr).model_.depth == 6
+    assert ChimeraBoostRegressor(n_estimators=10, loss="MAE", random_state=0).fit(X, yr).model_.depth == 6
+    mq = ChimeraBoostRegressor(n_estimators=10, loss="Quantile", alpha=0.9,
                                random_state=0).fit(X, yr)
     assert mq.model_.depth == 4
     # Explicit depth still wins.
-    assert ChimeraBoostRegressor(iterations=10, loss="Quantile", alpha=0.9, depth=8,
+    assert ChimeraBoostRegressor(n_estimators=10, loss="Quantile", alpha=0.9, depth=8,
                                  random_state=0).fit(X, yr).model_.depth == 8
 
 
@@ -749,7 +785,7 @@ def test_quantile_calibration_beats_deep_trees():
     Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.3, random_state=0)
 
     def coverage(depth, a):
-        m = ChimeraBoostRegressor(iterations=400, loss="Quantile", alpha=a,
+        m = ChimeraBoostRegressor(n_estimators=400, loss="Quantile", alpha=a,
                                   depth=depth, random_state=0).fit(Xtr, ytr)
         return float(np.mean(yte <= m.predict(Xte)))
 
@@ -772,12 +808,12 @@ def test_auto_min_child_weight_is_size_adaptive():
     # The resolved value lands on the fitted booster.
     rng = np.random.default_rng(0)
     Xs = rng.normal(size=(400, 6)); Xl = rng.normal(size=(4000, 6))
-    cs = ChimeraBoostClassifier(iterations=20, random_state=0).fit(Xs, (Xs[:, 0] > 0).astype(int))
-    cl = ChimeraBoostClassifier(iterations=20, random_state=0).fit(Xl, (Xl[:, 0] > 0).astype(int))
+    cs = ChimeraBoostClassifier(n_estimators=20, random_state=0).fit(Xs, (Xs[:, 0] > 0).astype(int))
+    cl = ChimeraBoostClassifier(n_estimators=20, random_state=0).fit(Xl, (Xl[:, 0] > 0).astype(int))
     assert cs.model_.min_child_weight == 1.0          # small -> full veto
     assert cl.model_.min_child_weight == 0.0          # large -> no veto
     # An explicit value is still honored (overrides auto).
-    ce = ChimeraBoostClassifier(iterations=20, min_child_weight=0.5,
+    ce = ChimeraBoostClassifier(n_estimators=20, min_child_weight=0.5,
                                 random_state=0).fit(Xl, (Xl[:, 0] > 0).astype(int))
     assert ce.model_.min_child_weight == 0.5
 
@@ -848,8 +884,8 @@ def test_hs_lambda_plumbs_and_changes_predictions(Est):
         X, y = load_breast_cancer(return_X_y=True)
         Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.25,
                                               random_state=0)
-        base = Est(iterations=120, random_state=0).fit(Xtr, ytr)
-        hs = Est(iterations=120, hs_lambda=2.0, random_state=0).fit(Xtr, ytr)
+        base = Est(n_estimators=120, random_state=0).fit(Xtr, ytr)
+        hs = Est(n_estimators=120, hs_lambda=2.0, random_state=0).fit(Xtr, ytr)
         assert base.model_.hs_lambda == 0.0 and hs.model_.hs_lambda == 2.0
         pb = base.predict_proba(Xte)[:, 1]
         ph = hs.predict_proba(Xte)[:, 1]
@@ -859,8 +895,8 @@ def test_hs_lambda_plumbs_and_changes_predictions(Est):
         X, y = load_diabetes(return_X_y=True)
         Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.25,
                                               random_state=0)
-        base = Est(iterations=120, random_state=0).fit(Xtr, ytr)
-        hs = Est(iterations=120, hs_lambda=2.0, random_state=0).fit(Xtr, ytr)
+        base = Est(n_estimators=120, random_state=0).fit(Xtr, ytr)
+        hs = Est(n_estimators=120, hs_lambda=2.0, random_state=0).fit(Xtr, ytr)
         assert base.model_.hs_lambda == 0.0 and hs.model_.hs_lambda == 2.0
         assert not np.allclose(base.predict(Xte), hs.predict(Xte))
 
@@ -876,7 +912,7 @@ def test_linear_leaves_beat_constant_on_smooth_target():
     X = rng.uniform(-3, 3, size=(3000, 3))
     y = 3.0 * X[:, 0] - 2.0 * X[:, 1] + 0.5 * X[:, 2] + 0.05 * rng.normal(size=3000)
     Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.3, random_state=0)
-    common = dict(iterations=60, depth=3, random_state=0, thread_count=4)
+    common = dict(n_estimators=60, depth=3, random_state=0, thread_count=4)
     const = ChimeraBoostRegressor(**common).fit(Xtr, ytr)
     lin = ChimeraBoostRegressor(linear_leaves=True, **common).fit(Xtr, ytr)
     r_const = mean_squared_error(yte, const.predict(Xte)) ** 0.5
@@ -895,8 +931,8 @@ def test_linear_leaves_default_off_uses_fused_path():
     """linear_leaves defaults to off: the fast fused-forest path is used
     (no centers table built), so default behavior is unchanged."""
     X, y = _big_reg()
-    off = ChimeraBoostRegressor(iterations=30, random_state=0).fit(X, y)
-    on = ChimeraBoostRegressor(iterations=30, linear_leaves=True,
+    off = ChimeraBoostRegressor(n_estimators=30, random_state=0).fit(X, y)
+    on = ChimeraBoostRegressor(n_estimators=30, linear_leaves=True,
                                random_state=0).fit(X, y)
     assert off.model_._centers_std_ is None        # fused (constant) path
     assert on.model_._centers_std_ is not None      # linear path active (n>=1000)
@@ -910,8 +946,8 @@ def test_linear_leaves_small_data_guard_falls_back_to_constant():
     from chimeraboost.booster import LINEAR_LEAVES_MIN_SAMPLES
     X, y = load_diabetes(return_X_y=True)          # 442 rows < the guard
     assert len(X) < LINEAR_LEAVES_MIN_SAMPLES
-    const = ChimeraBoostRegressor(iterations=40, random_state=0).fit(X, y)
-    lin = ChimeraBoostRegressor(iterations=40, linear_leaves=True,
+    const = ChimeraBoostRegressor(n_estimators=40, random_state=0).fit(X, y)
+    lin = ChimeraBoostRegressor(n_estimators=40, linear_leaves=True,
                                 random_state=0).fit(X, y)
     assert lin.model_._centers_std_ is None        # guard tripped -> constant
     assert np.array_equal(const.predict(X), lin.predict(X))   # bit-identical
@@ -922,7 +958,7 @@ def test_linear_leaves_predict_matches_staged_and_is_finite():
     linear-leaf predictions are finite (no solve blow-ups)."""
     X, y = _big_reg(seed=1)
     Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.25, random_state=1)
-    m = ChimeraBoostRegressor(iterations=40, linear_leaves=True,
+    m = ChimeraBoostRegressor(n_estimators=40, linear_leaves=True,
                               random_state=1, early_stopping=False).fit(Xtr, ytr)
     assert m.model_._centers_std_ is not None       # linear actually engaged
     pred = m.predict(Xte)
@@ -991,7 +1027,7 @@ def test_shap_efficiency_regression_linear_leaves():
     n = 1500
     X = rng.normal(size=(n, 6))
     y = 2 * X[:, 0] - 1.5 * X[:, 1] + X[:, 2] * X[:, 3] + 0.3 * rng.normal(size=n)
-    m = ChimeraBoostRegressor(iterations=80, depth=5, linear_leaves=True,
+    m = ChimeraBoostRegressor(n_estimators=80, depth=5, linear_leaves=True,
                               random_state=0).fit(X, y)
     phi = m.shap_values(X[:50])
     # Shapley efficiency must hold exactly, with the linear-leaf slopes included.
@@ -1003,7 +1039,7 @@ def test_shap_efficiency_regression_constant_leaves():
     rng = np.random.default_rng(1)
     X = rng.normal(size=(800, 5))
     y = X[:, 0] - X[:, 1] + 0.2 * rng.normal(size=800)
-    m = ChimeraBoostRegressor(iterations=60, depth=4, linear_leaves=False,
+    m = ChimeraBoostRegressor(n_estimators=60, depth=4, linear_leaves=False,
                               random_state=0).fit(X, y)
     phi = m.shap_values(X[:40])
     assert _shap_efficiency_err(m.predict(X[:40]), phi, m.expected_value_) < 1e-6
@@ -1014,7 +1050,7 @@ def test_shap_efficiency_binary_logodds():
     X = rng.normal(size=(1500, 6))
     score = 2 * X[:, 0] - 1.5 * X[:, 1] + X[:, 2] * X[:, 3]
     y = (score + 0.3 * rng.normal(size=1500) > 0).astype(int)
-    m = ChimeraBoostClassifier(iterations=80, depth=5, random_state=0).fit(X, y)
+    m = ChimeraBoostClassifier(n_estimators=80, depth=5, random_state=0).fit(X, y)
     phi = m.shap_values(X[:50])
     # Classifier SHAP is in pre-temperature log-odds (margin) space.
     raw = m.model_.predict_raw(X[:50])
@@ -1025,7 +1061,7 @@ def test_shap_efficiency_bagged():
     rng = np.random.default_rng(3)
     X = rng.normal(size=(1500, 6))
     y = 2 * X[:, 0] - X[:, 1] + 0.3 * rng.normal(size=1500)
-    m = ChimeraBoostRegressor(iterations=60, depth=4, n_ensembles=3,
+    m = ChimeraBoostRegressor(n_estimators=60, depth=4, n_ensembles=3,
                               linear_leaves=True, random_state=0).fit(X, y)
     phi = m.shap_values(X[:40])
     # The bag prediction is the members' mean, so averaged SHAP stays exact.
@@ -1036,7 +1072,7 @@ def test_shap_null_feature_is_negligible():
     rng = np.random.default_rng(4)
     X = rng.normal(size=(1500, 6))
     y = 2 * X[:, 0] - 1.5 * X[:, 1] + 0.3 * rng.normal(size=1500)  # 5 unused
-    m = ChimeraBoostRegressor(iterations=80, depth=5, random_state=0).fit(X, y)
+    m = ChimeraBoostRegressor(n_estimators=80, depth=5, random_state=0).fit(X, y)
     imp = np.abs(m.shap_values(X[:100])).mean(axis=0)
     # A feature absent from the target should carry near-zero attribution.
     assert imp[5] < 0.1 * imp[0]
@@ -1048,7 +1084,7 @@ def test_shap_maps_to_original_feature_space_with_categoricals():
     cat = rng.integers(0, 4, size=600).astype(object)
     X = np.column_stack([num, cat])
     y = (num + (cat.astype(int) == 2)).astype(float)
-    m = ChimeraBoostRegressor(iterations=40, depth=4, random_state=0)
+    m = ChimeraBoostRegressor(n_estimators=40, depth=4, random_state=0)
     m.fit(X, y, cat_features=[1])
     phi = m.shap_values(X[:30])
     # Attribution is reported in the user's 2-column input space, not the wider
@@ -1061,7 +1097,7 @@ def test_shap_custom_background():
     rng = np.random.default_rng(6)
     X = rng.normal(size=(1200, 5))
     y = X[:, 0] - X[:, 1] + 0.2 * rng.normal(size=1200)
-    m = ChimeraBoostRegressor(iterations=60, depth=4, random_state=0).fit(X, y)
+    m = ChimeraBoostRegressor(n_estimators=60, depth=4, random_state=0).fit(X, y)
     bg = X[:100]
     phi = m.shap_values(X[:30], X_background=bg)
     # expected_value_ must equal the mean prediction over the supplied background.
@@ -1073,6 +1109,6 @@ def test_shap_multiclass_raises():
     rng = np.random.default_rng(7)
     X = rng.normal(size=(300, 4))
     y = rng.integers(0, 3, size=300)
-    m = ChimeraBoostClassifier(iterations=30, random_state=0).fit(X, y)
+    m = ChimeraBoostClassifier(n_estimators=30, random_state=0).fit(X, y)
     with pytest.raises(NotImplementedError):
         m.shap_values(X[:10])


### PR DESCRIPTION
Two API changes (plus the in-progress docs no-slop cleanup that was already in the working tree):

1. Rename the number-of-trees hyperparameter `iterations` -> `n_estimators` (BREAKING), matching the LightGBM/XGBoost convention. The rename flows through both the sklearn wrappers and the core booster, since params are passed positionally via get_params(). `leaf_estimation_iterations` (a different parameter) and `n_ensembles`/`estimators_` (bagging) are unchanged.

2. cat_features now accepts DataFrame column names as well as integer positions, or a mix -- e.g. cat_features=["city", "brand"] or [0, 3]. Names are resolved against the DataFrame at fit, before validation and bagging, via _resolve_cat_feature_names(). Unknown names and names passed without column metadata raise clear errors.

Updated docs, CHANGELOG, examples, benchmarks, and tests; added test_cat_features_by_column_name. Full suite passes (96 tests).