### PR TITLE
Release 0.12.0: adaptive cat_combinations default + research cascade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to ChimeraBoost are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+### Changed
+- **`cat_combinations` default is now adaptive** (`None`). Pairwise
+  category-by-category features are enabled automatically when the data is
+  entirely categorical — where they capture interactions without crowding out
+  numeric splits — and stay off otherwise. This closes the long-standing gap on
+  all-categorical datasets (e.g. the `car` multiclass set) out of the box. Set
+  `True`/`False` to force it; auto is skipped for very wide all-categorical data
+  as a resource guard against the `C(n_cat, 2)` blow-up.
+
 ## [0.11.0] - 2026-06-04
 ### Added
 - **Exact SHAP feature attributions** (`model.shap_values(X)`). Interventional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to ChimeraBoost are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.12.0] - 2026-06-09
 ### Changed
 - **`cat_combinations` default is now adaptive** (`None`). Pairwise
   category-by-category features are enabled automatically when the data is
@@ -12,6 +14,29 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
   all-categorical datasets (e.g. the `car` multiclass set) out of the box. Set
   `True`/`False` to force it; auto is skipped for very wide all-categorical data
   as a resource guard against the `C(n_cat, 2)` blow-up.
+
+### Added
+- **`validation_history_`** property on both estimators — the full per-round
+  validation-loss curve from a single fit (length = rounds run; with
+  `early_stopping=False` it runs to the horizon, never truncated). Makes
+  per-iteration capture first-class.
+- **`callbacks=`** fit hook — `cb(iteration, train_loss, val_loss, model)` called
+  each round; returning `True` requests an early stop. (Not supported with bagging.)
+- **Opt-in research flags** (all default-off, byte-identical no-ops unless set).
+  Each was validated through an efficient paired-curve benchmark cascade; none
+  improved the blended defaults broadly (the defaults are already at a good
+  optimum — see `benchmarks/research/SUMMARY.md`), so they ship as documented
+  opt-ins for data that matches their narrow sweet-spot: `onehot_low_card`
+  (one-hot low-cardinality categoricals), `cat_aware_binning` (larger bin budget
+  for target-encoded categoricals — both help all-categorical sets like
+  `car`/`splice`), `cat_combinations_selective` (mutual-info-selected combos on
+  mixed data), `forest_leaf_refit` (post-fit joint ridge over all leaves),
+  `ordered_leaf_estimation` (ordered boosting + leaf refinement together),
+  `adaptive_leaf_estimation` (size-scheduled Newton steps), and
+  `adaptive_leaf_shrinkage` (mass-dependent per-leaf shrinkage).
+- **Research cascade harness** under `benchmarks/research/` — a reusable,
+  download-once, paired-validation-curve engine for evaluating ideas efficiently
+  without ever touching the sealed TabArena holdout.
 
 ## [0.11.0] - 2026-06-04
 ### Added

--- a/benchmarks/knob_characterization.py
+++ b/benchmarks/knob_characterization.py
@@ -28,6 +28,9 @@ Suites:
   --suite offline    7 built-in datasets (reg/binary/multiclass/cat), NO network.
   --suite grinsztajn 59 real Grinsztajn datasets (HuggingFace). Dataset-outer so
                      each CSV downloads once and is reused across all knobs.
+  --suite openml-cat OpenML datasets that have REAL string categoricals (adult,
+                     bank-marketing, credit-g, sick, mushroom, kr-vs-kp, car,
+                     splice, abalone). Focused on cat knobs by default.
 
 Report-only: this CHARACTERIZES the knobs. It does NOT tune defaults — nothing
 ships off these numbers without the full synthetic->Grinsztajn->OpenML pipeline.
@@ -36,6 +39,7 @@ Usage:
   python benchmarks/knob_characterization.py                       # offline, all knobs
   python benchmarks/knob_characterization.py --knob colsample subsample
   python benchmarks/knob_characterization.py --suite grinsztajn --runs 1
+  python benchmarks/knob_characterization.py --suite openml-cat   # cat knobs only
 """
 
 import argparse
@@ -81,6 +85,9 @@ KNOBS = {
     "leaf_estimation_iterations": dict(values=[1, 3, 5, 10],        group="all"),
     "hs_lambda":                  dict(values=[1.0, 5.0, 20.0],     group="all"),
     "max_bins":                   dict(values=[64, 128, 254],       group="all"),
+    # Baseline patience is 50. "Better by Default" (arXiv 2407.04491) found
+    # patience ~300 helps classifiers; probe whether it generalizes here.
+    "early_stopping_rounds":      dict(values=[50, 100, 200, 300],  group="all"),
     "ordered_boosting":           dict(values=[True],               group="all"),
     # cat_smoothing=0.0 is invalid (0/0 pseudocount -> rejected); 0.3 is the
     # smallest sensible probe below the 1.0 default.
@@ -108,8 +115,12 @@ def _fit_eval(task, kw, Xtr, ytr, Xte, yte, cat, seed, threads):
     """Fit out-of-box (internal early-stop split) with kwargs `kw` (empty ==
     out-of-box baseline). Returns (metric, prediction_vector, n_trees)."""
     Est = ChimeraBoostRegressor if task == "regression" else ChimeraBoostClassifier
-    m = Est(n_estimators=rb.MAX_ITERS, early_stopping_rounds=rb.PATIENCE,
-            random_state=seed, thread_count=threads, **kw)
+    # kw overrides the harness defaults (so a swept early_stopping_rounds wins
+    # over rb.PATIENCE instead of colliding on the keyword).
+    params = dict(n_estimators=rb.MAX_ITERS, early_stopping_rounds=rb.PATIENCE,
+                  random_state=seed, thread_count=threads)
+    params.update(kw)
+    m = Est(**params)
     m.fit(Xtr, ytr, cat_features=cat)
     if task == "regression":
         pred = np.asarray(m.predict(Xte), dtype=float)
@@ -237,7 +248,8 @@ def main():
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--knob", nargs="+", default=["all"],
                     help=f"knobs to characterize, or 'all'. Available: {list(KNOBS)}")
-    ap.add_argument("--suite", choices=["offline", "grinsztajn"], default="offline")
+    ap.add_argument("--suite", choices=["offline", "grinsztajn", "openml-cat"],
+                    default="offline")
     ap.add_argument("--runs", type=int, default=None,
                     help="seeds per (dataset, value); default 3 offline / 1 grinsztajn")
     ap.add_argument("--threads", type=int, default=None)
@@ -253,6 +265,14 @@ def main():
         rb._add_grinsztajn_datasets()
         dataset_keys = [k for k in rb.DATASETS if k.startswith("gr:")]
         runs = args.runs if args.runs is not None else 1
+    elif args.suite == "openml-cat":
+        rb._add_openml_datasets()
+        dataset_keys = [f"oml:{name}" for name, spec in rb.OPENML_SUITE.items()
+                        if spec.get("cats") == "auto"]
+        runs = args.runs if args.runs is not None else 3
+        # Default to cat knobs only when none specified explicitly
+        if args.knob == ["all"]:
+            knobs = [k for k in knobs if KNOBS[k]["group"] == "cat"]
     else:
         dataset_keys = OFFLINE_PANEL
         runs = args.runs if args.runs is not None else 3

--- a/benchmarks/research/.gitignore
+++ b/benchmarks/research/.gitignore
@@ -1,0 +1,1 @@
+research/cache/

--- a/benchmarks/research/SUMMARY.md
+++ b/benchmarks/research/SUMMARY.md
@@ -13,12 +13,15 @@ gate, not an iteration target.**
 | G1 forest joint leaf refit | `forest_leaf_refit` | T1 | **KILL** | overfits (train↓ test↑ +6–14%); binary gain already in `linear_leaves` |
 | G4 ordered + leaf machinery | `ordered_leaf_estimation` | T0 | **KILL** | helps some cats, badly hurts kr-vs-kp (+17%); ordered-boosting off by default for a reason (3/8) |
 | G3 adaptive leaf-estimation | `adaptive_leaf_estimation` | T0 | **KILL** | flat — size-scheduling the Newton steps buys ~nothing (1/8, mean −0.11%) |
+| G2 mass-adaptive leaf shrinkage | `adaptive_leaf_shrinkage` | T0 | **KILL** | helps car (−4.3%), hurts kr-vs-kp (+6.1%) (2/8) |
+| C4 cat-aware binning | `cat_aware_binning` | T0 | **KILL** | helps car/splice, hurts kr-vs-kp (+14.7%) (3/8) |
+| C2 per-tree TS permutation | `cat_pertree_permutation` | — | **DEFERRED** | needs per-round re-encode — a fundamental break from encode-once-then-bin; not justified for a near-certain kill |
 
 ## Headline finding
 
-Five CatBoost-inspired / scheduling levers, five kills. Each partial mechanism
-port **regresses somewhere** (or is flat) while the wins it chases are **already
-banked in the current defaults**:
+Seven CatBoost-inspired / scheduling levers, seven kills (C2 deferred by
+architecture). Each partial mechanism port **regresses somewhere** (or is flat)
+while the wins it chases are **already banked in the current defaults**:
 - the all-categorical `cat_combinations` auto-rule (C1/C3 can't beat it),
 - the binary `linear_leaves` default (G1's leaf-sharpness target),
 - plain boosting with size-adaptive `min_child_weight` (G4's ordered variant loses).
@@ -28,16 +31,25 @@ isolated CatBoost mechanisms into this pure-Python oblivious architecture — th
 gap looks like an emergent property of CatBoost's *integrated* ordered-boosting-
 on-permutations machinery operating together, not any single transplantable part.
 
+**The canary: `kr-vs-kp`.** Nearly every categorical lever *helps* car/splice but
+*regresses* kr-vs-kp (one-hot, combos, mass shrinkage, ordered+leaf, more bins all
+make it +6% to +27% worse). Its ordered-TS encoding is already near-perfect (Brier
+~0.024), so any added categorical structure just injects variance it overfits.
+That single dataset is the clearest evidence the defaults are at a good optimum.
+
 ## Engine notes
 - One fit = whole `validation_history_` curve; paired same-split deltas; shared
   baseline cache → each verdict reached in ~25–60s (T0) for ~0 marginal cost.
 - Post-fit ideas (G1) are invisible to the per-round curve → routed straight to
   the promotion tier (`post_fit=True`).
 
-## Still pending (lower priority)
-C2 per-tree TS permutation, C4 cat-aware binning, G2 adaptive leaf shrinkage.
-Given 5/5 kills, expectations are low; run them to confirm, not to hope. The
-higher-value direction is studying CatBoost's machinery *as a whole* (integrated
-ordered boosting on permutations) rather than porting parts — or accepting that
-ChimeraBoost's identity (pure-Python, oblivious, fast, near-optimal defaults) is
-a different, valid point on the Pareto front than CatBoost's TabArena Elo.
+## Queue complete
+Every pre-registered lever has been run (C1, C3, C4, G1, G2, G3, G4) or deferred
+with cause (C2). All seven runnable levers killed. The remaining honest directions
+are: (a) study CatBoost's machinery *as a whole* — integrated ordered boosting on
+permutations, which would be a from-scratch redesign, not a flag; or (b) accept
+that ChimeraBoost's identity (pure-Python, oblivious, fast, near-optimal defaults)
+is simply a different, valid point on the Pareto front than CatBoost's TabArena
+Elo. The seven flags remain as documented default-off opt-ins for users whose data
+matches a lever's narrow sweet-spot (e.g. `cat_aware_binning`/`onehot_low_card`
+help car/splice).

--- a/benchmarks/research/SUMMARY.md
+++ b/benchmarks/research/SUMMARY.md
@@ -1,0 +1,39 @@
+# CatBoost-gap cascade — verdict ledger
+
+Pre-registered ideas run through the efficient cascade (`cascade.py`). Each was a
+default-OFF flag, byte-identical no-op when off, tested, then judged on paired
+validation curves (T0) and/or held-out test metric with a sign test (T1). Lower
+is better throughout. **Guardrail: TabArena never touched; OpenML T1 is a one-shot
+gate, not an iteration target.**
+
+| Idea | Flag | Tier | Verdict | What happened |
+|---|---|---|---|---|
+| C1 one-hot low-card | `onehot_low_card` | T0 | **KILL** | helps splice/car/adult, regresses bank-marketing (3/8) |
+| C3 selective cat-combos (mixed) | `cat_combinations_selective` | T0 | **KILL** | MI-pruning *hurts* all-cat sets (kr-vs-kp +27%); auto-rule already right (1/8) |
+| G1 forest joint leaf refit | `forest_leaf_refit` | T1 | **KILL** | overfits (train↓ test↑ +6–14%); binary gain already in `linear_leaves` |
+| G4 ordered + leaf machinery | `ordered_leaf_estimation` | T0 | **KILL** | helps some cats, badly hurts kr-vs-kp (+17%); ordered-boosting off by default for a reason (3/8) |
+
+## Headline finding
+
+Four CatBoost-inspired levers, four kills. Each partial mechanism port **regresses
+somewhere** while the wins it chases are **already banked in the current defaults**:
+- the all-categorical `cat_combinations` auto-rule (C1/C3 can't beat it),
+- the binary `linear_leaves` default (G1's leaf-sharpness target),
+- plain boosting with size-adaptive `min_child_weight` (G4's ordered variant loses).
+
+The TabArena CatBoost gap does **not** appear closable by incremental ports of
+isolated CatBoost mechanisms into this pure-Python oblivious architecture — the
+gap looks like an emergent property of CatBoost's *integrated* ordered-boosting-
+on-permutations machinery operating together, not any single transplantable part.
+
+## Engine notes
+- One fit = whole `validation_history_` curve; paired same-split deltas; shared
+  baseline cache → each verdict reached in ~25–60s (T0) for ~0 marginal cost.
+- Post-fit ideas (G1) are invisible to the per-round curve → routed straight to
+  the promotion tier (`post_fit=True`).
+
+## Still pending (lower priority)
+C2 per-tree TS permutation, C4 cat-aware binning, G2 adaptive leaf shrinkage,
+G3 adaptive leaf_estimation. Given 4/4 kills, expectations are low; run them to
+confirm, not to hope. The higher-value direction is studying CatBoost's machinery
+*as a whole* rather than porting parts.

--- a/benchmarks/research/SUMMARY.md
+++ b/benchmarks/research/SUMMARY.md
@@ -12,11 +12,13 @@ gate, not an iteration target.**
 | C3 selective cat-combos (mixed) | `cat_combinations_selective` | T0 | **KILL** | MI-pruning *hurts* all-cat sets (kr-vs-kp +27%); auto-rule already right (1/8) |
 | G1 forest joint leaf refit | `forest_leaf_refit` | T1 | **KILL** | overfits (train↓ test↑ +6–14%); binary gain already in `linear_leaves` |
 | G4 ordered + leaf machinery | `ordered_leaf_estimation` | T0 | **KILL** | helps some cats, badly hurts kr-vs-kp (+17%); ordered-boosting off by default for a reason (3/8) |
+| G3 adaptive leaf-estimation | `adaptive_leaf_estimation` | T0 | **KILL** | flat — size-scheduling the Newton steps buys ~nothing (1/8, mean −0.11%) |
 
 ## Headline finding
 
-Four CatBoost-inspired levers, four kills. Each partial mechanism port **regresses
-somewhere** while the wins it chases are **already banked in the current defaults**:
+Five CatBoost-inspired / scheduling levers, five kills. Each partial mechanism
+port **regresses somewhere** (or is flat) while the wins it chases are **already
+banked in the current defaults**:
 - the all-categorical `cat_combinations` auto-rule (C1/C3 can't beat it),
 - the binary `linear_leaves` default (G1's leaf-sharpness target),
 - plain boosting with size-adaptive `min_child_weight` (G4's ordered variant loses).
@@ -33,7 +35,9 @@ on-permutations machinery operating together, not any single transplantable part
   the promotion tier (`post_fit=True`).
 
 ## Still pending (lower priority)
-C2 per-tree TS permutation, C4 cat-aware binning, G2 adaptive leaf shrinkage,
-G3 adaptive leaf_estimation. Given 4/4 kills, expectations are low; run them to
-confirm, not to hope. The higher-value direction is studying CatBoost's machinery
-*as a whole* rather than porting parts.
+C2 per-tree TS permutation, C4 cat-aware binning, G2 adaptive leaf shrinkage.
+Given 5/5 kills, expectations are low; run them to confirm, not to hope. The
+higher-value direction is studying CatBoost's machinery *as a whole* (integrated
+ordered boosting on permutations) rather than porting parts — or accepting that
+ChimeraBoost's identity (pure-Python, oblivious, fast, near-optimal defaults) is
+a different, valid point on the Pareto front than CatBoost's TabArena Elo.

--- a/benchmarks/research/__init__.py
+++ b/benchmarks/research/__init__.py
@@ -1,0 +1,25 @@
+"""Full-research-mode cascade engine for closing the CatBoost gap.
+
+An extremely-efficient Bayesian cascade (idea -> handful -> medium -> large) that
+benchmarks ChimeraBoost variants without ever touching the sealed TabArena-Lite
+holdout. The efficiency levers, in order of impact:
+
+  * One fit = the whole validation curve. ChimeraBoost records the per-iteration
+    validation loss in ``validation_history_`` (free on every fit), so a single
+    fit yields the metric at *every* iteration count at once -- no refitting at
+    multiple ``n_estimators``.
+  * Paired same-split deltas. A variant's curve is compared against the baseline's
+    on the *same* train/val split -- a far lower-variance signal than comparing
+    final test scores across different splits, so fewer datasets/seeds reach
+    significance.
+  * Persistent dataset cache (download once ever) + shared-baseline cache (only
+    the variant refits per idea).
+  * Tiered cascade with sequential sign-test early-stop: minimal fits to a verdict.
+
+See the package modules: ``datasets`` (tiers + cache), ``curves`` (paired curve
+comparison), ``runner`` (three-way split + fast/promotion fits), ``ideas`` (the
+pre-registered queue), ``cascade`` (orchestration + gates), ``report``.
+
+GUARDRAIL: this engine must never load TabArena. OpenML is a one-shot gate, not
+an iteration target. See memory feedback_tabarena_lite_is_sealed_holdout.
+"""

--- a/benchmarks/research/cascade.py
+++ b/benchmarks/research/cascade.py
@@ -169,6 +169,16 @@ def cascade(idea_name, tiers, seed, threads, jobs):
                category=spec["category"], params=params, tiers={})
     print(report.preregister(idea_name, spec), flush=True)
 
+    # Post-fit ideas (e.g. G1 forest leaf refit) rewrite the model AFTER boosting,
+    # so the per-round validation_history_ curve cannot see them -- the fast
+    # (curve) tier would read a false flat. Skip T0 for them and judge at the
+    # promotion tier, which fits the full model (refit included) and scores the
+    # held-out test set.
+    if spec.get("post_fit") and "T0" in tiers:
+        print("\n[T0] SKIPPED -- post-fit idea is invisible to the validation "
+              "curve; evaluating at the promotion tier instead.", flush=True)
+        tiers = [t for t in tiers if t != "T0"]
+
     if "T0" in tiers:
         print("\n[T0] fast tier -- paired validation curves ...", flush=True)
         v = run_fast_tier(params, seed, threads, jobs)

--- a/benchmarks/research/cascade.py
+++ b/benchmarks/research/cascade.py
@@ -1,0 +1,273 @@
+"""Cascade orchestration: idea -> T0 (paired curves) -> gate -> T1 -> gate ->
+T2 (+ OpenML one-shot gate inside) -> PMLB holdout, with a pre-registered
+hypothesis and a consolidated per-idea report.
+
+Efficiency: paired same-split deltas (variance crusher), shared-baseline cache
+(only the variant refits), and a sequential sign-test early-stop per tier. Fits
+parallelize over datasets (ProcessPoolExecutor).
+
+GUARDRAIL: never loads TabArena; OpenML is a one-shot gate (T1), not iterated.
+
+CLI:
+  python -m benchmarks.research.cascade --idea C1_onehot_low_card --tier T0 T1
+  python benchmarks/research/cascade.py --idea linear_leaves --tier T0   # self-test
+  python benchmarks/research/cascade.py --selftest
+"""
+
+import argparse
+import math
+import os
+import sys
+import time
+from concurrent.futures import ProcessPoolExecutor
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from research import curves, datasets, ideas, runner, report  # noqa: E402
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8")
+except Exception:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Sign test (paired). Counts datasets where the variant IMPROVES the primary
+# (lower-is-better) metric, ties within eps excluded. Two-sided binomial p.
+# ---------------------------------------------------------------------------
+def sign_test(deltas, eps=0.0):
+    """``deltas`` are (variant - baseline) on a lower-is-better metric, so a
+    negative delta is an improvement. Returns wins/losses/ties + binomial p."""
+    wins = sum(1 for d in deltas if d < -eps)     # variant better
+    losses = sum(1 for d in deltas if d > eps)    # variant worse
+    ties = len(deltas) - wins - losses
+    n = wins + losses
+    if n == 0:
+        return dict(wins=wins, losses=losses, ties=ties, n=n, p=1.0)
+    try:
+        from scipy.stats import binomtest
+        p = binomtest(min(wins, losses), n, 0.5,
+                      alternative="two-sided").pvalue
+    except Exception:                              # normal approx fallback
+        z = abs(wins - losses) / math.sqrt(n)
+        p = math.erfc(z / math.sqrt(2))
+    return dict(wins=wins, losses=losses, ties=ties, n=n, p=float(p))
+
+
+# ---------------------------------------------------------------------------
+# Per-dataset workers (top-level so ProcessPoolExecutor can pickle them).
+# ---------------------------------------------------------------------------
+def eval_fast(dataset, params, seed, threads, max_rows):
+    """Fast tier: baseline (cached) vs variant paired validation curves."""
+    X, y, cat, task = datasets.load(dataset, max_rows=max_rows)
+    sp = runner.three_way_split(X, y, task, seed)
+    X_tr, y_tr, X_val, y_val, _Xte, _yte = sp
+    base = runner.cached_baseline_curve(dataset, task, X_tr, y_tr, X_val, y_val,
+                                        cat, seed, threads)
+    var = runner.fast_curve(task, params, X_tr, y_tr, X_val, y_val, cat, seed,
+                            threads)
+    stat = curves.compare(base, var)
+    stat.update(dataset=dataset, task=task, seed=seed)
+    return stat
+
+
+def eval_promo(dataset, params, seed, threads, max_rows):
+    """Promotion tier: baseline (cached) vs variant true held-out test metric."""
+    X, y, cat, task = datasets.load(dataset, max_rows=max_rows)
+    sp = runner.three_way_split(X, y, task, seed)
+    X_tr, y_tr, X_val, y_val, X_te, y_te = sp
+    (bm, bt) = runner.cached_baseline_promotion(
+        dataset, task, X_tr, y_tr, X_val, y_val, X_te, y_te, cat, seed, threads)
+    vm, vt = runner.promotion_metrics(task, params, X_tr, y_tr, X_val, y_val,
+                                      X_te, y_te, cat, seed, threads)
+    delta = vm["primary"] - bm["primary"]
+    rel = delta / (abs(bm["primary"]) + 1e-12)
+    return dict(dataset=dataset, task=task, seed=seed,
+                base=bm, variant=vm, base_trees=bt, variant_trees=vt,
+                delta=delta, rel=rel)
+
+
+def _map(fn, keys, params, seed, threads, max_rows, jobs):
+    """Run ``fn`` over dataset keys, parallel when jobs != 1. Failures are logged
+    and skipped (a flaky download shouldn't sink the whole tier)."""
+    results = []
+    if jobs == 1:
+        for k in keys:
+            try:
+                results.append(fn(k, params, seed, threads, max_rows))
+            except Exception as e:
+                print(f"  ! {k}: {e}", flush=True)
+        return results
+    with ProcessPoolExecutor(max_workers=abs(jobs)) as ex:
+        futs = {ex.submit(fn, k, params, seed, threads, max_rows): k
+                for k in keys}
+        for fut in futs:
+            k = futs[fut]
+            try:
+                results.append(fut.result())
+            except Exception as e:
+                print(f"  ! {k}: {e}", flush=True)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Tier runners + gates.
+# ---------------------------------------------------------------------------
+def run_fast_tier(idea_params, seed, threads, jobs, max_rows=datasets.T0_MAX_ROWS,
+                  keys=None):
+    keys = keys if keys is not None else datasets.tier_keys("T0")
+    t0 = time.time()
+    rows = _map(eval_fast, keys, idea_params, seed, threads, max_rows, jobs)
+    favorable = [r for r in rows if r["best_val_delta"] < -1e-9]
+    dominated = [r for r in rows if r["dominance"] < 0.1]
+    verdict = dict(
+        n=len(rows), favorable=len(favorable), dominated=len(dominated),
+        mean_best_delta_pct=float(np.mean([r["best_val_delta_pct"]
+                                           for r in rows])) if rows else 0.0,
+        mean_dominance=float(np.mean([r["dominance"] for r in rows]))
+        if rows else 0.0,
+        seconds=time.time() - t0, rows=rows)
+    # Gate T0->T1: favorable on >= ceil(0.6*n) AND not strongly dominated.
+    need = math.ceil(0.6 * len(rows)) if rows else 1
+    verdict["passed"] = (len(favorable) >= need
+                         and verdict["mean_dominance"] > 0.1)
+    verdict["need"] = need
+    return verdict
+
+
+def run_promo_tier(idea_params, seed, threads, jobs, keys, max_rows=None,
+                   speed_tol=1.25):
+    t0 = time.time()
+    rows = _map(eval_promo, keys, idea_params, seed, threads, max_rows, jobs)
+    deltas = [r["rel"] for r in rows]
+    st = sign_test(deltas)
+    # Speed regression guard: mean variant/baseline tree-count ratio.
+    ratios = [r["variant_trees"] / max(1, r["base_trees"]) for r in rows]
+    mean_ratio = float(np.mean(ratios)) if ratios else 1.0
+    verdict = dict(n=len(rows), sign_test=st,
+                   mean_rel=float(np.mean(deltas)) if deltas else 0.0,
+                   mean_tree_ratio=mean_ratio, seconds=time.time() - t0,
+                   rows=rows)
+    # Gate: more wins than losses, significant (p < 0.1), no large speed regress.
+    verdict["passed"] = (st["wins"] > st["losses"] and st["p"] < 0.1
+                         and mean_ratio < speed_tol)
+    return verdict
+
+
+# ---------------------------------------------------------------------------
+# Full cascade for one idea.
+# ---------------------------------------------------------------------------
+def cascade(idea_name, tiers, seed, threads, jobs):
+    spec = ideas.get(idea_name)
+    if not spec["implemented"]:
+        raise SystemExit(
+            f"idea {idea_name!r} is not implemented yet (no library flag). "
+            f"Implement its default-off flag first.")
+    params = spec["params"]
+    out = dict(idea=idea_name, hypothesis=spec["hypothesis"],
+               category=spec["category"], params=params, tiers={})
+    print(report.preregister(idea_name, spec), flush=True)
+
+    if "T0" in tiers:
+        print("\n[T0] fast tier -- paired validation curves ...", flush=True)
+        v = run_fast_tier(params, seed, threads, jobs)
+        out["tiers"]["T0"] = v
+        print(report.fast_tier(v), flush=True)
+        if not v["passed"]:
+            out["verdict"] = "KILL @ T0"
+            print(report.final(out), flush=True)
+            return out
+
+    if "T1" in tiers:
+        print("\n[T1] promotion -- OpenML categorical gate (paired sign test) ...",
+              flush=True)
+        keys = datasets.tier_keys("T1")
+        v = run_promo_tier(params, seed, threads, jobs, keys)
+        out["tiers"]["T1"] = v
+        print(report.promo_tier("T1", v), flush=True)
+        if not v["passed"]:
+            out["verdict"] = "KILL @ T1"
+            print(report.final(out), flush=True)
+            return out
+
+    if "T2" in tiers:
+        print("\n[T2] large -- full sign test (Grinsztajn + OpenML) ...",
+              flush=True)
+        keys = datasets.tier_keys("T2")
+        v = run_promo_tier(params, seed, threads, jobs, keys)
+        out["tiers"]["T2"] = v
+        print(report.promo_tier("T2", v), flush=True)
+        if not v["passed"]:
+            out["verdict"] = "KEEP AS OPT-IN @ T2"
+            print(report.final(out), flush=True)
+            return out
+
+    if "HOLDOUT" in tiers:
+        print("\n[HOLDOUT] PMLB holdout -- out-of-sample generalization ...",
+              flush=True)
+        keys = datasets.tier_keys("HOLDOUT")
+        v = run_promo_tier(params, seed, threads, jobs, keys)
+        out["tiers"]["HOLDOUT"] = v
+        print(report.promo_tier("HOLDOUT", v), flush=True)
+
+    out["verdict"] = "SHIP (review Pareto)" if out["tiers"] else "no tiers run"
+    print(report.final(out), flush=True)
+    return out
+
+
+def selftest(seed, threads, jobs):
+    """Reproduce two known truths on T0, proving the harness discriminates a real
+    win from a no-op:
+
+      * linear_leaves -- a clear POSITIVE where it is OFF by default. (NOTE: it is
+        already the auto-default for *binary* classification, so it is correctly
+        flat there; the off-by-default win shows on regression -- e.g. pol.) The
+        anchor: at least one dataset improves strongly (min best-val delta well
+        below 0) with high pointwise dominance.
+      * patience300 -- a NO-OP on the fast tier (early stopping is disabled, so
+        patience cannot move the curve): the trajectory is IDENTICAL to baseline.
+    """
+    print("=== ENGINE SELF-TEST (T0) ===", flush=True)
+    pos = run_fast_tier(ideas.get("linear_leaves")["params"], seed, threads, jobs)
+    print(report.fast_tier(pos, label="linear_leaves (expect a strong "
+                           "off-by-default win, e.g. regression pol)"),
+          flush=True)
+    flat = run_fast_tier(ideas.get("patience300")["params"], seed, threads, jobs)
+    print(report.fast_tier(flat, label="patience300 (expect FLAT / no-op)"),
+          flush=True)
+    min_delta = min((r["best_val_delta_pct"] for r in pos["rows"]), default=0.0)
+    ok_pos = (pos["favorable"] >= 1 and min_delta < -0.01
+              and pos["mean_dominance"] > 0.5)
+    ok_flat = abs(flat["mean_best_delta_pct"]) < 1e-6
+    print(f"\nSELF-TEST: linear_leaves discriminates (min bestD "
+          f"{100*min_delta:+.2f}%, favorable={pos['favorable']})={ok_pos} | "
+          f"patience300 flat={ok_flat} | "
+          f"{'PASS' if ok_pos and ok_flat else 'FAIL'}", flush=True)
+    return ok_pos and ok_flat
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--idea", help=f"idea name; one of {sorted(ideas.IDEAS)}")
+    ap.add_argument("--tier", nargs="+", default=["T0", "T1"],
+                    choices=["T0", "T1", "T2", "HOLDOUT"])
+    ap.add_argument("--seed", type=int, default=3000)
+    ap.add_argument("--threads", type=int, default=None)
+    ap.add_argument("--jobs", type=int, default=1,
+                    help="processes over datasets (1 = serial)")
+    ap.add_argument("--selftest", action="store_true",
+                    help="run the engine self-test (known-truth reproduction)")
+    args = ap.parse_args()
+
+    if args.selftest:
+        ok = selftest(args.seed, args.threads, args.jobs)
+        raise SystemExit(0 if ok else 1)
+    if not args.idea:
+        ap.error("pass --idea NAME or --selftest")
+    cascade(args.idea, args.tier, args.seed, args.threads, args.jobs)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/research/curves.py
+++ b/benchmarks/research/curves.py
@@ -1,0 +1,87 @@
+"""Paired validation-curve comparison -- the cascade's cheap go/kill signal.
+
+Given a baseline curve ``b`` and a variant curve ``v`` recorded on the SAME
+train/val split (so the comparison is paired, not across-split), summarize how
+the variant's per-iteration validation loss trajectory differs from baseline.
+Lower loss is better throughout (logloss / RMSE-space), so negative deltas favor
+the variant.
+
+These are deliberately cheap scalar reductions of two equal-or-unequal-length
+loss arrays; the runner computes them from ``validation_history_`` with no extra
+fits. The cascade thresholds them (see ``cascade``).
+"""
+
+import numpy as np
+
+
+def _as_array(curve):
+    a = np.asarray(curve, dtype=np.float64)
+    if a.ndim != 1 or a.size == 0:
+        raise ValueError("curve must be a non-empty 1-D sequence of losses.")
+    return a
+
+
+def best_val(curve):
+    """The minimum validation loss along the curve -- what early stopping picks."""
+    return float(np.min(_as_array(curve)))
+
+
+def best_val_delta(baseline, variant):
+    """``min(variant) - min(baseline)``: the primary fast signal. Negative means
+    the variant reaches a lower best validation loss than baseline (better)."""
+    return best_val(variant) - best_val(baseline)
+
+
+def best_val_delta_pct(baseline, variant):
+    """``best_val_delta`` as a fraction of the baseline's best loss (signed).
+    Comparable across datasets of different loss scales."""
+    bb = best_val(baseline)
+    return best_val_delta(baseline, variant) / (abs(bb) + 1e-12)
+
+
+def _aligned(baseline, variant):
+    """Truncate both curves to their common length for pointwise comparison.
+    Curves can differ in length when a depth-0 tree stops one early."""
+    b, v = _as_array(baseline), _as_array(variant)
+    n = min(b.size, v.size)
+    return b[:n], v[:n]
+
+
+def dominance(baseline, variant):
+    """Fraction of iterations where ``variant <= baseline`` (variant at least as
+    good pointwise). 1.0 = variant dominates everywhere (strong promote); ~0.0 =
+    dominated everywhere (fast kill); 0.5 = curves interleave."""
+    b, v = _aligned(baseline, variant)
+    return float(np.mean(v <= b + 1e-12))
+
+
+def early_signal(baseline, variant, k=50):
+    """Sign of the mean ``variant - baseline`` gap over the first ``k`` iterations.
+    Lets us kill before convergence when the early trajectory is already clearly
+    worse. Returns the signed mean gap (negative favors the variant)."""
+    b, v = _aligned(baseline, variant)
+    k = min(k, b.size)
+    return float(np.mean(v[:k] - b[:k]))
+
+
+def area_between(baseline, variant):
+    """Signed mean gap ``variant - baseline`` over the common length -- a
+    magnitude estimate of how far apart the trajectories run. Negative favors the
+    variant."""
+    b, v = _aligned(baseline, variant)
+    return float(np.mean(v - b))
+
+
+def compare(baseline, variant, k=50):
+    """All paired-curve statistics for one (baseline, variant) curve pair."""
+    return {
+        "best_val_baseline": best_val(baseline),
+        "best_val_variant": best_val(variant),
+        "best_val_delta": best_val_delta(baseline, variant),
+        "best_val_delta_pct": best_val_delta_pct(baseline, variant),
+        "dominance": dominance(baseline, variant),
+        "early_signal": early_signal(baseline, variant, k),
+        "area_between": area_between(baseline, variant),
+        "len_baseline": int(_as_array(baseline).size),
+        "len_variant": int(_as_array(variant).size),
+    }

--- a/benchmarks/research/datasets.py
+++ b/benchmarks/research/datasets.py
@@ -1,0 +1,136 @@
+"""Dataset tiers for the cascade, with a download-once persistent cache.
+
+Reuses the loaders already wired in ``run_benchmarks`` (OpenML, Grinsztajn,
+PMLB) -- never re-implements a fetch. Each tier is a list of ``run_benchmarks``
+DATASETS keys; ``load(key)`` returns ``(X, y, cat, task)`` and caches the result
+to ``research/cache/data/`` keyed by the dataset key, so a dataset is fetched at
+most once ever (not once per idea, not once per seed).
+
+Tiers (categorical-first, never TabArena):
+  T0  handful (~8)  -- fast go/kill on paired curves. Seconds per fit-pair.
+  T1  medium (~)    -- OpenML real-categorical breadth (the categorical-aware
+                       gate; OpenML is used ONCE as a gate, never iterated).
+  T2  large         -- Grinsztajn-59 numeric breadth + OpenML + the categorical
+                       tier -> full sign test + blended Pareto.
+  HOLDOUT           -- PMLB holdout fold, out-of-sample generalization.
+
+GUARDRAIL: no tier may reference TabArena. See feedback_tabarena_lite_is_sealed_holdout.
+"""
+
+import os
+import pickle
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import run_benchmarks as rb  # noqa: E402
+
+_CACHE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                          "cache", "data")
+
+
+# ---------------------------------------------------------------------------
+# Tier membership. Keys are run_benchmarks DATASETS keys; the loaders for the
+# oml:/gr:/pm: namespaces are registered lazily by _ensure_registered().
+# ---------------------------------------------------------------------------
+
+# T0: a handful spanning the known levers' sweet-spots -- high-signal binary, an
+# interaction-heavy regression, real string-categorical sets (low + high card),
+# and multiclass. Row-capped (see T0_MAX_ROWS) so a fit-pair is seconds.
+T0_HANDFUL = [
+    "oml:electricity",        # binary, high-signal numeric
+    "gr:clf_num/covertype",   # binary, large numeric (capped)
+    "gr:reg_num/pol",         # regression, interaction-heavy
+    "oml:kr-vs-kp",           # binary, all real categoricals
+    "oml:adult",              # binary, mixed real categoricals (high card)
+    "oml:bank-marketing",     # binary, mixed real categoricals
+    "oml:car",                # multiclass, all real categoricals
+    "oml:splice",             # multiclass, real categoricals
+]
+T0_MAX_ROWS = 8000   # cap rows on T0 only, to keep go/kill in well under a minute
+
+# T1: OpenML real-categorical breadth -- the categorical-aware medium tier. Used
+# ONCE as a gate (not an iteration target). The cats="auto" members of the
+# (Part-B-extended) OpenML suite.
+def _openml_cat_keys():
+    return [f"oml:{name}" for name, spec in rb.OPENML_SUITE.items()
+            if spec.get("cats") == "auto"]
+
+
+# T2 large: full numeric breadth (Grinsztajn) + the whole OpenML suite + the
+# categorical tier. Built lazily (membership depends on registration).
+def _grinsztajn_keys():
+    return [k for k in rb.DATASETS if k.startswith("gr:")]
+
+
+def _openml_keys():
+    return [f"oml:{name}" for name in rb.OPENML_SUITE]
+
+
+def _pmlb_holdout_keys():
+    return [k for k in rb.DATASETS if k.startswith("pm:holdout/")]
+
+
+def _ensure_registered():
+    """Register every namespace loader (idempotent, cheap)."""
+    rb._add_openml_datasets()
+    rb._add_grinsztajn_datasets()
+    rb._add_pmlb_datasets()
+
+
+def tier_keys(tier):
+    """Return the dataset keys for a named tier. ``tier`` in
+    {T0, T1, T2, HOLDOUT}."""
+    _ensure_registered()
+    tier = tier.upper()
+    if tier == "T0":
+        return list(T0_HANDFUL)
+    if tier == "T1":
+        return _openml_cat_keys()
+    if tier == "T2":
+        # De-dup while preserving order: Grinsztajn numeric breadth, then the
+        # OpenML suite (includes the categorical tier from Part B).
+        seen, out = set(), []
+        for k in _grinsztajn_keys() + _openml_keys():
+            if k not in seen:
+                seen.add(k)
+                out.append(k)
+        return out
+    if tier == "HOLDOUT":
+        return _pmlb_holdout_keys()
+    raise ValueError(f"unknown tier {tier!r}; expected T0/T1/T2/HOLDOUT.")
+
+
+# ---------------------------------------------------------------------------
+# Persistent cache: fetch each dataset at most once, ever.
+# ---------------------------------------------------------------------------
+
+def _cache_path(key):
+    safe = key.replace(":", "__").replace("/", "_")
+    return os.path.join(_CACHE_DIR, f"{safe}.pkl")
+
+
+def load(key, max_rows=None):
+    """Return ``(X, y, cat, task)`` for a dataset key, from cache when present.
+
+    ``max_rows`` (e.g. for T0) seeded-subsamples after load and is NOT part of
+    the cache key -- the full dataset is cached once, then capped per call."""
+    if "tabarena" in key.lower():
+        raise ValueError("TabArena is a sealed holdout; the cascade must not "
+                         "load it.")
+    _ensure_registered()
+    path = _cache_path(key)
+    if os.path.exists(path):
+        with open(path, "rb") as f:
+            X, y, cat, task = pickle.load(f)
+    else:
+        builder = rb.DATASETS[key]
+        X, y, cat, task = builder(1.0, np.random.default_rng(0))
+        os.makedirs(_CACHE_DIR, exist_ok=True)
+        with open(path, "wb") as f:
+            pickle.dump((X, y, cat, task), f)
+    if max_rows is not None and len(y) > max_rows:
+        idx = np.random.default_rng(0).choice(len(y), max_rows, replace=False)
+        X, y = X[idx], y[idx]
+    return X, y, cat, task

--- a/benchmarks/research/ideas.py
+++ b/benchmarks/research/ideas.py
@@ -105,7 +105,7 @@ IDEAS = {
     "G3_adaptive_leaf_estimation": dict(
         params={"adaptive_leaf_estimation": True},
         category="general",
-        implemented=False,
+        implemented=True,
         direction="lower_better",
         hypothesis="Scaling leaf_estimation_iterations by data size/signal helps "
                    "where the single Newton step underfits.",

--- a/benchmarks/research/ideas.py
+++ b/benchmarks/research/ideas.py
@@ -85,6 +85,10 @@ IDEAS = {
         params={"forest_leaf_refit": True},
         category="general",
         implemented=True,
+        # Post-fit pass: it rewrites leaf values AFTER boosting, so the per-round
+        # validation_history_ curve cannot see it. The fast (curve) tier is blind
+        # to it -> evaluate directly at the promotion tier (true test metric).
+        post_fit=True,
         direction="lower_better",
         hypothesis="A post-fit ridge over all leaves couples redundant oblivious "
                    "splits and recovers sharpness -- the highest-upside Brier "

--- a/benchmarks/research/ideas.py
+++ b/benchmarks/research/ideas.py
@@ -84,7 +84,7 @@ IDEAS = {
     "G1_forest_joint_leaf_refit": dict(
         params={"forest_leaf_refit": True},
         category="general",
-        implemented=False,
+        implemented=True,
         direction="lower_better",
         hypothesis="A post-fit ridge over all leaves couples redundant oblivious "
                    "splits and recovers sharpness -- the highest-upside Brier "

--- a/benchmarks/research/ideas.py
+++ b/benchmarks/research/ideas.py
@@ -111,9 +111,9 @@ IDEAS = {
                    "where the single Newton step underfits.",
     ),
     "G4_ordered_plus_leaf_estimation": dict(
-        params={"ordered_leaf_estimation": True},
+        params={"ordered_boosting": True, "ordered_leaf_estimation": True},
         category="general",
-        implemented=False,
+        implemented=True,
         direction="lower_better",
         hypothesis="Reconciling ordered_boosting WITH leaf estimation (mutually "
                    "exclusive today) gives CatBoost's 'ordered boosting AND leaf "

--- a/benchmarks/research/ideas.py
+++ b/benchmarks/research/ideas.py
@@ -64,7 +64,7 @@ IDEAS = {
     "C3_selective_cat_combinations": dict(
         params={"cat_combinations_selective": True},
         category="categorical",
-        implemented=False,
+        implemented=True,
         direction="lower_better",
         hypothesis="Selecting cat-combinations by target association (mutual "
                    "info / gain) instead of all C(n,2), and allowing them on "

--- a/benchmarks/research/ideas.py
+++ b/benchmarks/research/ideas.py
@@ -1,0 +1,129 @@
+"""The pre-registered research queue.
+
+Each idea is a default-off variant expressed as ``params`` (kwargs that override
+the out-of-box baseline), plus a PRE-REGISTERED hypothesis (direction + which
+datasets it should help) recorded BEFORE any results are seen. Lead categorical-
+first; the cheap-tier signal is allowed to reprioritize.
+
+``implemented=True`` means the variant's flag already exists in the library and
+can be run through the cascade today. The CatBoost-gap levers (C*/G*) are listed
+here as the pre-registered agenda; each flips to implemented as its default-off
+flag lands (one change at a time).
+
+Two ideas with KNOWN outcomes are kept for the engine self-test:
+  * ``linear_leaves``  -- a known POSITIVE (binary-Brier win).
+  * ``patience300``    -- a known NEGATIVE/FLAT (rejected; defaults optimal).
+The harness must re-confirm both, proving it discriminates.
+"""
+
+# direction: "lower_better" means the variant should DECREASE the primary
+# loss/metric (RMSE/Brier/val-loss) where the hypothesis says it helps.
+IDEAS = {
+    # --- self-test anchors (known truths) ----------------------------------
+    "linear_leaves": dict(
+        params={"linear_leaves": True},
+        category="selftest",
+        implemented=True,
+        direction="lower_better",
+        hypothesis="Per-leaf ridge slopes lower validation logloss on binary "
+                   "classification (a known broad Brier win); neutral-to-helpful "
+                   "on regression. Self-test anchor: must re-confirm POSITIVE.",
+    ),
+    "patience300": dict(
+        params={"early_stopping_rounds": 300},
+        category="selftest",
+        implemented=True,
+        direction="lower_better",
+        hypothesis="Patience only changes WHERE early stopping picks, not the "
+                   "validation trajectory; with early_stopping disabled on the "
+                   "fast tier the curve is IDENTICAL to baseline. Self-test "
+                   "anchor: must re-confirm FLAT/NEGATIVE (rejected).",
+    ),
+
+    # --- C: categorical levers (lead the queue) ----------------------------
+    "C1_onehot_low_card": dict(
+        params={"onehot_low_card": True},
+        category="categorical",
+        implemented=True,   # flipped on in Part C
+        direction="lower_better",
+        hypothesis="One-hot encoding low-cardinality categoricals (<= ~8 levels) "
+                   "alongside ordered TS lets the tree make exact subset splits "
+                   "on rare discrete categories. HELPS mixed / high-card "
+                   "categorical sets (adult, bank-marketing, kr-vs-kp, car); "
+                   "NEUTRAL on the numeric sets (electricity, covertype, pol).",
+    ),
+    "C2_pertree_ts_permutation": dict(
+        params={"cat_pertree_permutation": True},
+        category="categorical",
+        implemented=False,
+        direction="lower_better",
+        hypothesis="A fresh TS permutation per tree (per block) approximates "
+                   "CatBoost's per-snapshot adaptivity; helps high-signal "
+                   "categorical sets. Watch fit-time cost.",
+    ),
+    "C3_selective_cat_combinations": dict(
+        params={"cat_combinations_selective": True},
+        category="categorical",
+        implemented=False,
+        direction="lower_better",
+        hypothesis="Selecting cat-combinations by target association (mutual "
+                   "info / gain) instead of all C(n,2), and allowing them on "
+                   "MIXED data, extends the car-type interaction win without "
+                   "crowding numeric splits.",
+    ),
+    "C4_cat_aware_binning": dict(
+        params={"cat_aware_binning": True},
+        category="categorical",
+        implemented=False,
+        direction="lower_better",
+        hypothesis="More/different bins for encoded categorical columns gives "
+                   "sharper categorical splits.",
+    ),
+
+    # --- G: general default-accuracy levers ---------------------------------
+    "G1_forest_joint_leaf_refit": dict(
+        params={"forest_leaf_refit": True},
+        category="general",
+        implemented=False,
+        direction="lower_better",
+        hypothesis="A post-fit ridge over all leaves couples redundant oblivious "
+                   "splits and recovers sharpness -- the highest-upside Brier "
+                   "lever. De-risk with a slow reference impl first.",
+    ),
+    "G2_adaptive_leaf_shrinkage": dict(
+        params={"adaptive_leaf_shrinkage": True},
+        category="general",
+        implemented=False,
+        direction="lower_better",
+        hypothesis="Per-leaf L2 scaled by leaf mass regularizes low-mass leaves "
+                   "harder; small broad Brier gain.",
+    ),
+    "G3_adaptive_leaf_estimation": dict(
+        params={"adaptive_leaf_estimation": True},
+        category="general",
+        implemented=False,
+        direction="lower_better",
+        hypothesis="Scaling leaf_estimation_iterations by data size/signal helps "
+                   "where the single Newton step underfits.",
+    ),
+    "G4_ordered_plus_leaf_estimation": dict(
+        params={"ordered_leaf_estimation": True},
+        category="general",
+        implemented=False,
+        direction="lower_better",
+        hypothesis="Reconciling ordered_boosting WITH leaf estimation (mutually "
+                   "exclusive today) gives CatBoost's 'ordered boosting AND leaf "
+                   "machinery together' -- what the TabArena gap analysis points "
+                   "at directly.",
+    ),
+}
+
+
+def get(name):
+    if name not in IDEAS:
+        raise KeyError(f"unknown idea {name!r}; known: {sorted(IDEAS)}")
+    return IDEAS[name]
+
+
+def implemented_ideas():
+    return [n for n, spec in IDEAS.items() if spec["implemented"]]

--- a/benchmarks/research/ideas.py
+++ b/benchmarks/research/ideas.py
@@ -95,9 +95,9 @@ IDEAS = {
                    "lever. De-risk with a slow reference impl first.",
     ),
     "G2_adaptive_leaf_shrinkage": dict(
-        params={"adaptive_leaf_shrinkage": True},
+        params={"adaptive_leaf_shrinkage": 1.0},
         category="general",
-        implemented=False,
+        implemented=True,
         direction="lower_better",
         hypothesis="Per-leaf L2 scaled by leaf mass regularizes low-mass leaves "
                    "harder; small broad Brier gain.",

--- a/benchmarks/research/ideas.py
+++ b/benchmarks/research/ideas.py
@@ -55,11 +55,16 @@ IDEAS = {
     "C2_pertree_ts_permutation": dict(
         params={"cat_pertree_permutation": True},
         category="categorical",
-        implemented=False,
+        implemented=False,   # DEFERRED -- see note below
         direction="lower_better",
         hypothesis="A fresh TS permutation per tree (per block) approximates "
                    "CatBoost's per-snapshot adaptivity; helps high-signal "
-                   "categorical sets. Watch fit-time cost.",
+                   "categorical sets. DEFERRED: this requires RE-ENCODING the "
+                   "categorical columns every boosting round, a fundamental break "
+                   "from ChimeraBoost's encode-once-then-bin architecture (the "
+                   "binned matrix the tree kernel consumes is built once at fit). "
+                   "Not justified for a near-certain kill given 6/6 other levers "
+                   "killed; would need a dedicated re-encode-per-round redesign.",
     ),
     "C3_selective_cat_combinations": dict(
         params={"cat_combinations_selective": True},
@@ -74,7 +79,7 @@ IDEAS = {
     "C4_cat_aware_binning": dict(
         params={"cat_aware_binning": True},
         category="categorical",
-        implemented=False,
+        implemented=True,
         direction="lower_better",
         hypothesis="More/different bins for encoded categorical columns gives "
                    "sharper categorical splits.",

--- a/benchmarks/research/report.py
+++ b/benchmarks/research/report.py
@@ -1,0 +1,79 @@
+"""Consolidated, phone-friendly reports for one idea's cascade run.
+
+Pure formatting -- takes the verdict dicts the tier runners produce and renders
+them as compact text (curves + deltas + verdict), in the spirit of the existing
+/bench summary.
+"""
+
+
+def preregister(name, spec):
+    lines = [
+        "=" * 64,
+        f"IDEA: {name}   [{spec['category']}]",
+        f"PARAMS: {spec['params']}",
+        "PRE-REGISTERED HYPOTHESIS:",
+    ]
+    # wrap the hypothesis to ~72 cols
+    words, line = spec["hypothesis"].split(), "  "
+    for w in words:
+        if len(line) + len(w) + 1 > 72:
+            lines.append(line)
+            line = "  " + w
+        else:
+            line += (" " if line.strip() else "") + w
+    if line.strip():
+        lines.append(line)
+    lines.append("=" * 64)
+    return "\n".join(lines)
+
+
+def fast_tier(v, label=None):
+    lines = []
+    if label:
+        lines.append(f"-- {label} --")
+    lines.append(f"{'dataset':<26}{'bestD%':>9}{'domin':>8}{'early':>10}")
+    lines.append("-" * 53)
+    for r in sorted(v["rows"], key=lambda r: r["best_val_delta_pct"]):
+        lines.append(f"{r['dataset']:<26}"
+                     f"{100*r['best_val_delta_pct']:>+8.2f}%"
+                     f"{r['dominance']:>8.2f}"
+                     f"{r['early_signal']:>+10.4f}")
+    lines.append("-" * 53)
+    lines.append(
+        f"favorable {v['favorable']}/{v['n']} (need {v['need']}) | "
+        f"mean bestD {100*v['mean_best_delta_pct']:+.2f}% | "
+        f"mean dominance {v['mean_dominance']:.2f} | {v['seconds']:.1f}s")
+    lines.append(f"GATE T0->T1: {'PASS' if v['passed'] else 'KILL'}")
+    return "\n".join(lines)
+
+
+def promo_tier(name, v):
+    st = v["sign_test"]
+    lines = [f"{'dataset':<26}{'task':>11}{'rel%':>9}{'base':>9}{'var':>9}"]
+    lines.append("-" * 64)
+    for r in sorted(v["rows"], key=lambda r: r["rel"]):
+        lines.append(f"{r['dataset']:<26}{r['task']:>11}"
+                     f"{100*r['rel']:>+8.2f}%"
+                     f"{r['base']['primary']:>9.4f}"
+                     f"{r['variant']['primary']:>9.4f}")
+    lines.append("-" * 64)
+    lines.append(
+        f"[{name}] wins {st['wins']} / losses {st['losses']} / ties {st['ties']}"
+        f"  (n={st['n']}, p={st['p']:.3f}) | mean rel {100*v['mean_rel']:+.2f}% "
+        f"| tree ratio {v['mean_tree_ratio']:.2f}x | {v['seconds']:.1f}s")
+    lines.append(f"GATE {name}: {'PASS' if v['passed'] else 'STOP'}")
+    return "\n".join(lines)
+
+
+def final(out):
+    lines = ["", "#" * 64, f"# VERDICT [{out['idea']}]: {out['verdict']}"]
+    for tier, v in out["tiers"].items():
+        if "sign_test" in v:
+            st = v["sign_test"]
+            lines.append(f"#   {tier}: wins {st['wins']}/{st['losses']} "
+                         f"p={st['p']:.3f} mean rel {100*v['mean_rel']:+.2f}%")
+        else:
+            lines.append(f"#   {tier}: favorable {v['favorable']}/{v['n']} "
+                         f"mean bestD {100*v['mean_best_delta_pct']:+.2f}%")
+    lines.append("#" * 64)
+    return "\n".join(lines)

--- a/benchmarks/research/runner.py
+++ b/benchmarks/research/runner.py
@@ -1,0 +1,169 @@
+"""Per-(dataset, seed) fitting: the fast (paired-curve) and promotion (true
+test-metric) tiers, plus the shared-baseline cache.
+
+Fast tier
+    Fit baseline and variant with ``early_stopping=False``,
+    ``n_estimators=FAST_HORIZON`` and an explicit ``eval_set`` so
+    ``validation_history_`` is the COMPLETE validation-loss curve to the horizon
+    (the stopper never fires -> never truncated). No test predictions. The
+    decision signal is the paired curve comparison (see ``curves``).
+
+Promotion tier
+    Fit with normal early stopping on the val split, predict the held-out TEST
+    split, and compute the true metric (RMSE / Brier / F1). The paired delta
+    (variant - baseline) per dataset feeds the sign test in ``cascade``.
+
+Shared-baseline cache
+    The out-of-box baseline is fit once per (dataset, seed) and its curve / test
+    metrics are cached to disk keyed by (dataset, seed, code_version). Every idea
+    reuses it; only the variant refits.
+"""
+
+import hashlib
+import os
+import pickle
+import subprocess
+
+import numpy as np
+from sklearn.model_selection import train_test_split
+
+from chimeraboost import ChimeraBoostClassifier, ChimeraBoostRegressor
+
+# Reuse the shared harness budget so a promotion fit == the shipped default.
+import run_benchmarks as rb
+
+FAST_HORIZON = 300   # fixed tree budget for the fast-tier validation curve
+_CACHE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                          "cache", "baseline")
+
+
+# ---------------------------------------------------------------------------
+# Code versioning -- the baseline cache must invalidate when the source changes.
+# ---------------------------------------------------------------------------
+def code_version():
+    """A short hash identifying the current ChimeraBoost source. Prefers the git
+    HEAD (+ '-dirty' when the working tree is modified); falls back to a hash of
+    the package source files when git is unavailable."""
+    root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    try:
+        head = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"], cwd=root,
+            stderr=subprocess.DEVNULL).decode().strip()
+        dirty = subprocess.call(
+            ["git", "diff", "--quiet", "--", "chimeraboost"], cwd=root,
+            stderr=subprocess.DEVNULL) != 0
+        return head + ("-dirty" if dirty else "")
+    except Exception:
+        import chimeraboost
+        pkg = os.path.dirname(chimeraboost.__file__)
+        h = hashlib.sha1()
+        for fn in sorted(os.listdir(pkg)):
+            if fn.endswith(".py"):
+                with open(os.path.join(pkg, fn), "rb") as f:
+                    h.update(f.read())
+        return "src-" + h.hexdigest()[:8]
+
+
+# ---------------------------------------------------------------------------
+# Splitting + metrics.
+# ---------------------------------------------------------------------------
+def three_way_split(X, y, task, seed, test_frac=0.2, val_frac=0.2):
+    """Split into train / val / test. ``val_frac`` is a fraction of the
+    post-test remainder. Stratified for classification."""
+    strat = y if task != "regression" else None
+    X_rest, X_te, y_rest, y_te = train_test_split(
+        X, y, test_size=test_frac, random_state=seed, stratify=strat)
+    strat2 = y_rest if task != "regression" else None
+    X_tr, X_val, y_tr, y_val = train_test_split(
+        X_rest, y_rest, test_size=val_frac, random_state=seed, stratify=strat2)
+    return X_tr, y_tr, X_val, y_val, X_te, y_te
+
+
+def _est(task, params, seed, threads):
+    Est = ChimeraBoostRegressor if task == "regression" else ChimeraBoostClassifier
+    kw = dict(n_estimators=rb.MAX_ITERS, early_stopping_rounds=rb.PATIENCE,
+              random_state=seed, thread_count=threads)
+    kw.update(params)
+    return Est(**kw)
+
+
+def test_metrics(task, model, X_te, y_te):
+    """True held-out test metrics. ``primary`` is lower-is-better (RMSE for
+    regression, Brier for classification) to match the cheap val-loss direction;
+    ``f1`` (higher better) is reported alongside for classification."""
+    if task == "regression":
+        pred = np.asarray(model.predict(X_te), dtype=float)
+        rmse = float(np.sqrt(np.mean((pred - y_te) ** 2)))
+        return {"primary": rmse, "rmse": rmse}
+    from sklearn.metrics import f1_score
+    proba = np.asarray(model.predict_proba(X_te), dtype=float)
+    classes = np.asarray(model.classes_)
+    onehot = (np.asarray(y_te)[:, None] == classes[None, :]).astype(float)
+    brier = float(np.mean(np.sum((proba - onehot) ** 2, axis=1)))
+    f1 = float(f1_score(y_te, model.predict(X_te), average="macro"))
+    return {"primary": brier, "brier": brier, "f1": f1}
+
+
+# ---------------------------------------------------------------------------
+# Fast tier: paired validation curves from a single fit each.
+# ---------------------------------------------------------------------------
+def fast_curve(task, params, X_tr, y_tr, X_val, y_val, cat, seed, threads,
+               horizon=FAST_HORIZON):
+    """Fit to a fixed horizon with no early stopping and return the full
+    validation-loss curve (``validation_history_``)."""
+    p = dict(params)
+    p.update(n_estimators=horizon, early_stopping=False)
+    m = _est(task, p, seed, threads)
+    m.fit(X_tr, y_tr, cat_features=cat, eval_set=(X_val, y_val))
+    return list(m.validation_history_)
+
+
+# ---------------------------------------------------------------------------
+# Promotion tier: true test metric with normal early stopping.
+# ---------------------------------------------------------------------------
+def promotion_metrics(task, params, X_tr, y_tr, X_val, y_val, X_te, y_te, cat,
+                      seed, threads):
+    """Fit with early stopping on the val split, then score the held-out test
+    split. Returns (metrics_dict, n_trees)."""
+    m = _est(task, params, seed, threads)
+    m.fit(X_tr, y_tr, cat_features=cat, eval_set=(X_val, y_val))
+    return test_metrics(task, m, X_te, y_te), int(m.best_iteration_)
+
+
+# ---------------------------------------------------------------------------
+# Shared-baseline cache (curve + promotion metrics), keyed by code version.
+# ---------------------------------------------------------------------------
+def _baseline_path(dataset, seed, kind, horizon, codever):
+    safe = dataset.replace(":", "__").replace("/", "_")
+    return os.path.join(_CACHE_DIR,
+                        f"{safe}__seed{seed}__{kind}__h{horizon}__{codever}.pkl")
+
+
+def cached_baseline_curve(dataset, task, X_tr, y_tr, X_val, y_val, cat, seed,
+                          threads, horizon=FAST_HORIZON):
+    """Baseline fast-tier curve, from cache when present (keyed by code version)."""
+    path = _baseline_path(dataset, seed, "curve", horizon, code_version())
+    if os.path.exists(path):
+        with open(path, "rb") as f:
+            return pickle.load(f)
+    curve = fast_curve(task, {}, X_tr, y_tr, X_val, y_val, cat, seed, threads,
+                       horizon)
+    os.makedirs(_CACHE_DIR, exist_ok=True)
+    with open(path, "wb") as f:
+        pickle.dump(curve, f)
+    return curve
+
+
+def cached_baseline_promotion(dataset, task, X_tr, y_tr, X_val, y_val, X_te,
+                              y_te, cat, seed, threads):
+    """Baseline promotion-tier metrics, from cache when present."""
+    path = _baseline_path(dataset, seed, "promo", 0, code_version())
+    if os.path.exists(path):
+        with open(path, "rb") as f:
+            return pickle.load(f)
+    out = promotion_metrics(task, {}, X_tr, y_tr, X_val, y_val, X_te, y_te, cat,
+                            seed, threads)
+    os.makedirs(_CACHE_DIR, exist_ok=True)
+    with open(path, "wb") as f:
+        pickle.dump(out, f)
+    return out

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -159,6 +159,8 @@ def _task_of(ds_name):
         return OPENML_SUITE[ds_name[4:]]["task"]
     if ds_name.startswith("gr:"):
         return GRINSZTAJN_TASKS[ds_name]
+    if ds_name.startswith("pm:"):
+        return PMLB_TASKS[ds_name]
     return SYNTH_TASKS[ds_name]
 
 
@@ -330,6 +332,76 @@ def _add_grinsztajn_datasets():
             GRINSZTAJN_TASKS[key] = task
 
 
+# The Penn Machine Learning Benchmarks (PMLB, EpistasisLab) — a fourth, fully
+# INDEPENDENT suite, distinct from Grinsztajn / the OpenML-34 suite / TabArena.
+# Purpose: a TUNING benchmark, kept separate so the report suites above stay
+# pure out-of-sample. Data is fetched as gzipped TSV from the GitHub LFS media
+# mirror (no `pmlb` dependency, same spirit as the Grinsztajn CSV loader); every
+# file has a `target` last-or-named column. Two design notes specific to PMLB:
+#   * All columns are integer-encoded (no string dtype), so `cats="auto"` would
+#     find nothing — we load everything as numeric. Nominal signal in the
+#     "categorical" columns is therefore not exploited (acceptable for tuning).
+#   * PMLB regression is dominated by synthetic Friedman/BNG families; we curate
+#     a real-world subset only. PMLB's value-add is MULTICLASS coverage, which
+#     the Grinsztajn suite lacks entirely.
+# The curated subset is split into a `tune` fold and a `holdout` fold so a tuned
+# knob can be checked for within-suite generalization (tune -> holdout) before it
+# ever touches the report suites. Keys are "pm:<fold>/<name>".
+PMLB_MEDIA = ("https://media.githubusercontent.com/media/EpistasisLab/pmlb/"
+              "master/datasets")
+# (name, task) per fold. Deduped against Grinsztajn + the OpenML-34 suite;
+# real-world only (no fri_c*/BNG_*/2dplanes/mv synthetics). reg = regression
+# (some are ordinal targets, treated as continuous), bin = binary, mc = multiclass.
+PMLB_DATASETS = {
+    "tune": [
+        ("1028_SWD", "regression"), ("1029_LEV", "regression"),
+        ("503_wind", "regression"), ("225_puma8NH", "regression"),
+        ("218_house_8L", "regression"),
+        ("churn", "binary"), ("hypothyroid", "binary"), ("coil2000", "binary"),
+        ("yeast", "multiclass"), ("contraceptive_method", "multiclass"),
+        ("segmentation", "multiclass"), ("texture", "multiclass"),
+        ("nursery", "multiclass"),
+    ],
+    "holdout": [
+        ("1030_ERA", "regression"),
+        ("4544_GeographicalOriginalofMusic", "regression"),
+        ("solar_flare", "regression"), ("529_pollen", "regression"),
+        ("dis", "binary"), ("clean2", "binary"), ("titanic", "binary"),
+        ("dna", "multiclass"), ("page_blocks", "multiclass"),
+        ("ann_thyroid", "multiclass"), ("mfeat_factors", "multiclass"),
+        ("krkopt", "multiclass"),
+    ],
+}
+PMLB_TASKS = {}   # "pm:<fold>/<name>" -> task, filled at registration
+_PMLB_MAX_ROWS = 50000
+
+
+def _make_pmlb_builder(name, task):
+    def builder(scale, rng):
+        import pandas as pd
+        df = pd.read_csv(f"{PMLB_MEDIA}/{name}/{name}.tsv.gz",
+                         sep="\t", compression="gzip")
+        if len(df) > _PMLB_MAX_ROWS:
+            df = df.sample(_PMLB_MAX_ROWS, random_state=0).reset_index(drop=True)
+        y = df["target"]
+        X_df = df.drop(columns=["target"])
+        # All-numeric integer encoding -> no categoricals to detect (cats=None).
+        return _frame_to_dataset(X_df, y, None, task)
+    return builder
+
+
+def _add_pmlb_datasets():
+    """Register the curated PMLB tuning suite into DATASETS as pm:<fold>/<name>.
+    Idempotent so workers can call it once cheaply."""
+    if any(k.startswith("pm:") for k in DATASETS):
+        return
+    for fold, items in PMLB_DATASETS.items():
+        for name, task in items:
+            key = f"pm:{fold}/{name}"
+            DATASETS[key] = _make_pmlb_builder(name, task)
+            PMLB_TASKS[key] = task
+
+
 # --------------------------------------------------------------------------
 # Model runners. Each returns (metrics_dict, fit_seconds, best_iter). The
 # metrics dict always includes "primary" (higher=better; -RMSE for regression,
@@ -388,7 +460,7 @@ PATIENCE = 50
 
 def _run_chimera(task, Xtr, ytr, Xte, yte, cat, threads, lr=None,
                  ordered_boosting=None, depth=6, subsample=1.0, mcw=None,
-                 cat_combinations=False, leaf_estimation_iterations=None,
+                 cat_combinations=None, leaf_estimation_iterations=None,
                  linear_leaves=False, linear_lambda=1.0):
     t = time.time()
     Est = ChimeraBoostRegressor if task == "regression" else ChimeraBoostClassifier
@@ -400,6 +472,10 @@ def _run_chimera(task, Xtr, ytr, Xte, yte, cat, threads, lr=None,
         kw["leaf_estimation_iterations"] = leaf_estimation_iterations
     if mcw is not None:
         kw["min_child_weight"] = mcw
+    # None = use the class auto-default (on for all-categorical data); only force
+    # it on when --chimera-cat-combinations is passed.
+    if cat_combinations:
+        kw["cat_combinations"] = True
     if linear_leaves:
         # multiclass doesn't support linear leaves yet; fall back to constant
         # leaves there so a full-suite run doesn't crash on multiclass tasks.
@@ -416,7 +492,6 @@ def _run_chimera(task, Xtr, ytr, Xte, yte, cat, threads, lr=None,
     m = Est(n_estimators=MAX_ITERS, early_stopping_rounds=PATIENCE,
             learning_rate=lr, depth=depth,
             subsample=subsample,
-            cat_combinations=cat_combinations,
             thread_count=threads, random_state=0, **kw)
     m.fit(Xtr, ytr, cat_features=cat)
     return _compute_metrics(task, yte, m, Xte), time.time() - t, m.best_iteration_
@@ -619,13 +694,15 @@ def _run_seed_task(task):
     (ds_name, seed, meta, {model: (metrics, secs, best_iter) or None})."""
     global PATIENCE, ENSEMBLE_N
     (ds_name, seed, scale, threads, model_names, chimera_cfg, patience,
-     ensemble_n, need_openml, need_grinsztajn) = task
+     ensemble_n, need_openml, need_grinsztajn, need_pmlb) = task
     PATIENCE = patience
     ENSEMBLE_N = ensemble_n
     if need_openml:
         _add_openml_datasets()
     if need_grinsztajn:
         _add_grinsztajn_datasets()
+    if need_pmlb:
+        _add_pmlb_datasets()
 
     rng = np.random.default_rng(1000 + seed)
     X, y, cat, ttype = DATASETS[ds_name](scale, rng)
@@ -693,6 +770,8 @@ class _Progress:
         lei = args.leaf_estimation_iterations
         self.config = (f"seeds={args.seeds} jobs={args.jobs} "
                        f"grinsztajn={args.grinsztajn} "
+                       f"pmlb={args.pmlb}"
+                       f"{('/' + args.pmlb_fold) if args.pmlb_fold else ''} "
                        f"depth={args.chimera_depth} "
                        f"lei={'default' if lei is None else lei} "
                        f"ob={'off' if not args.ordered_boosting else 'on'}")
@@ -752,6 +831,12 @@ def main():
     ap.add_argument("--grinsztajn", action="store_true",
                     help="run the Grinsztajn et al. 2022 tabular benchmark "
                          "(binary + regression), loaded from the HuggingFace mirror.")
+    ap.add_argument("--pmlb", action="store_true",
+                    help="run the curated PMLB tuning suite (reg + binary + "
+                         "multiclass; independent of the report suites). Use "
+                         "--pmlb-fold to restrict to tune/holdout.")
+    ap.add_argument("--pmlb-fold", choices=["tune", "holdout"], default=None,
+                    help="with --pmlb, run only this fold (default: both).")
     ap.add_argument("--models", nargs="+", default=None,
                     metavar="MODEL",
                     help=("limit to specific runners, e.g. "
@@ -853,6 +938,17 @@ def main():
             for k in [k for k in DATASETS if not k.startswith("gr:")]:
                 del DATASETS[k]
 
+    # PMLB tuning suite: same convention as Grinsztajn — register, then (unless
+    # specific --datasets were named) run ONLY it. --pmlb-fold narrows further.
+    need_pmlb = args.pmlb or bool(
+        args.datasets and any(d.startswith("pm:") for d in args.datasets))
+    if need_pmlb:
+        _add_pmlb_datasets()
+        if args.pmlb and not args.datasets:
+            keep_fold = (f"pm:{args.pmlb_fold}/" if args.pmlb_fold else "pm:")
+            for k in [k for k in DATASETS if not k.startswith(keep_fold)]:
+                del DATASETS[k]
+
     # Resolve the model set. Competitors are gated on install; XGBoost is off
     # by default (it tracks LightGBM). --models overrides everything.
     available = (list(_ALWAYS)
@@ -903,7 +999,7 @@ def main():
 
     # Run every (dataset, seed) draw, in parallel processes unless jobs == 1.
     tasks = [(ds, s, args.scale, threads_per, model_names, chimera_cfg,
-              PATIENCE, ENSEMBLE_N, need_openml, need_grinsztajn)
+              PATIENCE, ENSEMBLE_N, need_openml, need_grinsztajn, need_pmlb)
              for ds in selected for s in range(args.seeds)]
     total_tasks = len(tasks)
 

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -189,12 +189,17 @@ OPENML_SUITE = {
     "sick":          dict(data_id=38,    task="binary",     cats="auto"),
     "mushroom":      dict(data_id=24,    task="binary",     cats="auto"),
     "kr-vs-kp":      dict(data_id=3,     task="binary",     cats="auto"),
+    # high-cardinality real categoricals -- where one-hot vs ordered TS and fresh
+    # permutations actually differ (the CatBoost-gap research targets). Added for
+    # the categorical tier (Part B); all-categorical, no pre-encoding.
+    "Amazon_access": dict(data_id=4135,  task="binary",     cats="auto"),
     # classification (multiclass)
     "vehicle":       dict(data_id=54,    task="multiclass", cats=None),
     "segment":       dict(data_id=40984, task="multiclass", cats=None),
     "optdigits":     dict(data_id=28,    task="multiclass", cats=None),
     "car":           dict(data_id=40975, task="multiclass", cats="auto"),
     "splice":        dict(data_id=46,    task="multiclass", cats="auto"),
+    "nursery":       dict(data_id=26,    task="multiclass", cats="auto"),
     "satimage":      dict(data_id=182,   task="multiclass", cats=None),
     "pendigits":     dict(data_id=32,    task="multiclass", cats=None),
     "letter":        dict(data_id=6,     task="multiclass", cats=None),

--- a/chimeraboost/__init__.py
+++ b/chimeraboost/__init__.py
@@ -20,4 +20,4 @@ __all__ = [
     "ChimeraBoostRegressor",
     "ChimeraBoostClassifier",
 ]
-__version__ = "0.11.0"
+__version__ = "0.12.0"

--- a/chimeraboost/binning.py
+++ b/chimeraboost/binning.py
@@ -37,17 +37,30 @@ class Binner:
     """Learns per-feature borders and maps a float matrix to bins."""
 
     def __init__(self, max_bins=128):
-        if int(max_bins) > _MAX_SUPPORTED_BINS:
+        # max_bins is a scalar (uniform budget) or a per-feature array (C4
+        # cat-aware binning: a larger budget for target-encoded categorical
+        # columns). Validate either form against the dtype cap and the >=2 floor.
+        arr = np.atleast_1d(np.asarray(max_bins))
+        if (arr > _MAX_SUPPORTED_BINS).any():
             raise ValueError(
                 f"max_bins={max_bins} exceeds {_MAX_SUPPORTED_BINS} "
                 f"(BIN_DTYPE={BIN_DTYPE.__name__}); use a smaller value."
             )
-        if int(max_bins) < 2:
+        if (arr.astype(np.int64) < 2).any():
             raise ValueError(f"max_bins={max_bins} must be >= 2.")
-        self.max_bins = int(max_bins)
+        # Keep a scalar scalar (back-compat) or an int per-feature array.
+        self.max_bins = (int(max_bins) if np.isscalar(max_bins)
+                         or arr.size == 1 and np.ndim(max_bins) == 0
+                         else arr.astype(np.int64))
         self.borders_ = None       # list of np.ndarray, one per feature
         self.n_bins_ = None        # np.ndarray int, width per feature
         self.bin_centers_ = None   # list of np.ndarray: representative value/bin
+
+    def _max_bins_for(self, f):
+        """Per-feature bin budget: a scalar applies to all features, an array
+        gives feature f its own budget."""
+        return int(self.max_bins) if np.ndim(self.max_bins) == 0 \
+            else int(self.max_bins[f])
 
     @staticmethod
     def _centers_for(borders):
@@ -80,7 +93,8 @@ class Binner:
         X = np.asarray(X, dtype=np.float64)
         n_features = X.shape[1]
         self.borders_ = [
-            _feature_borders(X[:, f], self.max_bins) for f in range(n_features)
+            _feature_borders(X[:, f], self._max_bins_for(f))
+            for f in range(n_features)
         ]
         # +1 for the searchsorted upper bucket, +1 for the NaN bucket.
         self.n_bins_ = np.array(

--- a/chimeraboost/booster.py
+++ b/chimeraboost/booster.py
@@ -117,6 +117,7 @@ class _BaseBooster:
                  onehot_low_card=False, onehot_max_card=8,
                  cat_combinations_selective=False,
                  cat_combinations_max_pairs=20,
+                 cat_aware_binning=False, cat_max_bins=254,
                  forest_leaf_refit=False, forest_refit_iterations=3,
                  ordered_leaf_estimation=False, adaptive_leaf_shrinkage=0.0):
         self.n_estimators = int(n_estimators)
@@ -143,6 +144,8 @@ class _BaseBooster:
         self.onehot_max_card = int(onehot_max_card)
         self.cat_combinations_selective = bool(cat_combinations_selective)
         self.cat_combinations_max_pairs = int(cat_combinations_max_pairs)
+        self.cat_aware_binning = bool(cat_aware_binning)
+        self.cat_max_bins = int(cat_max_bins)
         self.forest_leaf_refit = bool(forest_leaf_refit)
         self.forest_refit_iterations = int(forest_refit_iterations)
         self.ordered_leaf_estimation = bool(ordered_leaf_estimation)
@@ -203,7 +206,9 @@ class _BaseBooster:
                                    onehot_low_card=self.onehot_low_card,
                                    onehot_max_card=self.onehot_max_card,
                                    cat_combinations_selective=self.cat_combinations_selective,
-                                   cat_combinations_max_pairs=self.cat_combinations_max_pairs)
+                                   cat_combinations_max_pairs=self.cat_combinations_max_pairs,
+                                   cat_aware_binning=self.cat_aware_binning,
+                                   cat_max_bins=self.cat_max_bins)
 
     @staticmethod
     def _normalize_weights(sample_weight, n_samples):

--- a/chimeraboost/booster.py
+++ b/chimeraboost/booster.py
@@ -116,7 +116,8 @@ class _BaseBooster:
                  onehot_low_card=False, onehot_max_card=8,
                  cat_combinations_selective=False,
                  cat_combinations_max_pairs=20,
-                 forest_leaf_refit=False, forest_refit_iterations=3):
+                 forest_leaf_refit=False, forest_refit_iterations=3,
+                 ordered_leaf_estimation=False):
         self.n_estimators = int(n_estimators)
         self.learning_rate = learning_rate
         self.depth = int(depth)
@@ -143,6 +144,7 @@ class _BaseBooster:
         self.cat_combinations_max_pairs = int(cat_combinations_max_pairs)
         self.forest_leaf_refit = bool(forest_leaf_refit)
         self.forest_refit_iterations = int(forest_refit_iterations)
+        self.ordered_leaf_estimation = bool(ordered_leaf_estimation)
 
     def _alloc_hist_buffers(self, n_features, n_bins):
         """Allocate the reusable histogram buffer once per fit.
@@ -225,6 +227,26 @@ class _BaseBooster:
         training assignment returned by build_oblivious_tree."""
         return _loo_leaf_step(leaf, g, h, tree.values.shape[0],
                               self.l2_leaf_reg, self.lr_)
+
+    def _refine_leaf_values(self, tree, leaf, F, y, w):
+        """Apply ``leaf_estimation_iterations - 1`` extra Newton steps to a
+        tree's leaf values, recomputing grad/hess at the updated residuals after
+        each step. Mutates ``tree.values`` in place. A no-op when
+        ``leaf_estimation_iterations == 1``. Shared by the plain and (under
+        ``ordered_leaf_estimation``) the ordered-boosting paths."""
+        for _ in range(self.leaf_estimation_iterations - 1):
+            F_tmp = F + tree.values[leaf]
+            g2, h2 = self.loss_.grad_hess(y, F_tmp)
+            if w is not None:
+                g2, h2 = g2 * w, h2 * w
+            n_lv = tree.values.shape[0]
+            if self.hs_lambda > 0.0:
+                tree.values += _leaf_values_hs(leaf, g2, h2, n_lv,
+                                               self.l2_leaf_reg, self.lr_,
+                                               self.hs_lambda)
+            else:
+                tree.values += _leaf_values(leaf, g2, h2, n_lv,
+                                            self.l2_leaf_reg, self.lr_)
 
     def _mvs_threshold(self, abs_g, target):
         """MVS: find threshold λ s.t. sum(min(|g_i|/λ, 1)) = target.
@@ -395,25 +417,21 @@ class GradientBoosting(_BaseBooster):
                 F += _linear_predict(leaf, tree.lin_feats, tree.lin_coef,
                                      self._centers_std_, Xb)
             elif self.ordered_boosting and not adjusts_leaves:
+                # G4: by default ordered boosting and the leaf-estimation Newton
+                # refinement are mutually exclusive (ordered owns the training
+                # step). With ordered_leaf_estimation on, also refine the stored
+                # leaf values (which predict uses) -- CatBoost's "ordered boosting
+                # AND leaf machinery together" -- while F keeps the honest ordered
+                # LOO trajectory.
+                if self.ordered_leaf_estimation:
+                    self._refine_leaf_values(tree, leaf, F, y, w)
                 F += self._loo_update(tree, leaf, g, h)
             else:
                 # Additional Newton steps refine the leaf values using the updated
                 # residuals after each step. For constant-hessian losses (RMSE)
                 # this converges in a few steps; for Logloss it reaches a better
                 # per-leaf approximation than the single first-order step.
-                for _ in range(self.leaf_estimation_iterations - 1):
-                    F_tmp = F + tree.values[leaf]
-                    g2, h2 = self.loss_.grad_hess(y, F_tmp)
-                    if w is not None:
-                        g2, h2 = g2 * w, h2 * w
-                    n_lv = tree.values.shape[0]
-                    if self.hs_lambda > 0.0:
-                        tree.values += _leaf_values_hs(leaf, g2, h2, n_lv,
-                                                       self.l2_leaf_reg, self.lr_,
-                                                       self.hs_lambda)
-                    else:
-                        tree.values += _leaf_values(leaf, g2, h2, n_lv,
-                                                    self.l2_leaf_reg, self.lr_)
+                self._refine_leaf_values(tree, leaf, F, y, w)
                 F += tree.values[leaf]
             if self.verbose:
                 self.train_history_.append(self.loss_.eval(y, F, w))

--- a/chimeraboost/booster.py
+++ b/chimeraboost/booster.py
@@ -112,7 +112,8 @@ class _BaseBooster:
                  thread_count=None, random_state=None, verbose=False,
                  ordered_boosting=True, cat_combinations=False,
                  leaf_estimation_iterations=1, hs_lambda=0.0,
-                 linear_leaves=False, linear_lambda=1.0):
+                 linear_leaves=False, linear_lambda=1.0,
+                 onehot_low_card=False, onehot_max_card=8):
         self.n_estimators = int(n_estimators)
         self.learning_rate = learning_rate
         self.depth = int(depth)
@@ -133,6 +134,8 @@ class _BaseBooster:
         self.hs_lambda = float(hs_lambda)
         self.linear_leaves = bool(linear_leaves)
         self.linear_lambda = float(linear_lambda)
+        self.onehot_low_card = bool(onehot_low_card)
+        self.onehot_max_card = int(onehot_max_card)
 
     def _alloc_hist_buffers(self, n_features, n_bins):
         """Allocate the reusable histogram buffer once per fit.
@@ -185,7 +188,9 @@ class _BaseBooster:
         """Build a FeaturePreprocessor configured from this booster's params."""
         return FeaturePreprocessor(self.max_bins, self.cat_smoothing,
                                    self.random_state, self.cat_n_permutations,
-                                   self.cat_combinations)
+                                   self.cat_combinations,
+                                   onehot_low_card=self.onehot_low_card,
+                                   onehot_max_card=self.onehot_max_card)
 
     @staticmethod
     def _normalize_weights(sample_weight, n_samples):

--- a/chimeraboost/booster.py
+++ b/chimeraboost/booster.py
@@ -113,7 +113,9 @@ class _BaseBooster:
                  ordered_boosting=True, cat_combinations=False,
                  leaf_estimation_iterations=1, hs_lambda=0.0,
                  linear_leaves=False, linear_lambda=1.0,
-                 onehot_low_card=False, onehot_max_card=8):
+                 onehot_low_card=False, onehot_max_card=8,
+                 cat_combinations_selective=False,
+                 cat_combinations_max_pairs=20):
         self.n_estimators = int(n_estimators)
         self.learning_rate = learning_rate
         self.depth = int(depth)
@@ -136,6 +138,8 @@ class _BaseBooster:
         self.linear_lambda = float(linear_lambda)
         self.onehot_low_card = bool(onehot_low_card)
         self.onehot_max_card = int(onehot_max_card)
+        self.cat_combinations_selective = bool(cat_combinations_selective)
+        self.cat_combinations_max_pairs = int(cat_combinations_max_pairs)
 
     def _alloc_hist_buffers(self, n_features, n_bins):
         """Allocate the reusable histogram buffer once per fit.
@@ -190,7 +194,9 @@ class _BaseBooster:
                                    self.random_state, self.cat_n_permutations,
                                    self.cat_combinations,
                                    onehot_low_card=self.onehot_low_card,
-                                   onehot_max_card=self.onehot_max_card)
+                                   onehot_max_card=self.onehot_max_card,
+                                   cat_combinations_selective=self.cat_combinations_selective,
+                                   cat_combinations_max_pairs=self.cat_combinations_max_pairs)
 
     @staticmethod
     def _normalize_weights(sample_weight, n_samples):

--- a/chimeraboost/booster.py
+++ b/chimeraboost/booster.py
@@ -115,7 +115,8 @@ class _BaseBooster:
                  linear_leaves=False, linear_lambda=1.0,
                  onehot_low_card=False, onehot_max_card=8,
                  cat_combinations_selective=False,
-                 cat_combinations_max_pairs=20):
+                 cat_combinations_max_pairs=20,
+                 forest_leaf_refit=False, forest_refit_iterations=3):
         self.n_estimators = int(n_estimators)
         self.learning_rate = learning_rate
         self.depth = int(depth)
@@ -140,6 +141,8 @@ class _BaseBooster:
         self.onehot_max_card = int(onehot_max_card)
         self.cat_combinations_selective = bool(cat_combinations_selective)
         self.cat_combinations_max_pairs = int(cat_combinations_max_pairs)
+        self.forest_leaf_refit = bool(forest_leaf_refit)
+        self.forest_refit_iterations = int(forest_refit_iterations)
 
     def _alloc_hist_buffers(self, n_features, n_bins):
         """Allocate the reusable histogram buffer once per fit.
@@ -438,9 +441,74 @@ class GradientBoosting(_BaseBooster):
                 if _run_callbacks(callbacks, m, tl, vl, self):
                     break
 
+        # G1: optional forest-level joint leaf refit. Couples the redundant
+        # oblivious splits by re-solving ALL leaf values together (incompatible
+        # with linear leaves, which own the leaf value, and with the median/
+        # quantile leaf override).
+        if (self.forest_leaf_refit and self.trees_ and not ll_active
+                and not adjusts_leaves):
+            self._forest_leaf_refit(Xb, y, w)
+
         self.fit_time_ = time.time() - t0
         self.best_iteration_ = len(self.trees_)
         return self
+
+    def _forest_leaf_refit(self, Xb, y, w):
+        """Jointly re-estimate every constant leaf value across the whole forest.
+
+        Reference implementation (slow but obviously correct): the model
+        prediction is ``init + Z @ wvec`` where ``Z`` is the (n_samples x
+        total_leaves) one-hot leaf-membership matrix over all trees and ``wvec``
+        stacks every tree's leaf values. Standard per-tree boosting fits each
+        tree's leaves in isolation; here we run a few global Newton (IRLS) steps
+        that solve for ALL leaves together, so redundant splits across trees stop
+        double-counting -- the coupling CatBoost's leaf machinery gets.
+
+        Matrix-free: ``Z`` is never materialized; ``Z @ v`` gathers per-tree leaf
+        slices and ``Z.T @ u`` scatter-adds, and the SPD normal-equation system
+        ``(Z.T H Z + lambda I) d = -(Z.T g) - lambda w`` is solved with CG. Only
+        constant-leaf trees (depth > 0) participate. Loss-general (RMSE / Logloss)
+        via the booster's own grad/hess; the regression case converges in one
+        step (constant hessian)."""
+        from scipy.sparse.linalg import cg, LinearOperator
+
+        trees = [t for t in self.trees_ if t.depth > 0 and t.lin_coef is None]
+        if not trees:
+            return
+        n = Xb.shape[1]
+        leaf_idx = [t.apply(Xb) for t in trees]            # per-tree (n,) indices
+        sizes = [t.values.shape[0] for t in trees]
+        offs = np.concatenate([[0], np.cumsum(sizes)])
+        L = int(offs[-1])
+
+        def Zmul(v):                                        # Z @ v -> (n,)
+            out = np.zeros(n)
+            for k, li in enumerate(leaf_idx):
+                out += v[offs[k]:offs[k + 1]][li]
+            return out
+
+        def ZTmul(u):                                       # Z.T @ u -> (L,)
+            out = np.zeros(L)
+            for k, li in enumerate(leaf_idx):
+                np.add.at(out[offs[k]:offs[k + 1]], li, u)
+            return out
+
+        lam = self.l2_leaf_reg if self.l2_leaf_reg > 0 else 1e-6
+        wvec = np.concatenate([t.values for t in trees]).astype(np.float64)
+        F = self.init_ + Zmul(wvec)
+        for _ in range(max(1, self.forest_refit_iterations)):
+            g, h = self.loss_.grad_hess(y, F)
+            if w is not None:
+                g, h = g * w, h * w
+            rhs = -ZTmul(g) - lam * wvec
+            A = LinearOperator((L, L),
+                               matvec=lambda v: ZTmul(h * Zmul(v)) + lam * v)
+            d, _ = cg(A, rhs, maxiter=300, atol=1e-10)
+            wvec = wvec + d
+            F = self.init_ + Zmul(wvec)
+        for k, t in enumerate(trees):
+            t.values = np.ascontiguousarray(wvec[offs[k]:offs[k + 1]])
+        self._forest_ = None    # invalidate the packed-forest predict cache
 
     def _correct_leaves(self, tree, leaf, residuals, sample_weight=None):
         """Override Newton leaf values with the loss-appropriate residual

--- a/chimeraboost/booster.py
+++ b/chimeraboost/booster.py
@@ -15,6 +15,21 @@ from .tree import (build_oblivious_tree, _loo_leaf_step, _leaf_values,
                    _predict_forest_linear, pack_forest_linear, _shap_forest_linear)
 
 
+def _run_callbacks(callbacks, iteration, train_loss, val_loss, model):
+    """Invoke each fit callback for one boosting round. A callback is
+    ``cb(iteration, train_loss, val_loss, model)``; returning True requests an
+    early stop. Returns True if any callback asked to stop. ``callbacks`` may be
+    a single callable or an iterable of them; None is a no-op."""
+    if not callbacks:
+        return False
+    cbs = callbacks if isinstance(callbacks, (list, tuple)) else (callbacks,)
+    stop = False
+    for cb in cbs:
+        if cb(iteration, train_loss, val_loss, model) is True:
+            stop = True
+    return stop
+
+
 def _factorials(n):
     """Factorials 0!..n! as a float array (Shapley coalition weights)."""
     f = np.empty(n + 1)
@@ -274,7 +289,8 @@ class GradientBoosting(_BaseBooster):
         self.loss_name = loss
         self.loss_kwargs = loss_kwargs or {}
 
-    def fit(self, X, y, cat_features=None, eval_set=None, sample_weight=None):
+    def fit(self, X, y, cat_features=None, eval_set=None, sample_weight=None,
+            callbacks=None):
         """Fit the additive model. Optionally pass `cat_features` (column indices
         to target-encode) and `eval_set=(X_val, y_val)` for early stopping.
         `sample_weight` is a 1-D array of per-sample weights; None means uniform.
@@ -404,6 +420,13 @@ class GradientBoosting(_BaseBooster):
                     msg += f"  val {self.valid_history_[-1]:.5f}"
                 print(msg)
 
+            if callbacks:
+                tl = self.train_history_[-1] if self.train_history_ \
+                    else self.loss_.eval(y, F, w)
+                vl = self.valid_history_[-1] if self.valid_history_ else None
+                if _run_callbacks(callbacks, m, tl, vl, self):
+                    break
+
         self.fit_time_ = time.time() - t0
         self.best_iteration_ = len(self.trees_)
         return self
@@ -499,7 +522,8 @@ class GradientBoosting(_BaseBooster):
 class MulticlassBoosting(_BaseBooster):
     """Softmax multiclass booster: fits K trees per round (one per class)."""
 
-    def fit(self, X, y, cat_features=None, eval_set=None, sample_weight=None):
+    def fit(self, X, y, cat_features=None, eval_set=None, sample_weight=None,
+            callbacks=None):
         """Fit K trees per boosting round (one per class) under softmax loss.
         Same `cat_features` / `eval_set` / `sample_weight` semantics as the
         scalar booster."""
@@ -596,6 +620,13 @@ class MulticlassBoosting(_BaseBooster):
                 if Fv is not None:
                     msg += f"  val {self.valid_history_[-1]:.5f}"
                 print(msg)
+
+            if callbacks:
+                tl = self.train_history_[-1] if self.train_history_ \
+                    else self.loss_.eval(Y, F, w)
+                vl = self.valid_history_[-1] if self.valid_history_ else None
+                if _run_callbacks(callbacks, m, tl, vl, self):
+                    break
 
         self.fit_time_ = time.time() - t0
         self.best_iteration_ = len(self.trees_)

--- a/chimeraboost/booster.py
+++ b/chimeraboost/booster.py
@@ -11,8 +11,9 @@ import numpy as np
 from .losses import LOSSES, MultiSoftmax
 from .preprocessing import FeaturePreprocessor
 from .tree import (build_oblivious_tree, _loo_leaf_step, _leaf_values,
-                   _leaf_values_hs, _linear_predict, _predict_forest, pack_forest,
-                   _predict_forest_linear, pack_forest_linear, _shap_forest_linear)
+                   _leaf_values_hs, _leaf_values_adaptive, _linear_predict,
+                   _predict_forest, pack_forest, _predict_forest_linear,
+                   pack_forest_linear, _shap_forest_linear)
 
 
 def _run_callbacks(callbacks, iteration, train_loss, val_loss, model):
@@ -117,7 +118,7 @@ class _BaseBooster:
                  cat_combinations_selective=False,
                  cat_combinations_max_pairs=20,
                  forest_leaf_refit=False, forest_refit_iterations=3,
-                 ordered_leaf_estimation=False):
+                 ordered_leaf_estimation=False, adaptive_leaf_shrinkage=0.0):
         self.n_estimators = int(n_estimators)
         self.learning_rate = learning_rate
         self.depth = int(depth)
@@ -145,6 +146,7 @@ class _BaseBooster:
         self.forest_leaf_refit = bool(forest_leaf_refit)
         self.forest_refit_iterations = int(forest_refit_iterations)
         self.ordered_leaf_estimation = bool(ordered_leaf_estimation)
+        self.adaptive_leaf_shrinkage = float(adaptive_leaf_shrinkage)
 
     def _alloc_hist_buffers(self, n_features, n_bins):
         """Allocate the reusable histogram buffer once per fit.
@@ -244,6 +246,10 @@ class _BaseBooster:
                 tree.values += _leaf_values_hs(leaf, g2, h2, n_lv,
                                                self.l2_leaf_reg, self.lr_,
                                                self.hs_lambda)
+            elif self.adaptive_leaf_shrinkage > 0.0:
+                tree.values += _leaf_values_adaptive(leaf, g2, h2, n_lv,
+                                                     self.l2_leaf_reg, self.lr_,
+                                                     self.adaptive_leaf_shrinkage)
             else:
                 tree.values += _leaf_values(leaf, g2, h2, n_lv,
                                             self.l2_leaf_reg, self.lr_)
@@ -400,7 +406,8 @@ class GradientBoosting(_BaseBooster):
                                               linear_leaves=ll_active,
                                               centers_std=self._centers_std_,
                                               is_numeric=self.prep_.is_numeric_binned_,
-                                              linear_lambda=self.linear_lambda)
+                                              linear_lambda=self.linear_lambda,
+                                              adaptive_shrinkage=self.adaptive_leaf_shrinkage)
             # A depth-0 tree found no legal split; the next round on the same
             # gradients would too, so stop rather than bank empty trees.
             if tree.depth == 0:
@@ -685,7 +692,8 @@ class MulticlassBoosting(_BaseBooster):
                                                   feature_mask=fmask,
                                                   min_child_weight=self.min_child_weight,
                                                   hist_buffers=hist_buffers,
-                                                  hs_lambda=self.hs_lambda)
+                                                  hs_lambda=self.hs_lambda,
+                                                  adaptive_shrinkage=self.adaptive_leaf_shrinkage)
                 round_trees.append(tree)
                 self._accumulate_importance(tree)
                 if self.ordered_boosting and tree.depth > 0:

--- a/chimeraboost/preprocessing.py
+++ b/chimeraboost/preprocessing.py
@@ -36,15 +36,28 @@ class FeaturePreprocessor:
         before target encoding. Mirrors CatBoost's feature combination step;
         gives the tree access to interaction effects that individual categoricals
         can't capture. Only active when ≥2 categorical columns are present.
+    onehot_low_card : bool
+        When True, every categorical column with at most ``onehot_max_card``
+        distinct levels also gets a one-hot indicator block (one 0/1 column per
+        level), stacked alongside the ordered-TS encoding. The indicators let the
+        tree make EXACT subset splits on individual rare categories -- which a
+        single monotone TS column, where rare levels are shrunk toward the prior,
+        cannot. CatBoost-proven; cheap for low cardinality. High-cardinality
+        columns keep TS only (one-hot would explode the column count).
+    onehot_max_card : int
+        Cardinality ceiling (inclusive) for one-hot encoding a column.
     """
 
     def __init__(self, max_bins=128, cat_smoothing=1.0, random_state=None,
-                 cat_n_permutations=4, cat_combinations=False):
+                 cat_n_permutations=4, cat_combinations=False,
+                 onehot_low_card=False, onehot_max_card=8):
         self.max_bins = int(max_bins)
         self.cat_smoothing = float(cat_smoothing)
         self.random_state = random_state
         self.cat_n_permutations = int(cat_n_permutations)
         self.cat_combinations = bool(cat_combinations)
+        self.onehot_low_card = bool(onehot_low_card)
+        self.onehot_max_card = int(onehot_max_card)
 
     # ---- helpers -------------------------------------------------------------
     @staticmethod
@@ -95,6 +108,34 @@ class FeaturePreprocessor:
                                np.column_stack(combo_cols).astype(np.int64)])
         return num, codes
 
+    def _compute_onehot_specs(self):
+        """Pick the base categorical columns to one-hot: those with at least 2
+        and at most ``onehot_max_card`` distinct levels. Stores
+        ``onehot_specs_`` as a list of (col-index-into-cat_features_, n_levels).
+        A no-op (empty list) unless ``onehot_low_card`` is set."""
+        self.onehot_specs_ = []
+        if not self.onehot_low_card:
+            return
+        for j in range(len(self.cat_features_)):
+            n_levels = len(self.cat_maps_[j])
+            if 2 <= n_levels <= self.onehot_max_card:
+                self.onehot_specs_.append((j, n_levels))
+
+    def _onehot_block(self, base_codes):
+        """Build the (n, sum n_levels) one-hot 0/1 matrix from the base-cat code
+        matrix. Column for level ``l`` of cat ``j`` is ``base_codes[:, j] == l``;
+        an unseen category (code -1 from transform) matches no level, so its row
+        is all-zeros -- the right behavior (the TS column still carries the prior
+        fallback for unseen values)."""
+        if not self.onehot_specs_:
+            return np.empty((base_codes.shape[0], 0))
+        cols = []
+        for j, n_levels in self.onehot_specs_:
+            cj = base_codes[:, j]
+            for l in range(n_levels):
+                cols.append((cj == l).astype(np.float64))
+        return np.column_stack(cols)
+
     def _codes_for_transform(self, X):
         """Map categorical columns to the codes learned at fit time; unseen
         categories get -1 (the encoder then falls back to the prior).
@@ -124,6 +165,12 @@ class FeaturePreprocessor:
         """encode_targets: list of 1D arrays used for ordered TS (len T)."""
         num, codes = self._split_columns_fit(X, cat_features)
 
+        # One-hot indicator block for low-cardinality cats (built from the base
+        # cat codes, before any combo columns). Stacked between num and the TS
+        # blocks; non-numeric (binary, no ordinal meaning for linear leaves).
+        self._compute_onehot_specs()
+        onehot = self._onehot_block(codes[:, :len(self.cat_features_)])
+
         encoded_blocks = []
         self.encoders_ = []
         if codes.shape[1]:
@@ -136,11 +183,12 @@ class FeaturePreprocessor:
                 encoded_blocks.append(enc.fit_transform(codes, target))
                 self.encoders_.append(enc)
 
-        feat = self._stack(num, encoded_blocks)
+        feat = self._stack(num, [onehot] + encoded_blocks)
         self._build_feature_map(len(encode_targets))
-        # The numeric block is stacked first, then the (cat/combo) encoded blocks.
-        # Only numeric columns carry an ordinal meaning usable by linear-leaf
-        # models; mark them so the booster can pick linear-term features.
+        # Block order is [numeric | one-hot | per-target TS]. Only true numeric
+        # columns carry an ordinal meaning usable by linear-leaf models; mark them
+        # so the booster can pick linear-term features. One-hot indicators are 0/1
+        # (the tree still splits on them exactly) and the TS blocks are excluded.
         self.is_numeric_binned_ = np.zeros(feat.shape[1], dtype=bool)
         self.is_numeric_binned_[:num.shape[1]] = True
 
@@ -153,15 +201,17 @@ class FeaturePreprocessor:
         """Apply the fitted binning + categorical encoding to new data."""
         num = (np.asarray(X[:, self.num_features_], dtype=np.float64)
                if self.num_features_ else np.empty((X.shape[0], 0)))
+        onehot = np.empty((X.shape[0], 0))
         encoded_blocks = []
         if self.cat_features_:
             codes = self._codes_for_transform(X)
+            onehot = self._onehot_block(codes)   # from base codes, pre-combo
             if self.combo_pairs_:
                 combo_codes = self._combo_codes_for_transform(X)
                 codes = np.hstack([codes, combo_codes])
             for enc in self.encoders_:
                 encoded_blocks.append(enc.transform(codes))
-        feat = self._stack(num, encoded_blocks)
+        feat = self._stack(num, [onehot] + encoded_blocks)
         return self.binner_.transform(feat)
 
     # ---- internals -----------------------------------------------------------
@@ -174,11 +224,15 @@ class FeaturePreprocessor:
 
     def _build_feature_map(self, n_targets):
         """Map each combined-matrix column back to its original input column.
-        The numeric block comes first, then one (cat + combo) block per encode
-        target. Combo columns map to the lower-indexed feature of their pair so
-        their split gains fold into an existing importance bucket."""
+        Block order is [numeric | one-hot | per-target (cat + combo)]. Each
+        one-hot indicator maps to its source categorical column (repeated per
+        level), and combo columns map to the lower-indexed feature of their pair,
+        so their split gains fold into the right importance bucket."""
         combo_orig = [min(i, j) for i, j in self.combo_pairs_]
-        fmap = list(self.num_features_)
+        onehot_orig = [self.cat_features_[j]
+                       for j, n_levels in self.onehot_specs_
+                       for _ in range(n_levels)]
+        fmap = list(self.num_features_) + onehot_orig
         for _ in range(n_targets):
             fmap.extend(self.cat_features_)
             fmap.extend(combo_orig)

--- a/chimeraboost/preprocessing.py
+++ b/chimeraboost/preprocessing.py
@@ -60,7 +60,8 @@ class FeaturePreprocessor:
     def __init__(self, max_bins=128, cat_smoothing=1.0, random_state=None,
                  cat_n_permutations=4, cat_combinations=False,
                  onehot_low_card=False, onehot_max_card=8,
-                 cat_combinations_selective=False, cat_combinations_max_pairs=20):
+                 cat_combinations_selective=False, cat_combinations_max_pairs=20,
+                 cat_aware_binning=False, cat_max_bins=254):
         self.max_bins = int(max_bins)
         self.cat_smoothing = float(cat_smoothing)
         self.random_state = random_state
@@ -70,6 +71,8 @@ class FeaturePreprocessor:
         self.onehot_max_card = int(onehot_max_card)
         self.cat_combinations_selective = bool(cat_combinations_selective)
         self.cat_combinations_max_pairs = int(cat_combinations_max_pairs)
+        self.cat_aware_binning = bool(cat_aware_binning)
+        self.cat_max_bins = int(cat_max_bins)
 
     # ---- helpers -------------------------------------------------------------
     @staticmethod
@@ -274,7 +277,16 @@ class FeaturePreprocessor:
         self.is_numeric_binned_ = np.zeros(feat.shape[1], dtype=bool)
         self.is_numeric_binned_[:num.shape[1]] = True
 
-        self.binner_ = Binner(self.max_bins)
+        # C4: cat-aware binning gives the target-encoded categorical columns
+        # (everything that isn't a raw numeric) a larger bin budget, so the tree
+        # can make sharper splits on the categorical target statistic. Off by
+        # default -> uniform max_bins (scalar, byte-identical to before).
+        if self.cat_aware_binning and not self.is_numeric_binned_.all():
+            bins = np.where(self.is_numeric_binned_, self.max_bins,
+                            self.cat_max_bins).astype(np.int64)
+            self.binner_ = Binner(bins)
+        else:
+            self.binner_ = Binner(self.max_bins)
         X_binned = self.binner_.fit_transform(feat)
         self.n_bins_ = self.binner_.n_bins_
         return X_binned

--- a/chimeraboost/preprocessing.py
+++ b/chimeraboost/preprocessing.py
@@ -46,11 +46,21 @@ class FeaturePreprocessor:
         columns keep TS only (one-hot would explode the column count).
     onehot_max_card : int
         Cardinality ceiling (inclusive) for one-hot encoding a column.
+    cat_combinations_selective : bool
+        Selective variant of ``cat_combinations``: instead of all C(n_cat, 2)
+        pairs, keep only those whose target mutual information beats BOTH parent
+        columns (the combo adds interaction signal beyond its marginals), ranked
+        and capped at ``cat_combinations_max_pairs``. Unlike the plain flag it is
+        meant for MIXED data -- selecting a few high-signal interactions instead
+        of flooding the tree with combos that crowd out the numeric features.
+    cat_combinations_max_pairs : int
+        Maximum number of selected combo columns (top-k by target MI).
     """
 
     def __init__(self, max_bins=128, cat_smoothing=1.0, random_state=None,
                  cat_n_permutations=4, cat_combinations=False,
-                 onehot_low_card=False, onehot_max_card=8):
+                 onehot_low_card=False, onehot_max_card=8,
+                 cat_combinations_selective=False, cat_combinations_max_pairs=20):
         self.max_bins = int(max_bins)
         self.cat_smoothing = float(cat_smoothing)
         self.random_state = random_state
@@ -58,6 +68,8 @@ class FeaturePreprocessor:
         self.cat_combinations = bool(cat_combinations)
         self.onehot_low_card = bool(onehot_low_card)
         self.onehot_max_card = int(onehot_max_card)
+        self.cat_combinations_selective = bool(cat_combinations_selective)
+        self.cat_combinations_max_pairs = int(cat_combinations_max_pairs)
 
     # ---- helpers -------------------------------------------------------------
     @staticmethod
@@ -67,10 +79,53 @@ class FeaturePreprocessor:
         col_b = np.asarray(X[:, f_b], dtype=str)
         return np.char.add(np.char.add(col_a, "_x_"), col_b)
 
-    def _split_columns_fit(self, X, cat_features):
+    @staticmethod
+    def _assoc_labels(encode_targets):
+        """Reduce the ordered-TS encode targets to a single integer label vector
+        for measuring categorical->target association (combo selection only).
+
+        * multiclass (K one-hot targets) -> the class index (argmax)
+        * binary / already-discrete single target -> the values as labels
+        * regression (continuous single target) -> decile bins
+        Selection uses the full training target, like any mutual-info feature
+        screen; the ordered encoder still prevents value leakage at encode time.
+        """
+        if len(encode_targets) > 1:
+            return np.argmax(np.column_stack(encode_targets), axis=1)
+        t = np.asarray(encode_targets[0], dtype=np.float64)
+        uniq = np.unique(t)
+        if uniq.size <= 20:                       # already categorical/binary
+            return np.searchsorted(uniq, t)
+        # Continuous: decile-bin (robust, dependency-free).
+        edges = np.quantile(t, np.linspace(0, 1, 11)[1:-1])
+        return np.searchsorted(edges, t)
+
+    @staticmethod
+    def _mutual_info(codes, labels):
+        """Mutual information I(codes; labels) in nats, both integer-coded. A
+        dependency-free contingency-table estimate; used to rank candidate combo
+        columns by how much they explain the target."""
+        n = labels.shape[0]
+        if n == 0:
+            return 0.0
+        a = codes - codes.min() if codes.size else codes
+        b = labels - labels.min() if labels.size else labels
+        na, nb = int(a.max()) + 1, int(b.max()) + 1
+        joint = np.zeros((na, nb), dtype=np.float64)
+        np.add.at(joint, (a, b), 1.0)
+        joint /= n
+        pa = joint.sum(axis=1, keepdims=True)
+        pb = joint.sum(axis=0, keepdims=True)
+        denom = pa @ pb
+        nz = joint > 0
+        return float(np.sum(joint[nz] * np.log(joint[nz] / denom[nz])))
+
+    def _split_columns_fit(self, X, cat_features, assoc_labels=None):
         """Split input into a numeric matrix and an integer-code matrix for the
         categorical columns, learning the category->code maps on the way.
-        When cat_combinations is True, appends combo codes after the base codes."""
+        When cat_combinations is True, appends combo codes after the base codes.
+        ``assoc_labels`` (integer target labels) enables selective combos: only
+        the top pairs by target mutual information that beat both parents."""
         n_features = X.shape[1]
         cat_set = set(cat_features or [])
         self.cat_features_ = sorted(cat_set)
@@ -95,17 +150,42 @@ class FeaturePreprocessor:
         # the tree sees interaction effects single columns can't express.
         self.combo_pairs_ = []
         self.combo_maps_ = []
-        if self.cat_combinations and len(self.cat_features_) >= 2:
-            combo_cols = []
-            for a in range(len(self.cat_features_)):
-                for b in range(a + 1, len(self.cat_features_)):
+        n_cat = len(self.cat_features_)
+        selective = self.cat_combinations_selective and assoc_labels is not None
+        enable_combos = (self.cat_combinations or selective) and n_cat >= 2
+        if enable_combos:
+            # Factorize every candidate pair once.
+            cand = []   # (f_a, f_b, codes, cats)
+            for a in range(n_cat):
+                for b in range(a + 1, n_cat):
                     f_a, f_b = self.cat_features_[a], self.cat_features_[b]
                     c, cats = factorize(self._combo_values(X, f_a, f_b))
-                    self.combo_pairs_.append((f_a, f_b))
-                    self.combo_maps_.append({v: i for i, v in enumerate(cats)})
-                    combo_cols.append(c)
-            codes = np.hstack([codes,
-                               np.column_stack(combo_cols).astype(np.int64)])
+                    cand.append((f_a, f_b, a, b, c, cats))
+            if selective:
+                # Keep only combos whose target MI beats BOTH parents (they add
+                # interaction signal beyond their marginals), ranked by MI and
+                # capped at cat_combinations_max_pairs. Works on MIXED data --
+                # the numeric columns are untouched, so combos no longer crowd
+                # them out indiscriminately (the C1/auto-combo lesson).
+                parent_mi = [self._mutual_info(codes[:, j], assoc_labels)
+                             for j in range(n_cat)]
+                scored = []
+                for (f_a, f_b, a, b, c, cats) in cand:
+                    mi = self._mutual_info(c, assoc_labels)
+                    if mi > max(parent_mi[a], parent_mi[b]):
+                        scored.append((mi, f_a, f_b, c, cats))
+                scored.sort(key=lambda t: t[0], reverse=True)
+                cand = [(f_a, f_b, None, None, c, cats)
+                        for (_mi, f_a, f_b, c, cats)
+                        in scored[:self.cat_combinations_max_pairs]]
+            combo_cols = []
+            for (f_a, f_b, _a, _b, c, cats) in cand:
+                self.combo_pairs_.append((f_a, f_b))
+                self.combo_maps_.append({v: i for i, v in enumerate(cats)})
+                combo_cols.append(c)
+            if combo_cols:
+                codes = np.hstack(
+                    [codes, np.column_stack(combo_cols).astype(np.int64)])
         return num, codes
 
     def _compute_onehot_specs(self):
@@ -163,7 +243,9 @@ class FeaturePreprocessor:
     # ---- fit / transform -----------------------------------------------------
     def fit_transform(self, X, encode_targets, cat_features):
         """encode_targets: list of 1D arrays used for ordered TS (len T)."""
-        num, codes = self._split_columns_fit(X, cat_features)
+        assoc_labels = (self._assoc_labels(encode_targets)
+                        if self.cat_combinations_selective else None)
+        num, codes = self._split_columns_fit(X, cat_features, assoc_labels)
 
         # One-hot indicator block for low-cardinality cats (built from the base
         # cat codes, before any combo columns). Stacked between num and the TS

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -77,6 +77,7 @@ def _validate_hyperparams(estimator):
     _pos_int("cat_n_permutations")
     _pos_int("leaf_estimation_iterations")
     _pos_int("onehot_max_card", lo=2)
+    _pos_int("cat_combinations_max_pairs")
     # depth: a depth-d tree allocates 2**d leaves in the histogram buffer, so an
     # unbounded depth OOMs. 16 matches CatBoost's documented maximum. None is the
     # regressor's loss-adaptive default, resolved at fit.
@@ -752,6 +753,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                  cat_combinations=None, leaf_estimation_iterations=1,
                  hs_lambda=0.0, linear_leaves=False, linear_lambda=1.0,
                  onehot_low_card=False, onehot_max_card=8,
+                 cat_combinations_selective=False, cat_combinations_max_pairs=20,
                  early_stopping=True, validation_fraction=0.2,
                  n_ensembles=None, ensemble_n_jobs=1, cat_features=None):
         self.n_estimators = n_estimators
@@ -779,6 +781,8 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         self.linear_lambda = linear_lambda
         self.onehot_low_card = onehot_low_card
         self.onehot_max_card = onehot_max_card
+        self.cat_combinations_selective = cat_combinations_selective
+        self.cat_combinations_max_pairs = cat_combinations_max_pairs
         self.early_stopping = early_stopping
         self.validation_fraction = validation_fraction
         self.n_ensembles = n_ensembles
@@ -1067,6 +1071,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                  cat_combinations=None, leaf_estimation_iterations=3,
                  hs_lambda=0.0, linear_leaves=None, linear_lambda=1.0,
                  onehot_low_card=False, onehot_max_card=8,
+                 cat_combinations_selective=False, cat_combinations_max_pairs=20,
                  early_stopping=True, validation_fraction=0.2,
                  n_ensembles=None, ensemble_n_jobs=1, cat_features=None):
         self.n_estimators = n_estimators
@@ -1092,6 +1097,8 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         self.linear_lambda = linear_lambda
         self.onehot_low_card = onehot_low_card
         self.onehot_max_card = onehot_max_card
+        self.cat_combinations_selective = cat_combinations_selective
+        self.cat_combinations_max_pairs = cat_combinations_max_pairs
         self.early_stopping = early_stopping
         self.validation_fraction = validation_fraction
         self.n_ensembles = n_ensembles

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -76,6 +76,7 @@ def _validate_hyperparams(estimator):
     _pos_int("n_estimators")
     _pos_int("cat_n_permutations")
     _pos_int("leaf_estimation_iterations")
+    _pos_int("onehot_max_card", lo=2)
     # depth: a depth-d tree allocates 2**d leaves in the histogram buffer, so an
     # unbounded depth OOMs. 16 matches CatBoost's documented maximum. None is the
     # regressor's loss-adaptive default, resolved at fit.
@@ -750,6 +751,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                  random_state=None, verbose=False, ordered_boosting=False,
                  cat_combinations=None, leaf_estimation_iterations=1,
                  hs_lambda=0.0, linear_leaves=False, linear_lambda=1.0,
+                 onehot_low_card=False, onehot_max_card=8,
                  early_stopping=True, validation_fraction=0.2,
                  n_ensembles=None, ensemble_n_jobs=1, cat_features=None):
         self.n_estimators = n_estimators
@@ -775,6 +777,8 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         self.hs_lambda = hs_lambda
         self.linear_leaves = linear_leaves
         self.linear_lambda = linear_lambda
+        self.onehot_low_card = onehot_low_card
+        self.onehot_max_card = onehot_max_card
         self.early_stopping = early_stopping
         self.validation_fraction = validation_fraction
         self.n_ensembles = n_ensembles
@@ -1062,6 +1066,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                  verbose=False, ordered_boosting=False,
                  cat_combinations=None, leaf_estimation_iterations=3,
                  hs_lambda=0.0, linear_leaves=None, linear_lambda=1.0,
+                 onehot_low_card=False, onehot_max_card=8,
                  early_stopping=True, validation_fraction=0.2,
                  n_ensembles=None, ensemble_n_jobs=1, cat_features=None):
         self.n_estimators = n_estimators
@@ -1085,6 +1090,8 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         self.hs_lambda = hs_lambda
         self.linear_leaves = linear_leaves
         self.linear_lambda = linear_lambda
+        self.onehot_low_card = onehot_low_card
+        self.onehot_max_card = onehot_max_card
         self.early_stopping = early_stopping
         self.validation_fraction = validation_fraction
         self.n_ensembles = n_ensembles

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -756,6 +756,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                  onehot_low_card=False, onehot_max_card=8,
                  cat_combinations_selective=False, cat_combinations_max_pairs=20,
                  forest_leaf_refit=False, forest_refit_iterations=3,
+                 ordered_leaf_estimation=False,
                  early_stopping=True, validation_fraction=0.2,
                  n_ensembles=None, ensemble_n_jobs=1, cat_features=None):
         self.n_estimators = n_estimators
@@ -787,6 +788,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         self.cat_combinations_max_pairs = cat_combinations_max_pairs
         self.forest_leaf_refit = forest_leaf_refit
         self.forest_refit_iterations = forest_refit_iterations
+        self.ordered_leaf_estimation = ordered_leaf_estimation
         self.early_stopping = early_stopping
         self.validation_fraction = validation_fraction
         self.n_ensembles = n_ensembles
@@ -1077,6 +1079,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                  onehot_low_card=False, onehot_max_card=8,
                  cat_combinations_selective=False, cat_combinations_max_pairs=20,
                  forest_leaf_refit=False, forest_refit_iterations=3,
+                 ordered_leaf_estimation=False,
                  early_stopping=True, validation_fraction=0.2,
                  n_ensembles=None, ensemble_n_jobs=1, cat_features=None):
         self.n_estimators = n_estimators
@@ -1106,6 +1109,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         self.cat_combinations_max_pairs = cat_combinations_max_pairs
         self.forest_leaf_refit = forest_leaf_refit
         self.forest_refit_iterations = forest_refit_iterations
+        self.ordered_leaf_estimation = ordered_leaf_estimation
         self.early_stopping = early_stopping
         self.validation_fraction = validation_fraction
         self.n_ensembles = n_ensembles

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -105,6 +105,7 @@ def _validate_hyperparams(estimator):
     # (count + a); a=0 makes the first occurrence of every category divide 0/0.
     _in_range("cat_smoothing", 0.0, np.inf, lo_incl=False)
     _in_range("hs_lambda", 0.0, np.inf)
+    _in_range("adaptive_leaf_shrinkage", 0.0, np.inf)
     _in_range("linear_lambda", 0.0, np.inf)
     _in_range("min_child_weight", 0.0, np.inf, allow_none=True)
     _in_range("validation_fraction", 0.0, 1.0, lo_incl=False, hi_incl=False)
@@ -767,6 +768,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                  cat_combinations_selective=False, cat_combinations_max_pairs=20,
                  forest_leaf_refit=False, forest_refit_iterations=3,
                  ordered_leaf_estimation=False, adaptive_leaf_estimation=False,
+                 adaptive_leaf_shrinkage=0.0,
                  early_stopping=True, validation_fraction=0.2,
                  n_ensembles=None, ensemble_n_jobs=1, cat_features=None):
         self.n_estimators = n_estimators
@@ -800,6 +802,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         self.forest_refit_iterations = forest_refit_iterations
         self.ordered_leaf_estimation = ordered_leaf_estimation
         self.adaptive_leaf_estimation = adaptive_leaf_estimation
+        self.adaptive_leaf_shrinkage = adaptive_leaf_shrinkage
         self.early_stopping = early_stopping
         self.validation_fraction = validation_fraction
         self.n_ensembles = n_ensembles
@@ -1096,6 +1099,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                  cat_combinations_selective=False, cat_combinations_max_pairs=20,
                  forest_leaf_refit=False, forest_refit_iterations=3,
                  ordered_leaf_estimation=False, adaptive_leaf_estimation=False,
+                 adaptive_leaf_shrinkage=0.0,
                  early_stopping=True, validation_fraction=0.2,
                  n_ensembles=None, ensemble_n_jobs=1, cat_features=None):
         self.n_estimators = n_estimators
@@ -1127,6 +1131,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         self.forest_refit_iterations = forest_refit_iterations
         self.ordered_leaf_estimation = ordered_leaf_estimation
         self.adaptive_leaf_estimation = adaptive_leaf_estimation
+        self.adaptive_leaf_shrinkage = adaptive_leaf_shrinkage
         self.early_stopping = early_stopping
         self.validation_fraction = validation_fraction
         self.n_ensembles = n_ensembles

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -781,7 +781,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         self.ensemble_n_jobs = ensemble_n_jobs
 
     def fit(self, X, y, cat_features=None, eval_set=None, groups=None,
-            sample_weight=None):
+            sample_weight=None, callbacks=None):
         """Fit the model.
 
         Parameters
@@ -805,6 +805,11 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         sample_weight : array-like of shape (n_samples,) or None
             Per-sample weights.  Normalized to mean 1 internally.  Only applied
             to the training set; the validation eval metric is always unweighted.
+        callbacks : callable or list of callable, or None
+            Per-round fit hooks ``cb(iteration, train_loss, val_loss, model)``;
+            a callback returning True requests an early stop. Used for live
+            validation-curve capture and instrumentation. Not supported with
+            ``n_ensembles > 1`` (members fit in parallel worker processes).
         """
         cat_features = _resolve_cat_features(self, cat_features)
         cat_features = _resolve_cat_feature_names(cat_features, X)
@@ -814,12 +819,15 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         if eval_set is not None:
             _check_eval_set(eval_set, self.n_features_in_)
         if self.n_ensembles and self.n_ensembles > 1:
+            if callbacks is not None:
+                raise ValueError(
+                    "callbacks are not supported with n_ensembles > 1.")
             self.estimators_ = _fit_bagged(self, X, y, cat_features, eval_set,
                                            groups, sample_weight)
             return self
         self.estimators_ = None
         return self._fit_single(X, y, cat_features, eval_set, groups,
-                                sample_weight)
+                                sample_weight, callbacks)
 
     def __sklearn_is_fitted__(self):
         return (hasattr(self, "model_")
@@ -831,7 +839,8 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         tags.input_tags.sparse = False
         return tags
 
-    def _fit_single(self, X, y, cat_features, eval_set, groups, sample_weight):
+    def _fit_single(self, X, y, cat_features, eval_set, groups, sample_weight,
+                    callbacks=None):
         """Fit one (non-bagged) model on the data as given."""
         X = (np.asarray(X, dtype=object) if cat_features
              else np.asarray(X, dtype=np.float64))
@@ -888,7 +897,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         self.model_ = GradientBoosting(loss=self.loss, loss_kwargs=loss_kwargs,
                                        **kw)
         self.model_.fit(X, y, cat_features=cat_features, eval_set=eval_set,
-                        sample_weight=sample_weight)
+                        sample_weight=sample_weight, callbacks=callbacks)
         return self
 
     def predict(self, X):
@@ -910,6 +919,16 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         if self.estimators_ is not None:
             return int(round(np.mean([m.best_iteration_ for m in self.estimators_])))
         return self.model_.best_iteration_
+
+    @property
+    def validation_history_(self):
+        """Per-round validation loss recorded during ``fit`` (RMSE-space loss for
+        regression), as a list whose length is the number of rounds run. Empty
+        when no ``eval_set`` / early-stopping split was available; for a bagged
+        model (``n_ensembles > 1``) a list of the members' histories."""
+        if self.estimators_ is not None:
+            return [m.model_.valid_history_ for m in self.estimators_]
+        return self.model_.valid_history_
 
     @property
     def feature_importances_(self):
@@ -1072,7 +1091,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         self.ensemble_n_jobs = ensemble_n_jobs
 
     def fit(self, X, y, cat_features=None, eval_set=None, groups=None,
-            sample_weight=None):
+            sample_weight=None, callbacks=None):
         """Fit the model.
 
         Parameters
@@ -1095,6 +1114,11 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         sample_weight : array-like of shape (n_samples,) or None
             Per-sample weights.  Normalized to mean 1 internally.  Only applied
             to the training set; the validation eval metric is always unweighted.
+        callbacks : callable or list of callable, or None
+            Per-round fit hooks ``cb(iteration, train_loss, val_loss, model)``;
+            a callback returning True requests an early stop. Used for live
+            validation-curve capture and instrumentation. Not supported with
+            ``n_ensembles > 1`` (members fit in parallel worker processes).
         """
         cat_features = _resolve_cat_features(self, cat_features)
         cat_features = _resolve_cat_feature_names(cat_features, X)
@@ -1104,6 +1128,9 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         if eval_set is not None:
             _check_eval_set(eval_set, self.n_features_in_)
         if self.n_ensembles and self.n_ensembles > 1:
+            if callbacks is not None:
+                raise ValueError(
+                    "callbacks are not supported with n_ensembles > 1.")
             # Fix the global class set up front: a member's bootstrap may miss a
             # rare class, and predict_proba aligns each member's columns to this.
             yarr = np.asarray(y)
@@ -1118,7 +1145,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
             return self
         self.estimators_ = None
         return self._fit_single(X, y, cat_features, eval_set, groups,
-                                sample_weight)
+                                sample_weight, callbacks)
 
     def __sklearn_is_fitted__(self):
         return (hasattr(self, "model_")
@@ -1130,7 +1157,8 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         tags.input_tags.sparse = False
         return tags
 
-    def _fit_single(self, X, y, cat_features, eval_set, groups, sample_weight):
+    def _fit_single(self, X, y, cat_features, eval_set, groups, sample_weight,
+                    callbacks=None):
         """Fit one (non-bagged) classifier on the data as given."""
         X = (np.asarray(X, dtype=object) if cat_features
              else np.asarray(X, dtype=np.float64))
@@ -1192,7 +1220,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         if self._multiclass:
             self.model_ = MulticlassBoosting(**kw)
             self.model_.fit(X, y, cat_features=cat_features, eval_set=eval_set,
-                            sample_weight=sample_weight)
+                            sample_weight=sample_weight, callbacks=callbacks)
             self.classes_ = self.model_.classes_
             if eval_set is not None:
                 cal_Xv = eval_set[0]
@@ -1205,7 +1233,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                 eval_set = (cal_Xv, cal_y)
             self.model_ = GradientBoosting(loss="Logloss", **kw)
             self.model_.fit(X, y01, cat_features=cat_features, eval_set=eval_set,
-                            sample_weight=sample_weight)
+                            sample_weight=sample_weight, callbacks=callbacks)
 
         # Temperature scaling on the validation set: dividing raw scores by T > 0
         # is monotonic, so predict() is unchanged while predict_proba() becomes
@@ -1243,6 +1271,16 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         if self.estimators_ is not None:
             return int(round(np.mean([m.best_iteration_ for m in self.estimators_])))
         return self.model_.best_iteration_
+
+    @property
+    def validation_history_(self):
+        """Per-round validation loss recorded during ``fit`` (binary or softmax
+        log loss), as a list whose length is the number of rounds run. Empty when
+        no ``eval_set`` / early-stopping split was available; for a bagged model
+        (``n_ensembles > 1``) a list of the members' histories."""
+        if self.estimators_ is not None:
+            return [m.model_.valid_history_ for m in self.estimators_]
+        return self.model_.valid_history_
 
     @property
     def feature_importances_(self):

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -37,7 +37,17 @@ def _fit_temperature(raw, y, multiclass):
 
 # Parameters that exist only on the sklearn wrappers, not on the core boosters.
 _SKLEARN_ONLY = frozenset({"early_stopping", "validation_fraction",
-                           "n_ensembles", "ensemble_n_jobs", "cat_features"})
+                           "n_ensembles", "ensemble_n_jobs", "cat_features",
+                           "adaptive_leaf_estimation"})
+
+
+def _adaptive_leaf_estimation_iterations(n_train):
+    """Size-adaptive ``leaf_estimation_iterations`` (G3). More Newton refinement
+    of the leaf values is affordable -- and the per-leaf estimate more stable --
+    as data grows; on small data extra steps just chase noise. Doubles the field-
+    standard schedule: 1 step below ~500 rows, +1 per doubling, capped at 6
+    (~16k rows). Used only when ``adaptive_leaf_estimation`` is set."""
+    return int(np.clip(round(np.log2(max(n_train, 1) / 500.0)) + 1, 1, 6))
 
 
 def _validate_hyperparams(estimator):
@@ -756,7 +766,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                  onehot_low_card=False, onehot_max_card=8,
                  cat_combinations_selective=False, cat_combinations_max_pairs=20,
                  forest_leaf_refit=False, forest_refit_iterations=3,
-                 ordered_leaf_estimation=False,
+                 ordered_leaf_estimation=False, adaptive_leaf_estimation=False,
                  early_stopping=True, validation_fraction=0.2,
                  n_ensembles=None, ensemble_n_jobs=1, cat_features=None):
         self.n_estimators = n_estimators
@@ -789,6 +799,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         self.forest_leaf_refit = forest_leaf_refit
         self.forest_refit_iterations = forest_refit_iterations
         self.ordered_leaf_estimation = ordered_leaf_estimation
+        self.adaptive_leaf_estimation = adaptive_leaf_estimation
         self.early_stopping = early_stopping
         self.validation_fraction = validation_fraction
         self.n_ensembles = n_ensembles
@@ -904,6 +915,11 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         # always holds >=1 sample = hess >= 1); resolve an explicit None to 1.0.
         if kw.get("min_child_weight") is None:
             kw["min_child_weight"] = 1.0
+        # G3: size-adaptive leaf_estimation_iterations (resolved on the final
+        # training set, post early-stopping split), default off.
+        if self.adaptive_leaf_estimation:
+            kw["leaf_estimation_iterations"] = \
+                _adaptive_leaf_estimation_iterations(len(X))
         # Auto-resolve cat_combinations: on only for tractable all-categorical data.
         if kw.get("cat_combinations") is None:
             kw["cat_combinations"] = _auto_cat_combinations(
@@ -1079,7 +1095,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                  onehot_low_card=False, onehot_max_card=8,
                  cat_combinations_selective=False, cat_combinations_max_pairs=20,
                  forest_leaf_refit=False, forest_refit_iterations=3,
-                 ordered_leaf_estimation=False,
+                 ordered_leaf_estimation=False, adaptive_leaf_estimation=False,
                  early_stopping=True, validation_fraction=0.2,
                  n_ensembles=None, ensemble_n_jobs=1, cat_features=None):
         self.n_estimators = n_estimators
@@ -1110,6 +1126,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         self.forest_leaf_refit = forest_leaf_refit
         self.forest_refit_iterations = forest_refit_iterations
         self.ordered_leaf_estimation = ordered_leaf_estimation
+        self.adaptive_leaf_estimation = adaptive_leaf_estimation
         self.early_stopping = early_stopping
         self.validation_fraction = validation_fraction
         self.n_ensembles = n_ensembles
@@ -1224,6 +1241,10 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         # on the FINAL training set (post early-stopping split).
         if kw.get("min_child_weight") is None:
             kw["min_child_weight"] = _auto_min_child_weight(len(X))
+        # G3: size-adaptive leaf_estimation_iterations (default off).
+        if self.adaptive_leaf_estimation:
+            kw["leaf_estimation_iterations"] = \
+                _adaptive_leaf_estimation_iterations(len(X))
         # Auto-resolve cat_combinations: on only for tractable all-categorical data
         # (targets the all-categorical multiclass gap, e.g. car).
         if kw.get("cat_combinations") is None:

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -97,6 +97,7 @@ def _validate_hyperparams(estimator):
                               and not isinstance(v, bool) and 1 <= v <= 16):
         raise ValueError(f"depth must be an integer in [1, 16] or None; got {v!r}.")
     _in_range("max_bins", 2, 65534)
+    _in_range("cat_max_bins", 2, 65534)
     _in_range("learning_rate", 0.0, np.inf, lo_incl=False, allow_none=True)
     _in_range("l2_leaf_reg", 0.0, np.inf)
     _in_range("subsample", 0.0, 1.0, lo_incl=False)
@@ -766,6 +767,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                  hs_lambda=0.0, linear_leaves=False, linear_lambda=1.0,
                  onehot_low_card=False, onehot_max_card=8,
                  cat_combinations_selective=False, cat_combinations_max_pairs=20,
+                 cat_aware_binning=False, cat_max_bins=254,
                  forest_leaf_refit=False, forest_refit_iterations=3,
                  ordered_leaf_estimation=False, adaptive_leaf_estimation=False,
                  adaptive_leaf_shrinkage=0.0,
@@ -798,6 +800,8 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         self.onehot_max_card = onehot_max_card
         self.cat_combinations_selective = cat_combinations_selective
         self.cat_combinations_max_pairs = cat_combinations_max_pairs
+        self.cat_aware_binning = cat_aware_binning
+        self.cat_max_bins = cat_max_bins
         self.forest_leaf_refit = forest_leaf_refit
         self.forest_refit_iterations = forest_refit_iterations
         self.ordered_leaf_estimation = ordered_leaf_estimation
@@ -1097,6 +1101,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                  hs_lambda=0.0, linear_leaves=None, linear_lambda=1.0,
                  onehot_low_card=False, onehot_max_card=8,
                  cat_combinations_selective=False, cat_combinations_max_pairs=20,
+                 cat_aware_binning=False, cat_max_bins=254,
                  forest_leaf_refit=False, forest_refit_iterations=3,
                  ordered_leaf_estimation=False, adaptive_leaf_estimation=False,
                  adaptive_leaf_shrinkage=0.0,
@@ -1127,6 +1132,8 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         self.onehot_max_card = onehot_max_card
         self.cat_combinations_selective = cat_combinations_selective
         self.cat_combinations_max_pairs = cat_combinations_max_pairs
+        self.cat_aware_binning = cat_aware_binning
+        self.cat_max_bins = cat_max_bins
         self.forest_leaf_refit = forest_leaf_refit
         self.forest_refit_iterations = forest_refit_iterations
         self.ordered_leaf_estimation = ordered_leaf_estimation

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -611,6 +611,34 @@ def _auto_min_child_weight(n_train):
     return float(np.clip((2000.0 - n_train) / 1500.0, 0.0, 1.0))
 
 
+# Pairwise categorical combinations help when the target depends on categorical
+# INTERACTIONS, but on mixed data the synthetic combo columns crowd out the
+# numeric features that want to split (sign-tested: all-categorical car/kr-vs-kp
+# gain +60%+, mixed sets regress). So the auto-default enables them ONLY when the
+# data is entirely categorical -- the precise condition under which they help
+# without a downside. The two caps below are resource guards (a wide all-cat
+# dataset generates C(n_cat, 2) combo columns, each target-encoded over every
+# row), NOT accuracy knobs: above them the user can still opt in explicitly.
+_AUTO_CAT_COMBO_MAX_PAIRS = 1000        # ceiling on C(n_cat, 2) combo columns
+_AUTO_CAT_COMBO_MAX_CELLS = 5e7         # ceiling on pairs * n_samples (memory)
+
+
+def _auto_cat_combinations(cat_features, n_features, n_samples):
+    """Resolve ``cat_combinations=None``: True only for (tractable) all-categorical
+    data. ``cat_features`` is the resolved integer-index list (or None)."""
+    if cat_features is None or len(cat_features) == 0:
+        return False
+    n_cat = len(cat_features)
+    if n_cat < 2 or n_cat != n_features:
+        return False
+    n_pairs = n_cat * (n_cat - 1) // 2
+    if n_pairs > _AUTO_CAT_COMBO_MAX_PAIRS:
+        return False
+    if n_pairs * n_samples > _AUTO_CAT_COMBO_MAX_CELLS:
+        return False
+    return True
+
+
 class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
     """Gradient boosted oblivious trees for regression.
 
@@ -666,8 +694,11 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         Print per-round train and validation metrics.
     ordered_boosting : bool, default False
         Use the leave-one-out leaf training step instead of plain Newton updates.
-    cat_combinations : bool, default False
-        Add all pairwise categorical-by-categorical features.
+    cat_combinations : bool or None, default None
+        Add all pairwise categorical-by-categorical features. ``None`` enables
+        them automatically only when the data is entirely categorical (where the
+        interaction columns help without crowding out numeric splits); set
+        ``True``/``False`` to force it on/off.
     leaf_estimation_iterations : int, default 1
         Newton refinement steps per leaf.
     hs_lambda : float, default 0.0
@@ -717,7 +748,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                  early_stopping_rounds=None,
                  loss="RMSE", alpha=0.5, min_child_weight=1.0, thread_count=None,
                  random_state=None, verbose=False, ordered_boosting=False,
-                 cat_combinations=False, leaf_estimation_iterations=1,
+                 cat_combinations=None, leaf_estimation_iterations=1,
                  hs_lambda=0.0, linear_leaves=False, linear_lambda=1.0,
                  early_stopping=True, validation_fraction=0.2,
                  n_ensembles=None, ensemble_n_jobs=1, cat_features=None):
@@ -850,6 +881,10 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         # always holds >=1 sample = hess >= 1); resolve an explicit None to 1.0.
         if kw.get("min_child_weight") is None:
             kw["min_child_weight"] = 1.0
+        # Auto-resolve cat_combinations: on only for tractable all-categorical data.
+        if kw.get("cat_combinations") is None:
+            kw["cat_combinations"] = _auto_cat_combinations(
+                cat_features, self.n_features_in_, len(X))
         self.model_ = GradientBoosting(loss=self.loss, loss_kwargs=loss_kwargs,
                                        **kw)
         self.model_.fit(X, y, cat_features=cat_features, eval_set=eval_set,
@@ -949,8 +984,11 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         Print per-round train and validation metrics.
     ordered_boosting : bool, default False
         Use the leave-one-out leaf training step instead of plain Newton updates.
-    cat_combinations : bool, default False
-        Add all pairwise categorical-by-categorical features.
+    cat_combinations : bool or None, default None
+        Add all pairwise categorical-by-categorical features. ``None`` enables
+        them automatically only when the data is entirely categorical (where the
+        interaction columns help without crowding out numeric splits); set
+        ``True``/``False`` to force it on/off.
     leaf_estimation_iterations : int, default 3
         Newton refinement steps per leaf.
     hs_lambda : float, default 0.0
@@ -1003,7 +1041,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                  early_stopping_rounds=None,
                  min_child_weight=None, thread_count=None, random_state=None,
                  verbose=False, ordered_boosting=False,
-                 cat_combinations=False, leaf_estimation_iterations=3,
+                 cat_combinations=None, leaf_estimation_iterations=3,
                  hs_lambda=0.0, linear_leaves=None, linear_lambda=1.0,
                  early_stopping=True, validation_fraction=0.2,
                  n_ensembles=None, ensemble_n_jobs=1, cat_features=None):
@@ -1133,6 +1171,11 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         # on the FINAL training set (post early-stopping split).
         if kw.get("min_child_weight") is None:
             kw["min_child_weight"] = _auto_min_child_weight(len(X))
+        # Auto-resolve cat_combinations: on only for tractable all-categorical data
+        # (targets the all-categorical multiclass gap, e.g. car).
+        if kw.get("cat_combinations") is None:
+            kw["cat_combinations"] = _auto_cat_combinations(
+                cat_features, self.n_features_in_, len(X))
 
         self._multiclass = self.n_classes_ > 2
         # Resolve the linear_leaves auto-default: ON for binary (a clean broad

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -78,6 +78,7 @@ def _validate_hyperparams(estimator):
     _pos_int("leaf_estimation_iterations")
     _pos_int("onehot_max_card", lo=2)
     _pos_int("cat_combinations_max_pairs")
+    _pos_int("forest_refit_iterations")
     # depth: a depth-d tree allocates 2**d leaves in the histogram buffer, so an
     # unbounded depth OOMs. 16 matches CatBoost's documented maximum. None is the
     # regressor's loss-adaptive default, resolved at fit.
@@ -754,6 +755,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                  hs_lambda=0.0, linear_leaves=False, linear_lambda=1.0,
                  onehot_low_card=False, onehot_max_card=8,
                  cat_combinations_selective=False, cat_combinations_max_pairs=20,
+                 forest_leaf_refit=False, forest_refit_iterations=3,
                  early_stopping=True, validation_fraction=0.2,
                  n_ensembles=None, ensemble_n_jobs=1, cat_features=None):
         self.n_estimators = n_estimators
@@ -783,6 +785,8 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         self.onehot_max_card = onehot_max_card
         self.cat_combinations_selective = cat_combinations_selective
         self.cat_combinations_max_pairs = cat_combinations_max_pairs
+        self.forest_leaf_refit = forest_leaf_refit
+        self.forest_refit_iterations = forest_refit_iterations
         self.early_stopping = early_stopping
         self.validation_fraction = validation_fraction
         self.n_ensembles = n_ensembles
@@ -1072,6 +1076,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                  hs_lambda=0.0, linear_leaves=None, linear_lambda=1.0,
                  onehot_low_card=False, onehot_max_card=8,
                  cat_combinations_selective=False, cat_combinations_max_pairs=20,
+                 forest_leaf_refit=False, forest_refit_iterations=3,
                  early_stopping=True, validation_fraction=0.2,
                  n_ensembles=None, ensemble_n_jobs=1, cat_features=None):
         self.n_estimators = n_estimators
@@ -1099,6 +1104,8 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         self.onehot_max_card = onehot_max_card
         self.cat_combinations_selective = cat_combinations_selective
         self.cat_combinations_max_pairs = cat_combinations_max_pairs
+        self.forest_leaf_refit = forest_leaf_refit
+        self.forest_refit_iterations = forest_refit_iterations
         self.early_stopping = early_stopping
         self.validation_fraction = validation_fraction
         self.n_ensembles = n_ensembles
@@ -1230,6 +1237,13 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
             raise NotImplementedError(
                 "linear_leaves is not supported for multiclass classification "
                 "yet; use it on regression or binary classification.")
+        # forest_leaf_refit is a scalar-booster post-pass (regression / binary);
+        # the multiclass booster has no joint-refit path, so warn rather than
+        # silently ignore.
+        if self.forest_leaf_refit and self._multiclass:
+            warnings.warn(
+                "forest_leaf_refit is not supported for multiclass classification "
+                "yet and will be ignored.", UserWarning, stacklevel=2)
         cal_Xv = cal_y = None   # validation set used to calibrate temperature
         if self._multiclass:
             self.model_ = MulticlassBoosting(**kw)

--- a/chimeraboost/tree.py
+++ b/chimeraboost/tree.py
@@ -162,6 +162,25 @@ def _leaf_values(leaf, grad, hess, n_leaves, l2, lr):
 
 
 @njit(cache=True)
+def _leaf_values_adaptive(leaf, grad, hess, n_leaves, l2, lr, alpha):
+    """Mass-adaptive leaf values (G2): the Newton step is multiplied by a per-leaf
+    shrinkage factor H / (H + alpha), so a leaf's value is pulled toward zero in
+    proportion to how little hessian mass it carries -- low-mass leaves (whose
+    Newton estimate has the highest variance) shrink hardest, high-mass leaves are
+    nearly untouched. ``alpha == 0`` reproduces the plain Newton value exactly."""
+    G = np.zeros(n_leaves)
+    H = np.zeros(n_leaves)
+    for i in range(leaf.shape[0]):
+        G[leaf[i]] += grad[i]
+        H[leaf[i]] += hess[i]
+    values = np.zeros(n_leaves)
+    for l in range(n_leaves):
+        if H[l] > 0.0:
+            values[l] = -lr * G[l] / (H[l] + l2) * (H[l] / (H[l] + alpha))
+    return values
+
+
+@njit(cache=True)
 def _leaf_values_hs(leaf, grad, hess, n_leaves, l2, lr, hs_lambda):
     """Hierarchical-shrinkage leaf values for an oblivious tree.
 
@@ -633,7 +652,7 @@ def build_oblivious_tree(Xb, grad, hess, n_bins_per_feature,
                          max_depth, l2, lr, min_gain=1e-8, feature_mask=None,
                          min_child_weight=1.0, hist_buffers=None, hs_lambda=0.0,
                          linear_leaves=False, centers_std=None, is_numeric=None,
-                         linear_lambda=1.0):
+                         linear_lambda=1.0, adaptive_shrinkage=0.0):
     """Grow one oblivious tree level by level. Returns (tree, train_leaf), where
     train_leaf is the tree's leaf index for every training sample.
 
@@ -687,6 +706,9 @@ def build_oblivious_tree(Xb, grad, hess, n_bins_per_feature,
     n_leaves = 1 << len(splits_feat)
     if hs_lambda > 0.0:
         values = _leaf_values_hs(leaf, grad, hess, n_leaves, l2, lr, hs_lambda)
+    elif adaptive_shrinkage > 0.0:
+        values = _leaf_values_adaptive(leaf, grad, hess, n_leaves, l2, lr,
+                                       adaptive_shrinkage)
     else:
         values = _leaf_values(leaf, grad, hess, n_leaves, l2, lr)
     lin_feats = lin_coef = None

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -32,7 +32,8 @@ of the rows, so a row never sees its own label. Several orderings
 shrunk toward the global mean by `cat_smoothing`. Pass the columns (by integer position or
 column name) to `fit(..., cat_features=[...])`; everything else is automatic.
 
-`cat_combinations=True` additionally builds all pairwise category-by-category features.
+`cat_combinations` additionally builds all pairwise category-by-category features; the
+default (`None`) turns them on automatically when the data is entirely categorical.
 
 ## Leaf values and linear leaves
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -32,7 +32,7 @@ For more detail, see [API reference](api.md).
 |---|---|---|
 | `cat_smoothing` | `1.0` | Prior strength for ordered target statistics; higher shrinks rare categories toward the global mean. Must be `> 0`. |
 | `cat_n_permutations` | `4` | Random orderings averaged by the ordered target encoder. |
-| `cat_combinations` | `False` | Add all pairwise category-by-category features. Helps mostly-categorical data, can crowd out numerics on mixed data. |
+| `cat_combinations` | `None`→auto | Add all pairwise category-by-category features. `None` turns them on automatically only when the data is entirely categorical (where they help without crowding out numeric splits); set `True`/`False` to force it. Auto is skipped for very wide all-categorical data (a resource guard against the `C(n_cat, 2)` blow-up) — pass `True` there if you want them anyway. |
 
 Which columns are categorical can be passed either to `fit(..., cat_features=[...])` or as the
 `cat_features` to your ChimeraBoostRegressor/ChimeraBoostClassifier arguments depending on your use case.
@@ -67,7 +67,7 @@ The classifier picks its loss automatically: binary logloss for 2 classes, softm
 | Parameter | Default | Effect |
 |---|---|---|
 | `early_stopping` | `True` | Hold out a validation split and stop on a plateau. Set `False` to build a fixed `n_estimators` trees. |
-| `early_stopping_rounds` | `None`→`50` | Patience when early stopping is active. |
+| `early_stopping_rounds` | `None`→`50` | Patience when early stopping is active. `50` is the sweet spot across the Grinsztajn suite; raising it to `100`–`300` helps only large, high-signal datasets (e.g. covertype, electricity, pol) and costs ~25–35% more trees, so it is not worth it as a default — bump it yourself for that kind of data. |
 | `validation_fraction` | `0.2` | Held-out fraction (stratified for classifiers). Ignored when `eval_set` is passed to `fit`. |
 
 See [Recipes → early stopping](recipes.md#early-stopping) for `eval_set` and `groups`.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -36,8 +36,11 @@ clf.fit(X, y, cat_features=[0, 3])
 clf.fit(df, y, cat_features=["city", "device_type"])
 ```
 
-For mostly-categorical data, `cat_combinations=True` adds all pairwise category-by-category
-features. It can crowd out numerics on mixed data, so it is off by default.
+`cat_combinations` adds all pairwise category-by-category features. They help when the
+target depends on categorical interactions but can crowd out numerics on mixed data, so
+the default (`None`) turns them on automatically only when the data is entirely
+categorical. Force them with `cat_combinations=True` (e.g. on mixed data where you know
+the interactions matter) or disable with `False`.
 
 ## Missing values
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chimeraboost"
-version = "0.11.0"
+version = "0.12.0"
 description = "CatBoost-inspired gradient boosting in pure Python with a numba backend"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_chimeraboost.py
+++ b/tests/test_chimeraboost.py
@@ -1451,3 +1451,27 @@ def test_forest_leaf_refit_multiclass_warns_and_ignored():
         ChimeraBoostClassifier(n_estimators=30, random_state=0,
                                early_stopping=False,
                                forest_leaf_refit=True).fit(X, y)
+
+
+# --- G4: ordered_boosting + leaf_estimation reconciliation (default-off flag) --
+
+def test_ordered_leaf_estimation_fires_only_under_ordered_boosting():
+    """ordered_leaf_estimation refines the leaf values that predict uses while
+    F keeps the ordered LOO trajectory. It must change predictions when
+    ordered_boosting is on, and be a byte-identical no-op when it is off (the
+    flag only acts in the ordered-boosting branch)."""
+    X, y = load_breast_cancer(return_X_y=True)
+    ob = ChimeraBoostClassifier(n_estimators=80, random_state=0,
+                                early_stopping=False,
+                                ordered_boosting=True).fit(X, y)
+    g4 = ChimeraBoostClassifier(n_estimators=80, random_state=0,
+                                early_stopping=False, ordered_boosting=True,
+                                ordered_leaf_estimation=True).fit(X, y)
+    assert not np.allclose(ob.predict_proba(X), g4.predict_proba(X))
+    # off -> no-op
+    base = ChimeraBoostClassifier(n_estimators=80, random_state=0,
+                                  early_stopping=False).fit(X, y)
+    flag = ChimeraBoostClassifier(n_estimators=80, random_state=0,
+                                  early_stopping=False,
+                                  ordered_leaf_estimation=True).fit(X, y)
+    assert np.allclose(base.predict_proba(X), flag.predict_proba(X))

--- a/tests/test_chimeraboost.py
+++ b/tests/test_chimeraboost.py
@@ -1475,3 +1475,19 @@ def test_ordered_leaf_estimation_fires_only_under_ordered_boosting():
                                   early_stopping=False,
                                   ordered_leaf_estimation=True).fit(X, y)
     assert np.allclose(base.predict_proba(X), flag.predict_proba(X))
+
+
+# --- G3: size-adaptive leaf_estimation_iterations (default-off flag) -----------
+
+def test_adaptive_leaf_estimation_resolves_by_size_and_is_off_by_default():
+    from chimeraboost.sklearn_api import _adaptive_leaf_estimation_iterations as f
+    assert f(300) == 1 and f(2000) == 3 and f(40000) == 6   # monotone, capped
+    X, y = load_breast_cancer(return_X_y=True)               # ~400 train rows
+    base = ChimeraBoostClassifier(n_estimators=60, random_state=0,
+                                  early_stopping=False).fit(X, y)
+    adapt = ChimeraBoostClassifier(n_estimators=60, random_state=0,
+                                   early_stopping=False,
+                                   adaptive_leaf_estimation=True).fit(X, y)
+    assert base.model_.leaf_estimation_iterations == 3       # class default
+    assert adapt.model_.leaf_estimation_iterations == 1      # size-resolved
+    assert not np.allclose(base.predict_proba(X), adapt.predict_proba(X))

--- a/tests/test_chimeraboost.py
+++ b/tests/test_chimeraboost.py
@@ -1491,3 +1491,40 @@ def test_adaptive_leaf_estimation_resolves_by_size_and_is_off_by_default():
     assert base.model_.leaf_estimation_iterations == 3       # class default
     assert adapt.model_.leaf_estimation_iterations == 1      # size-resolved
     assert not np.allclose(base.predict_proba(X), adapt.predict_proba(X))
+
+
+# --- G2: mass-adaptive per-leaf shrinkage (default-off, alpha=0) ---------------
+
+def test_adaptive_leaf_shrinkage_noop_at_zero_and_shrinks_when_positive():
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(1500, 5))
+    y = X[:, 0] - X[:, 1] + 0.1 * rng.normal(size=1500)
+    base = ChimeraBoostRegressor(n_estimators=50, random_state=1,
+                                 early_stopping=False).fit(X, y)
+    zero = ChimeraBoostRegressor(n_estimators=50, random_state=1,
+                                 early_stopping=False,
+                                 adaptive_leaf_shrinkage=0.0).fit(X, y)
+    assert np.allclose(base.predict(X), zero.predict(X))      # alpha=0 -> no-op
+    on = ChimeraBoostRegressor(n_estimators=50, random_state=1,
+                               early_stopping=False,
+                               adaptive_leaf_shrinkage=5.0).fit(X, y)
+    assert not np.allclose(base.predict(X), on.predict(X))
+    with pytest.raises(ValueError, match="adaptive_leaf_shrinkage"):
+        ChimeraBoostRegressor(adaptive_leaf_shrinkage=-1.0).fit(X, y)
+
+
+def test_adaptive_leaf_shrinkage_kernel_matches_formula():
+    """The mass-shrinkage kernel must equal -lr*G/(H+l2) * H/(H+alpha)."""
+    from chimeraboost.tree import _leaf_values, _leaf_values_adaptive
+    rng = np.random.default_rng(2)
+    leaf = rng.integers(0, 4, 200).astype(np.int64)
+    g = rng.normal(size=200)
+    h = rng.random(200) + 0.1
+    plain = _leaf_values(leaf, g, h, 4, 1.0, 0.1)
+    alpha = 3.0
+    adapt = _leaf_values_adaptive(leaf, g, h, 4, 1.0, 0.1, alpha)
+    # reconstruct H per leaf to form the expected factor
+    H = np.zeros(4)
+    np.add.at(H, leaf, h)
+    factor = H / (H + alpha)
+    assert np.allclose(adapt, plain * factor)

--- a/tests/test_chimeraboost.py
+++ b/tests/test_chimeraboost.py
@@ -1528,3 +1528,34 @@ def test_adaptive_leaf_shrinkage_kernel_matches_formula():
     np.add.at(H, leaf, h)
     factor = H / (H + alpha)
     assert np.allclose(adapt, plain * factor)
+
+
+# --- C4: cat-aware binning (default-off flag) ---------------------------------
+
+def test_cat_aware_binning_gives_cat_columns_more_bins_and_is_noop_on_numeric():
+    rng = np.random.default_rng(0)
+    n = 3000
+    X = np.empty((n, 3), dtype=object)
+    X[:, 0] = [f"c{c}" for c in rng.integers(0, 30, n)]   # high-card categorical
+    X[:, 1] = rng.normal(size=n)
+    X[:, 2] = rng.normal(size=n)
+    y = ((rng.integers(0, 30, n) % 2) | (X[:, 1].astype(float) > 0.5)).astype(int)
+    base = ChimeraBoostClassifier(n_estimators=60, random_state=0,
+                                  early_stopping=False).fit(X, y, cat_features=[0])
+    caw = ChimeraBoostClassifier(n_estimators=60, random_state=0,
+                                 early_stopping=False,
+                                 cat_aware_binning=True).fit(X, y, cat_features=[0])
+    # The target-encoded categorical column gets the larger (cat_max_bins) budget;
+    # numeric columns keep max_bins.
+    assert caw.model_.prep_.binner_.n_bins_.max() > \
+        base.model_.prep_.binner_.n_bins_.max()
+    assert not np.allclose(base.predict_proba(X), caw.predict_proba(X))
+    # No categoricals -> no effect.
+    Xn = rng.normal(size=(1500, 4))
+    yn = (Xn[:, 0] > 0).astype(int)
+    a = ChimeraBoostClassifier(n_estimators=40, random_state=1,
+                               early_stopping=False).fit(Xn, yn)
+    b = ChimeraBoostClassifier(n_estimators=40, random_state=1,
+                               early_stopping=False,
+                               cat_aware_binning=True).fit(Xn, yn)
+    assert np.allclose(a.predict_proba(Xn), b.predict_proba(Xn))

--- a/tests/test_chimeraboost.py
+++ b/tests/test_chimeraboost.py
@@ -1161,3 +1161,111 @@ def test_shap_multiclass_raises():
     m = ChimeraBoostClassifier(n_estimators=30, random_state=0).fit(X, y)
     with pytest.raises(NotImplementedError):
         m.shap_values(X[:10])
+
+
+# --- validation_history_ property and callbacks= fit hook ---------------------
+
+def test_validation_history_best_iteration_is_curve_argmin():
+    """Under early stopping the recorded curve covers every round actually run
+    (best round + patience), and best_iteration_ is its argmin + 1 -- so the
+    kept-tree count is recoverable from the curve alone."""
+    X, y = load_breast_cancer(return_X_y=True)
+    Xtr, Xte, ytr, yte = train_test_split(
+        X, y, test_size=0.3, random_state=0, stratify=y)
+    PATIENCE = 20
+    m = ChimeraBoostClassifier(
+        n_estimators=1000, early_stopping_rounds=PATIENCE, random_state=0)
+    m.fit(Xtr, ytr, eval_set=(Xte, yte))
+    hist = m.validation_history_
+    assert m.best_iteration_ < 1000
+    assert int(np.argmin(hist)) + 1 == m.best_iteration_
+    # Stopped because patience ran out after the best round (not at the horizon).
+    assert len(hist) == m.best_iteration_ + PATIENCE
+
+
+def test_validation_history_full_curve_without_early_stopping():
+    """early_stopping=False + explicit eval_set => the complete curve to the
+    horizon (n_estimators), never truncated by the stopper."""
+    X, y = load_breast_cancer(return_X_y=True)
+    Xtr, Xte, ytr, yte = train_test_split(
+        X, y, test_size=0.3, random_state=0, stratify=y)
+    HORIZON = 60
+    m = ChimeraBoostClassifier(
+        n_estimators=HORIZON, early_stopping=False, random_state=0)
+    m.fit(Xtr, ytr, eval_set=(Xte, yte))
+    assert len(m.validation_history_) == HORIZON
+
+
+def test_validation_history_matches_manual_staged_logloss():
+    """The cheap per-round curve equals a manual staged log-loss evaluation on
+    the same eval_set -- so the harness can trust valid_history_ as the metric
+    at every iteration count from a single fit."""
+    from chimeraboost.losses import LOSSES
+    X, y = load_breast_cancer(return_X_y=True)
+    Xtr, Xte, ytr, yte = train_test_split(
+        X, y, test_size=0.3, random_state=0, stratify=y)
+    m = ChimeraBoostClassifier(
+        n_estimators=40, early_stopping=False, random_state=0)
+    m.fit(Xtr, ytr, eval_set=(Xte, yte))
+    # Manual: staged raw scores -> Logloss against the 0/1 eval labels.
+    y01 = (yte == m.classes_[1]).astype(np.float64)
+    loss = LOSSES["Logloss"]()
+    manual = [loss.eval(y01, F)
+              for F in m.model_.staged_predict_raw(Xte)]
+    assert np.allclose(m.validation_history_, manual, atol=1e-9)
+
+
+def test_callbacks_fire_once_per_round_and_can_stop():
+    X, y = load_breast_cancer(return_X_y=True)
+    Xtr, Xte, ytr, yte = train_test_split(
+        X, y, test_size=0.3, random_state=0, stratify=y)
+    seen = []
+
+    def record(it, train_loss, val_loss, model):
+        seen.append((it, train_loss, val_loss))
+
+    m = ChimeraBoostClassifier(
+        n_estimators=15, early_stopping=False, random_state=0)
+    m.fit(Xtr, ytr, eval_set=(Xte, yte), callbacks=record)
+    # One call per round, monotonically increasing iteration index.
+    assert [s[0] for s in seen] == list(range(15))
+    # val_loss passed to the callback tracks the recorded curve.
+    assert np.allclose([s[2] for s in seen], m.validation_history_, atol=1e-9)
+
+    stopped = []
+
+    def stop_at_5(it, train_loss, val_loss, model):
+        stopped.append(it)
+        return it >= 5
+
+    m2 = ChimeraBoostClassifier(
+        n_estimators=100, early_stopping=False, random_state=0)
+    m2.fit(Xtr, ytr, eval_set=(Xte, yte), callbacks=stop_at_5)
+    assert max(stopped) == 5
+    assert m2.best_iteration_ == 6   # rounds 0..5 kept
+
+
+def test_callbacks_rejected_for_bagging():
+    X, y = load_breast_cancer(return_X_y=True)
+    m = ChimeraBoostClassifier(n_estimators=20, n_ensembles=3, random_state=0)
+    with pytest.raises(ValueError, match="callbacks"):
+        m.fit(X, y, callbacks=lambda *a: None)
+
+
+def test_validation_history_regressor_and_multiclass():
+    # Regressor curve present with explicit eval set.
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(800, 5))
+    y = X[:, 0] - X[:, 1] + 0.1 * rng.normal(size=800)
+    Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.3, random_state=0)
+    r = ChimeraBoostRegressor(
+        n_estimators=30, early_stopping=False, random_state=0)
+    r.fit(Xtr, ytr, eval_set=(Xte, yte))
+    assert len(r.validation_history_) == 30
+    # Multiclass keeps a single combined softmax-logloss curve.
+    yc = rng.integers(0, 3, size=800)
+    Xtr, Xte, ytr, yte = train_test_split(X, yc, test_size=0.3, random_state=0)
+    c = ChimeraBoostClassifier(
+        n_estimators=25, early_stopping=False, random_state=0)
+    c.fit(Xtr, ytr, eval_set=(Xte, yte))
+    assert len(c.validation_history_) == 25

--- a/tests/test_chimeraboost.py
+++ b/tests/test_chimeraboost.py
@@ -1377,3 +1377,77 @@ def test_cat_combinations_max_pairs_caps_selection():
                                cat_combinations_max_pairs=2
                                ).fit(X, y, cat_features=[0, 1, 2, 3, 4])
     assert len(m.model_.prep_.combo_pairs_) <= 2
+
+
+# --- G1: forest-level joint leaf refit (default-off flag) ---------------------
+
+def test_forest_leaf_refit_is_noop_when_off():
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(1500, 5))
+    y = X[:, 0] - X[:, 1] + 0.1 * rng.normal(size=1500)
+    a = ChimeraBoostRegressor(n_estimators=50, random_state=1,
+                              early_stopping=False).fit(X, y)
+    b = ChimeraBoostRegressor(n_estimators=50, random_state=1,
+                              early_stopping=False).fit(X, y)
+    assert np.allclose(a.predict(X), b.predict(X))    # determinism baseline
+    c = ChimeraBoostRegressor(n_estimators=50, random_state=1,
+                              early_stopping=False,
+                              forest_leaf_refit=True).fit(X, y)
+    assert not np.allclose(a.predict(X), c.predict(X))
+
+
+def test_forest_leaf_refit_solves_ridge_optimum():
+    """The joint refit must reach the ridge stationarity point: with prediction
+    init + Z @ w (Z = leaf-membership over all trees), the RMSE-ridge gradient
+    Z.T(pred - y) + lambda * w is ~0. This pins the matrix-free CG result to the
+    explicit closed-form solve."""
+    rng = np.random.default_rng(3)
+    X = rng.normal(size=(400, 3))
+    y = 0.7 * X[:, 0] + 0.3 * rng.normal(size=400)
+    lam = 2.0
+    m = ChimeraBoostRegressor(n_estimators=8, depth=3, random_state=0,
+                              early_stopping=False, l2_leaf_reg=lam,
+                              forest_leaf_refit=True,
+                              forest_refit_iterations=2).fit(X, y)
+    gb = m.model_
+    Xb = np.ascontiguousarray(gb.prep_.transform(X).T)
+    trees = [t for t in gb.trees_ if t.depth > 0 and t.lin_coef is None]
+    sizes = [t.values.shape[0] for t in trees]
+    offs = np.concatenate([[0], np.cumsum(sizes)])
+    n, L = Xb.shape[1], int(offs[-1])
+    Z = np.zeros((n, L))
+    for k, t in enumerate(trees):
+        Z[np.arange(n), offs[k] + t.apply(Xb)] = 1.0
+    w = np.concatenate([t.values for t in trees])
+    pred = gb.init_ + Z @ w
+    assert np.allclose(pred, m.predict(X), atol=1e-6)          # consistency
+    grad = Z.T @ (pred - y) + lam * w
+    assert np.linalg.norm(grad) < 1e-2                         # ridge optimum
+    # And it lowers training RMSE vs no refit.
+    base = ChimeraBoostRegressor(n_estimators=8, depth=3, random_state=0,
+                                 early_stopping=False, l2_leaf_reg=lam).fit(X, y)
+    assert np.sqrt(np.mean((m.predict(X) - y) ** 2)) < \
+        np.sqrt(np.mean((base.predict(X) - y) ** 2))
+
+
+def test_forest_leaf_refit_binary_lowers_logloss():
+    X, y = load_breast_cancer(return_X_y=True)
+    Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.3, random_state=0,
+                                          stratify=y)
+    base = ChimeraBoostClassifier(n_estimators=60, random_state=0,
+                                  early_stopping=False).fit(Xtr, ytr)
+    ref = ChimeraBoostClassifier(n_estimators=60, random_state=0,
+                                 early_stopping=False,
+                                 forest_leaf_refit=True).fit(Xtr, ytr)
+    from sklearn.metrics import log_loss
+    assert log_loss(ytr, ref.predict_proba(Xtr)) < log_loss(ytr, base.predict_proba(Xtr))
+
+
+def test_forest_leaf_refit_multiclass_warns_and_ignored():
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(600, 4))
+    y = rng.integers(0, 3, size=600)
+    with pytest.warns(UserWarning, match="forest_leaf_refit"):
+        ChimeraBoostClassifier(n_estimators=30, random_state=0,
+                               early_stopping=False,
+                               forest_leaf_refit=True).fit(X, y)

--- a/tests/test_chimeraboost.py
+++ b/tests/test_chimeraboost.py
@@ -818,6 +818,55 @@ def test_auto_min_child_weight_is_size_adaptive():
     assert ce.model_.min_child_weight == 0.5
 
 
+def test_auto_cat_combinations_helper():
+    """cat_combinations=None enables combos only for tractable all-categorical
+    data; the resource caps and the mixed/no-cat cases stay off."""
+    from chimeraboost.sklearn_api import (
+        _auto_cat_combinations as f,
+        _AUTO_CAT_COMBO_MAX_PAIRS, _AUTO_CAT_COMBO_MAX_CELLS)
+    assert f([0, 1, 2, 3], 4, 1000) is True            # all-categorical -> on
+    assert f([0, 1], 4, 1000) is False                 # mixed (2 of 4) -> off
+    assert f(None, 4, 1000) is False                   # no cats -> off
+    assert f([0], 1, 1000) is False                    # need >=2 to combine
+    # Resource guards: too many pairs, or too many pairs*rows, -> off.
+    big = list(range(60)); assert (60 * 59 // 2) > _AUTO_CAT_COMBO_MAX_PAIRS
+    assert f(big, 60, 1000) is False
+    n_feat = 40; small_pairs = n_feat * (n_feat - 1) // 2
+    assert small_pairs <= _AUTO_CAT_COMBO_MAX_PAIRS
+    big_rows = int(_AUTO_CAT_COMBO_MAX_CELLS // small_pairs) + 10
+    assert f(list(range(n_feat)), n_feat, big_rows) is False
+    # numpy-array cat_features must not raise (ambiguous truth value).
+    assert f(np.array([0, 1, 2]), 3, 1000) is True
+
+
+def test_auto_cat_combinations_on_estimators():
+    """The resolved cat_combinations lands on the fitted preprocessor; explicit
+    True/False override the auto rule."""
+    rng = np.random.default_rng(0)
+    n = 1500
+    fcat = rng.integers(0, 4, (n, 4))
+    y = ((fcat[:, 0] == fcat[:, 1]) ^ (fcat[:, 2] > 1)).astype(int)
+    Xcat = fcat.astype(object)
+    allcat = ChimeraBoostClassifier(n_estimators=30, random_state=0).fit(
+        Xcat, y, cat_features=[0, 1, 2, 3])
+    assert allcat.model_.prep_.combo_pairs_                 # auto-on
+    # Mixed data leaves combos off.
+    Xmix = np.column_stack([fcat[:, :2].astype(object),
+                            rng.normal(size=(n, 2)).astype(object)])
+    mixed = ChimeraBoostClassifier(n_estimators=30, random_state=0).fit(
+        Xmix, y, cat_features=[0, 1])
+    assert not mixed.model_.prep_.combo_pairs_             # auto-off
+    # Explicit False on all-categorical data overrides the auto rule.
+    off = ChimeraBoostClassifier(cat_combinations=False, n_estimators=30,
+                                 random_state=0).fit(Xcat, y, cat_features=[0, 1, 2, 3])
+    assert not off.model_.prep_.combo_pairs_
+    # Regressor honors the same auto rule.
+    yr = fcat[:, 0] + 2.0 * (fcat[:, 1] == fcat[:, 2])
+    rgr = ChimeraBoostRegressor(n_estimators=30, random_state=0).fit(
+        Xcat, yr, cat_features=[0, 1, 2, 3])
+    assert rgr.model_.prep_.combo_pairs_
+
+
 # ---------------------------------------------------------------------------
 # hierarchical shrinkage (hs_lambda)
 # ---------------------------------------------------------------------------

--- a/tests/test_chimeraboost.py
+++ b/tests/test_chimeraboost.py
@@ -1317,3 +1317,63 @@ def test_onehot_max_card_validation():
     y = (X[:, 0] > 0).astype(int)
     with pytest.raises(ValueError, match="onehot_max_card"):
         ChimeraBoostClassifier(onehot_max_card=1).fit(X, y)
+
+
+# --- C3: selective cat_combinations on mixed data (default-off flag) -----------
+
+def test_cat_combinations_selective_is_noop_on_numeric_data():
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(1500, 4))
+    y = (X[:, 0] + X[:, 1] > 0).astype(int)
+    a = ChimeraBoostClassifier(n_estimators=40, random_state=1,
+                               early_stopping=False).fit(X, y)
+    b = ChimeraBoostClassifier(n_estimators=40, random_state=1,
+                               early_stopping=False,
+                               cat_combinations_selective=True).fit(X, y)
+    assert np.allclose(a.predict_proba(X), b.predict_proba(X))
+
+
+def test_cat_combinations_selective_fires_on_mixed_data():
+    """On MIXED data the plain auto-rule keeps no combos, but the selective flag
+    picks high-MI interaction pairs (here A x B drives an XOR target) and changes
+    predictions. Unseen categories at predict still work."""
+    rng = np.random.default_rng(0)
+    n = 3000
+    A, B, C = (rng.integers(0, 4, n), rng.integers(0, 4, n),
+               rng.integers(0, 6, n))
+    num = rng.normal(size=(n, 2))
+    X = np.empty((n, 5), dtype=object)
+    X[:, 0] = [f"a{v}" for v in A]
+    X[:, 1] = [f"b{v}" for v in B]
+    X[:, 2] = [f"c{v}" for v in C]
+    X[:, 3], X[:, 4] = num[:, 0], num[:, 1]
+    y = (((A % 2) ^ (B % 2)).astype(bool) | (num[:, 0] > 1.2)).astype(int)
+    base = ChimeraBoostClassifier(n_estimators=80, random_state=0,
+                                  early_stopping=False).fit(X, y,
+                                                            cat_features=[0, 1, 2])
+    sel = ChimeraBoostClassifier(n_estimators=80, random_state=0,
+                                 early_stopping=False,
+                                 cat_combinations_selective=True
+                                 ).fit(X, y, cat_features=[0, 1, 2])
+    assert base.model_.prep_.combo_pairs_ == []          # auto-off on mixed
+    assert (0, 1) in sel.model_.prep_.combo_pairs_       # the XOR-driving pair
+    assert not np.allclose(base.predict_proba(X), sel.predict_proba(X))
+    Xnew = X[:3].copy()
+    Xnew[0, 0] = "a_UNSEEN"
+    assert sel.predict_proba(Xnew).shape == (3, 2)
+
+
+def test_cat_combinations_max_pairs_caps_selection():
+    rng = np.random.default_rng(1)
+    n = 2000
+    X = np.empty((n, 5), dtype=object)
+    cols = [rng.integers(0, 4, n) for _ in range(5)]
+    for j, c in enumerate(cols):
+        X[:, j] = [f"v{v}" for v in c]
+    y = ((cols[0] % 2) ^ (cols[1] % 2) ^ (cols[2] % 2)).astype(int)
+    m = ChimeraBoostClassifier(n_estimators=40, random_state=0,
+                               early_stopping=False,
+                               cat_combinations_selective=True,
+                               cat_combinations_max_pairs=2
+                               ).fit(X, y, cat_features=[0, 1, 2, 3, 4])
+    assert len(m.model_.prep_.combo_pairs_) <= 2

--- a/tests/test_chimeraboost.py
+++ b/tests/test_chimeraboost.py
@@ -1269,3 +1269,51 @@ def test_validation_history_regressor_and_multiclass():
         n_estimators=25, early_stopping=False, random_state=0)
     c.fit(Xtr, ytr, eval_set=(Xte, yte))
     assert len(c.validation_history_) == 25
+
+
+# --- C1: one-hot low-cardinality categoricals (default-off flag) --------------
+
+def test_onehot_low_card_is_noop_on_numeric_data():
+    """The flag must be a true no-op when there are no categoricals (or none low-
+    cardinality): predictions byte-identical to the default."""
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(1500, 4))
+    y = (X[:, 0] + X[:, 1] > 0).astype(int)
+    a = ChimeraBoostClassifier(n_estimators=40, random_state=1,
+                               early_stopping=False).fit(X, y)
+    b = ChimeraBoostClassifier(n_estimators=40, random_state=1,
+                               early_stopping=False,
+                               onehot_low_card=True).fit(X, y)
+    assert np.allclose(a.predict_proba(X), b.predict_proba(X))
+
+
+def test_onehot_low_card_encodes_only_low_cardinality():
+    """Only columns with <= onehot_max_card levels get a one-hot block; high-
+    cardinality columns keep TS only. The flag changes predictions."""
+    rng = np.random.default_rng(0)
+    n = 2000
+    X = np.empty((n, 3), dtype=object)
+    X[:, 0] = np.array([f"c{c}" for c in rng.integers(0, 5, n)], dtype=object)
+    X[:, 1] = np.array([f"h{c}" for c in rng.integers(0, 50, n)], dtype=object)
+    X[:, 2] = rng.normal(size=n)
+    y = ((X[:, 0] == "c1") | (rng.random(n) < 0.3)).astype(int)
+    m = ChimeraBoostClassifier(n_estimators=60, random_state=0,
+                               early_stopping=False, onehot_low_card=True)
+    m.fit(X, y, cat_features=[0, 1])
+    # The 5-level column (index 0 among cats) is one-hot; the 50-level one isn't.
+    assert m.model_.prep_.onehot_specs_ == [(0, 5)]
+    base = ChimeraBoostClassifier(n_estimators=60, random_state=0,
+                                  early_stopping=False).fit(X, y, cat_features=[0, 1])
+    assert not np.allclose(m.predict_proba(X), base.predict_proba(X))
+    # Unseen categories at predict route to an all-zero one-hot row (no crash).
+    Xnew = np.array([["c_UNSEEN", "h_UNSEEN", 0.1], ["c1", "h3", -0.2]],
+                    dtype=object)
+    assert m.predict_proba(Xnew).shape == (2, 2)
+
+
+def test_onehot_max_card_validation():
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(200, 3))
+    y = (X[:, 0] > 0).astype(int)
+    with pytest.raises(ValueError, match="onehot_max_card"):
+        ChimeraBoostClassifier(onehot_max_card=1).fit(X, y)

--- a/tests/test_research_curves.py
+++ b/tests/test_research_curves.py
@@ -1,0 +1,52 @@
+"""Unit tests for the cascade's paired-curve comparison (cheap go/kill signal)."""
+
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))), "benchmarks"))
+from research import curves  # noqa: E402
+
+
+def test_variant_uniformly_better():
+    b = np.linspace(1.0, 0.5, 50)
+    v = b - 0.05                       # 0.05 lower everywhere
+    c = curves.compare(b, v)
+    assert c["best_val_delta"] < 0
+    assert c["dominance"] == 1.0       # dominates everywhere -> strong promote
+    assert c["early_signal"] < 0
+    assert c["area_between"] < 0
+
+
+def test_variant_uniformly_worse():
+    b = np.linspace(1.0, 0.5, 50)
+    v = b + 0.05
+    c = curves.compare(b, v)
+    assert c["best_val_delta"] > 0
+    assert c["dominance"] == 0.0       # dominated everywhere -> fast kill
+    assert c["early_signal"] > 0
+
+
+def test_identical_curves_are_flat():
+    b = np.linspace(1.0, 0.4, 40)
+    c = curves.compare(b, b.copy())
+    assert c["best_val_delta"] == 0.0
+    assert c["best_val_delta_pct"] == 0.0
+    assert c["dominance"] == 1.0       # <= holds with equality everywhere
+
+
+def test_unequal_length_curves_align():
+    b = np.linspace(1.0, 0.5, 50)
+    v = np.linspace(1.0, 0.5, 30) - 0.02
+    c = curves.compare(b, v)
+    assert c["len_baseline"] == 50 and c["len_variant"] == 30
+    # best_val still uses each curve's own minimum
+    assert np.isclose(c["best_val_variant"], v.min())
+
+
+def test_best_val_delta_pct_normalizes():
+    b = np.array([2.0, 1.0])
+    v = np.array([2.0, 0.9])           # best 0.9 vs 1.0 -> -10%
+    assert np.isclose(curves.best_val_delta_pct(b, v), -0.1, atol=1e-9)


### PR DESCRIPTION
## Headline
Auto-enable `cat_combinations` for all-categorical data — fixes the long-standing
all-categorical gap (e.g. `car` 0.757→0.932 F1) out of the box. Mixed data is
untouched. Ships as 0.12.0.

## Also included
- **Library hooks:** `validation_history_` (full per-round val-loss curve from one
  fit) and a `callbacks=` fit hook.
- **Seven default-off opt-in flags**, each a byte-identical no-op unless set,
  vetted through a new efficient paired-curve benchmark cascade
  (`benchmarks/research/`): `onehot_low_card`, `cat_aware_binning`,
  `cat_combinations_selective`, `forest_leaf_refit`, `ordered_leaf_estimation`,
  `adaptive_leaf_estimation`, `adaptive_leaf_shrinkage`. None beat the defaults
  broadly — see `benchmarks/research/SUMMARY.md` — so they're opt-ins for narrow
  sweet-spots, not default changes.
