### PR TITLE
Auto cat combinations

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+# What
+
+<!-- 1-3 sentences: what changed and why. Link issues if any. -->
+
+## Benchmark impact
+
+<!-- Pick one: -->
+- [ ] No default behavior changes (benchmarks unaffected)
+- [ ] Default/algorithm change — Grinsztajn + OpenML-gate evidence attached (sign test, before/after aggregate table)
+
+## Checklist
+
+- [ ] `pytest` green
+- [ ] TabArena-Lite untouched (sealed holdout — results are report-only, never a reason for a change)
+- [ ] CHANGELOG.md updated (user-facing changes)
+- [ ] Docs updated (API/parameter changes)

--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,9 @@ benchmarks/results/*
 
 # MkDocs build output (the site is built/published by CI, never committed)
 site/
+
+# Research-cascade dataset/baseline cache (regenerable, large)
+benchmarks/research/cache/
+
+# AutoGluon scratch dirs created when running the TabArena scripts locally
+AutogluonModels/

--- a/benchmarks/random_search.py
+++ b/benchmarks/random_search.py
@@ -1,0 +1,257 @@
+"""Random-search hyperparameter study for ChimeraBoost on the PMLB tuning suite.
+
+Goal: characterize WHICH knobs help across the suite (not ship a default). The
+report suites (Grinsztajn / OpenML-34 / TabArena) stay untouched; PMLB is the
+designated tuning ground (see memory project-pmlb-tuning-holdout).
+
+Protocol
+--------
+* Search on the `tune` fold (13 datasets). For each dataset, evaluate the DEFAULT
+  config plus N random configs, each averaged over `--seeds` fresh 75/25 splits
+  (the model carves its own early-stopping validation from the 75% train; we score
+  macro-F1 for classification / RMSE for regression on the 25% test).
+* Per dataset, every config's score is turned into `rel_impr` = signed fractional
+  improvement over THAT dataset's default (positive = better than default). This
+  removes the dataset scale so configs can be pooled across the suite.
+* Knob importance: within-dataset Spearman corr(knob value, rel_impr), averaged
+  across datasets (avoids Simpson's paradox). Plus per-value mean rel_impr.
+* The single best SHARED config (best mean rel_impr on tune) is then re-evaluated
+  on the `holdout` fold — the out-of-sample generalization check.
+
+Only accuracy-relevant knobs are searched; cat_* knobs are skipped because PMLB
+loads all-numeric (no categoricals detected). n_estimators is capped and
+early_stopping_rounds fixed so every fit is compared in the same budget regime.
+"""
+import os
+import sys
+import json
+import time
+import argparse
+from collections import defaultdict
+
+import numpy as np
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import f1_score, mean_squared_error
+
+sys.path.insert(0, os.path.dirname(__file__))
+import run_benchmarks as RB  # noqa: E402  (reuse the PMLB dataset builders)
+import chimeraboost as cb    # noqa: E402
+
+# Fixed budget so every config is judged in the same regime.
+N_ESTIMATORS = 1500
+EARLY_STOP_ROUNDS = 50
+
+
+def sample_config(rng):
+    """One random ChimeraBoost config over the accuracy-relevant knobs."""
+    return dict(
+        learning_rate=float(np.exp(rng.uniform(np.log(0.02), np.log(0.30)))),
+        depth=int(rng.integers(4, 11)),               # 4..10 inclusive
+        l2_leaf_reg=float(np.exp(rng.uniform(np.log(0.3), np.log(10.0)))),
+        max_bins=int(rng.choice([64, 128, 254])),
+        subsample=float(rng.choice([0.6, 0.8, 1.0])),
+        colsample=float(rng.choice([0.6, 0.8, 1.0])),
+        min_child_weight=float(rng.choice([0.0, 1.0, 5.0, 20.0])),
+        leaf_estimation_iterations=int(rng.choice([1, 3, 5, 10])),
+        ordered_boosting=bool(rng.choice([False, True])),
+        hs_lambda=float(rng.choice([0.0, 0.5, 1.0])),
+    )
+
+
+# Knobs treated as ordinal/continuous for the correlation analysis (ordered_boosting
+# is binary and handled separately).
+NUMERIC_KNOBS = ["learning_rate", "depth", "l2_leaf_reg", "max_bins", "subsample",
+                 "colsample", "min_child_weight", "leaf_estimation_iterations",
+                 "hs_lambda"]
+
+
+def _fit_score(task, X, y, cat, cfg, seed, threads):
+    """Fit one config on one split, return the held-out metric (F1 macro / RMSE)."""
+    strat = y if task != "regression" else None
+    Xtr, Xte, ytr, yte = train_test_split(
+        X, y, test_size=0.25, random_state=seed, stratify=strat)
+    common = dict(thread_count=threads, random_state=seed,
+                  n_estimators=N_ESTIMATORS, early_stopping=True,
+                  early_stopping_rounds=EARLY_STOP_ROUNDS, cat_features=cat)
+    if cfg:
+        common.update(cfg)
+    if task == "regression":
+        m = cb.ChimeraBoostRegressor(**common)
+        m.fit(Xtr, ytr)
+        return float(np.sqrt(mean_squared_error(yte, m.predict(Xte))))
+    m = cb.ChimeraBoostClassifier(**common)
+    m.fit(Xtr, ytr)
+    return float(f1_score(yte, m.predict(Xte), average="macro"))
+
+
+def _task(ds):
+    return RB._task_of(ds)
+
+
+# ----- worker (top-level + picklable for ProcessPoolExecutor) -----------------
+def _eval_task(t):
+    ds, cfg_id, cfg, seed, scale, threads = t
+    RB._add_pmlb_datasets()
+    rng = np.random.default_rng(1000 + seed)
+    X, y, cat, task = RB.DATASETS[ds](scale, rng)
+    t0 = time.time()
+    score = _fit_score(task, X, y, cat, cfg, seed, threads)
+    return ds, cfg_id, seed, score, time.time() - t0
+
+
+def run(fold, n_configs, seeds, jobs, threads_per, out_path, configs=None):
+    RB._add_pmlb_datasets()
+    datasets = [k for k in RB.DATASETS if k.startswith(f"pm:{fold}/")]
+    rng = np.random.default_rng(0)
+    if configs is None:
+        configs = {"default": None}
+        for i in range(n_configs):
+            configs[f"cfg{i:03d}"] = sample_config(rng)
+
+    tasks = [(ds, cid, cfg, s, 1.0, threads_per)
+             for ds in datasets for cid, cfg in configs.items()
+             for s in range(seeds)]
+    print(f"[{fold}] {len(datasets)} datasets x {len(configs)} configs x "
+          f"{seeds} seeds = {len(tasks)} fits  (jobs={jobs})")
+
+    raw = defaultdict(lambda: defaultdict(list))  # raw[ds][cid] = [scores]
+    done = 0
+    t0 = time.time()
+    from concurrent.futures import ProcessPoolExecutor, as_completed
+    with ProcessPoolExecutor(max_workers=jobs) as ex:
+        futs = [ex.submit(_eval_task, t) for t in tasks]
+        for fut in as_completed(futs):
+            ds, cid, seed, score, secs = fut.result()
+            raw[ds][cid].append(score)
+            done += 1
+            if done % 25 == 0 or done == len(tasks):
+                el = time.time() - t0
+                eta = el / done * (len(tasks) - done)
+                print(f"  {done}/{len(tasks)}  elapsed {el:.0f}s  eta {eta:.0f}s",
+                      flush=True)
+
+    # mean over seeds
+    scores = {ds: {cid: float(np.mean(v)) for cid, v in cfgs.items()}
+              for ds, cfgs in raw.items()}
+    payload = {"fold": fold, "seeds": seeds, "n_estimators": N_ESTIMATORS,
+               "configs": {k: v for k, v in configs.items()},
+               "tasks_of": {ds: _task(ds) for ds in datasets},
+               "scores": scores}
+    with open(out_path, "w") as f:
+        json.dump(payload, f, indent=2)
+    print(f"saved -> {out_path}")
+    return payload
+
+
+def rel_impr(task, default, score):
+    """Signed fractional improvement over default (positive = better)."""
+    if default == 0:
+        return 0.0
+    if task == "regression":     # RMSE, lower better
+        return (default - score) / default
+    return (score - default) / default   # F1, higher better
+
+
+def _spearman(x, y):
+    x = np.asarray(x, float); y = np.asarray(y, float)
+    if len(x) < 3 or np.all(x == x[0]):
+        return np.nan
+    rx = np.argsort(np.argsort(x)); ry = np.argsort(np.argsort(y))
+    rx = rx - rx.mean(); ry = ry - ry.mean()
+    d = np.sqrt((rx**2).sum() * (ry**2).sum())
+    return float((rx * ry).sum() / d) if d else np.nan
+
+
+def analyze(payload):
+    tasks_of = payload["tasks_of"]; configs = payload["configs"]
+    scores = payload["scores"]
+    # rel_impr[ds][cid]
+    rel = {}
+    for ds, cfgs in scores.items():
+        d = cfgs["default"]; t = tasks_of[ds]
+        rel[ds] = {cid: rel_impr(t, d, s) for cid, s in cfgs.items() if cid != "default"}
+
+    rng_cids = [c for c in configs if c != "default"]
+
+    # ---- per-dataset headroom: best random config vs default ----
+    print("\n=== Per-dataset tuning headroom (best random config vs default) ===")
+    print(f"{'dataset':40} {'task':11} {'best rel_impr':>13} {'best cfg':>9}")
+    headroom = []
+    for ds in sorted(rel):
+        best_cid = max(rel[ds], key=rel[ds].get)
+        bi = rel[ds][best_cid]
+        headroom.append(bi)
+        print(f"{ds:40} {tasks_of[ds]:11} {bi*100:+12.2f}% {best_cid:>9}")
+    print(f"{'MEAN best-per-dataset headroom':40} {'':11} {np.mean(headroom)*100:+12.2f}%")
+
+    # ---- knob importance: within-dataset Spearman(value, rel_impr), averaged ----
+    print("\n=== Knob importance (mean within-dataset Spearman corr with rel_impr) ===")
+    print("    positive => larger value tends to beat default; |corr| => strength")
+    rows = []
+    for knob in NUMERIC_KNOBS:
+        corrs = []
+        for ds in rel:
+            vals = [configs[c][knob] for c in rng_cids]
+            ri = [rel[ds][c] for c in rng_cids]
+            c = _spearman(vals, ri)
+            if not np.isnan(c):
+                corrs.append(c)
+        rows.append((knob, np.mean(corrs) if corrs else np.nan))
+    for knob, mc in sorted(rows, key=lambda r: -abs(r[1] if not np.isnan(r[1]) else 0)):
+        print(f"  {knob:28} {mc:+.3f}")
+    # ordered_boosting (binary): mean rel_impr on vs off, pooled across datasets
+    on = [rel[ds][c] for ds in rel for c in rng_cids if configs[c]["ordered_boosting"]]
+    off = [rel[ds][c] for ds in rel for c in rng_cids if not configs[c]["ordered_boosting"]]
+    print(f"  {'ordered_boosting=True':28} mean rel_impr {np.mean(on)*100:+.2f}% "
+          f"(vs False {np.mean(off)*100:+.2f}%)")
+
+    # ---- per-value marginal: mean rel_impr for each discrete knob value ----
+    print("\n=== Marginal: mean rel_impr by knob value (pooled; 0% = ties default) ===")
+    discrete = {"max_bins": [64, 128, 254], "subsample": [0.6, 0.8, 1.0],
+                "colsample": [0.6, 0.8, 1.0], "min_child_weight": [0.0, 1.0, 5.0, 20.0],
+                "leaf_estimation_iterations": [1, 3, 5, 10], "hs_lambda": [0.0, 0.5, 1.0]}
+    for knob, vals in discrete.items():
+        parts = []
+        for v in vals:
+            ri = [rel[ds][c] for ds in rel for c in rng_cids if configs[c][knob] == v]
+            parts.append(f"{v}:{np.mean(ri)*100:+.2f}%" if ri else f"{v}:NA")
+        print(f"  {knob:28} " + "  ".join(parts))
+
+    # ---- best single SHARED config across the tune fold ----
+    print("\n=== Best single shared config (mean rel_impr across tune datasets) ===")
+    mean_ri = {c: np.mean([rel[ds][c] for ds in rel]) for c in rng_cids}
+    best_shared = max(mean_ri, key=mean_ri.get)
+    print(f"  {best_shared}: mean rel_impr {mean_ri[best_shared]*100:+.2f}%")
+    for k, v in configs[best_shared].items():
+        print(f"    {k:28} {v}")
+    return best_shared, configs[best_shared]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--fold", default="tune", choices=["tune", "holdout"])
+    ap.add_argument("--n-configs", type=int, default=40)
+    ap.add_argument("--seeds", type=int, default=3)
+    ap.add_argument("--jobs", type=int, default=max(1, (os.cpu_count() or 2) // 2))
+    ap.add_argument("--threads-per", type=int, default=2)
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--analyze", default=None,
+                    help="path to an existing results JSON: skip search, just analyze")
+    args = ap.parse_args()
+
+    if args.analyze:
+        analyze(json.load(open(args.analyze)))
+        return
+
+    import datetime
+    stamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+    out = args.out or os.path.join(os.path.dirname(__file__), "results",
+                                   f"rsearch-{args.fold}-{stamp}.json")
+    payload = run(args.fold, args.n_configs, args.seeds, args.jobs,
+                  args.threads_per, out)
+    analyze(payload)
+    print(f"\n# results JSON: {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/summarize.py
+++ b/benchmarks/summarize.py
@@ -60,9 +60,17 @@ def load(json_path):
 
 
 def latest_json(results_dir=RESULTS_DIR):
-    """Path to the most recently modified results .json, or None."""
+    """Path to the most recently modified results .json that has a 'records' key, or None."""
     files = glob.glob(os.path.join(results_dir, "*.json"))
-    return max(files, key=os.path.getmtime) if files else None
+    valid = []
+    for f in files:
+        try:
+            with open(f, encoding="utf-8") as fh:
+                if "records" in json.load(fh):
+                    valid.append(f)
+        except Exception:
+            pass
+    return max(valid, key=os.path.getmtime) if valid else None
 
 
 def _agg_metric(records, key):

--- a/benchmarks/tabarena/README.md
+++ b/benchmarks/tabarena/README.md
@@ -1,0 +1,48 @@
+# TabArena-Lite integration
+
+Scripts to run ChimeraBoost on [TabArena](https://tabarena.ai) (Lite protocol)
+and produce an Elo leaderboard entry. **TabArena is a sealed holdout: results
+are report-only and must never feed back into source or default choices.**
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `chimeraboost_tabarena_model.py` | AutoGluon `AbstractModel` wrapper (native `cat_features` passed through) + config generators. Must stay a separate file — TabArena pickles the class. |
+| `run_chimera_lite.py` / `run_chimera_eval.py` | Default-config entry (1 config, 51 tasks) + Elo eval. |
+| `run_chimera_e10.py` / `run_chimera_e10_eval.py` | `n_ensembles=10` variant as a separate entry. |
+| `run_chimera_tuned_lite.py` / `run_chimera_tuned_lite_eval.py` | Tuned entry: default + 200 random configs (TabArena convention). Search space = core knobs + the default-off research flags (see `benchmarks/research/SUMMARY.md`). |
+| `run_chimera_tuned.py` / `run_chimera_tuned_eval.py` | Full-repetitions variant of the tuned run (all folds/repeats). ~30x Lite cost; unused so far. |
+
+## Environment (Windows box; keep everything off C:!)
+
+Venv: `A:\code\tabarena\.venv\Scripts\python.exe` (Python 3.11, editable
+installs of tabarena + bencheval + this repo). Before running, set:
+
+```powershell
+$env:TMP='A:\code\tmp'; $env:TEMP='A:\code\tmp'
+$env:HF_HOME='A:\code\hf'; $env:PYTHONIOENCODING='utf-8'
+```
+
+OpenML caches to `A:\code\openml` (set in-script). Outputs land in
+`A:\code\tabarena_out\`; leaderboards in `A:\code\tabarena_out\evals\`.
+
+Run from this directory (the wrapper module is imported from cwd):
+
+```powershell
+& A:\code\tabarena\.venv\Scripts\python.exe run_chimera_tuned_lite.py --limit 2   # smoke
+& A:\code\tabarena\.venv\Scripts\python.exe run_chimera_tuned_lite.py             # full
+& A:\code\tabarena\.venv\Scripts\python.exe run_chimera_tuned_lite_eval.py        # Elo
+```
+
+## Gotchas
+
+* **Result caching**: a re-run silently loads cached results
+  (`Loading cache exists=True`) instead of refitting. To force fresh fits,
+  delete `A:\code\tabarena_out\<run>\data\<Method>_*` and the processed cache
+  `~/.cache/tabarena/artifacts/<Method>` before evaluating.
+* **OpenML outages**: pre-cache all task files and verify they exist on disk
+  (the API can "succeed" without writing); see the precache scripts in
+  `A:\code\tabarena\examples\benchmarking\custom_tabarena_model\`.
+* Windows: `os.sched_getaffinity` shim + UTF-8 output are handled in the eval
+  scripts.

--- a/benchmarks/tabarena/chimeraboost_tabarena_model.py
+++ b/benchmarks/tabarena/chimeraboost_tabarena_model.py
@@ -1,0 +1,205 @@
+"""Custom TabArena model wrapping ChimeraBoost (a CatBoost-inspired, numba-backed
+oblivious gradient-boosting library: https://github.com/bbstats/chimeraboost).
+
+Mirrors the official custom_random_forest_model.py template. NOTE: the model class
+MUST live in its own file (not the run script) because TabArena pickles it.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from autogluon.core.models import AbstractModel
+from autogluon.features import LabelEncoderFeatureGenerator
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+class ChimeraBoostModel(AbstractModel):
+    """ChimeraBoost as an AutoGluon/TabArena model (scikit-learn style API)."""
+
+    ag_key = "CHIMERA"
+    ag_name = "ChimeraBoost"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._feature_generator = None
+
+    def _preprocess(self, X: pd.DataFrame, is_train=False, **kwargs) -> np.ndarray:
+        """Label-encode categoricals and hand the model an object matrix while
+        recording which columns are categorical, so ChimeraBoost applies its
+        NATIVE ordered-target-statistics encoding (and auto cat_combinations on
+        all-categorical data) rather than seeing cats as plain numbers."""
+        X = super()._preprocess(X, **kwargs)
+        if is_train:
+            self._feature_generator = LabelEncoderFeatureGenerator(verbosity=0)
+            self._feature_generator.fit(X=X)
+            # Positions of the categorical columns in the final column order,
+            # passed verbatim as cat_features to ChimeraBoost. Computed once on
+            # train and reused at predict (column order is identical).
+            self._cat_indices = [X.columns.get_loc(c)
+                                 for c in self._feature_generator.features_in]
+        if self._feature_generator.features_in:
+            X = X.copy()
+            X[self._feature_generator.features_in] = self._feature_generator.transform(X=X)
+        # object dtype: cat columns stay integer-coded categories (ChimeraBoost
+        # factorizes them), numeric columns stay float. fillna(0) for numerics;
+        # the label encoder already maps unseen/NaN cats to a reserved code.
+        return X.fillna(0).to_numpy(dtype=object)
+
+    def _fit(self, X, y, num_cpus: int = 1, **kwargs):
+        if self.problem_type in ["regression"]:
+            from chimeraboost import ChimeraBoostRegressor
+
+            model_cls = ChimeraBoostRegressor
+        else:  # 'binary' and 'multiclass'
+            from chimeraboost import ChimeraBoostClassifier
+
+            model_cls = ChimeraBoostClassifier
+
+        X = self.preprocess(X, y=y, is_train=True)
+        params = self._get_model_params()
+        # Tuned configs may sample linear_leaves=True, which raises on multiclass;
+        # None = auto (binary on, multiclass off) keeps the config valid everywhere.
+        if self.problem_type == "multiclass" and params.get("linear_leaves") is True:
+            params["linear_leaves"] = None
+        self.model = model_cls(**params)
+        # early_stopping=True with no eval_set => ChimeraBoost auto-splits a
+        # validation fraction internally and stops on it. cat_features triggers
+        # native ordered-TS encoding + (on all-cat data) auto cat_combinations.
+        cat = self._cat_indices or None
+        self.model.fit(X, y, cat_features=cat)
+
+    def _set_default_params(self):
+        default_params = {
+            "n_estimators": 500,
+            "early_stopping": True,
+            "thread_count": -1,
+            "random_state": 0,
+        }
+        for param, val in default_params.items():
+            self._set_default_param_value(param, val)
+
+    def _get_default_auxiliary_params(self) -> dict:
+        default_auxiliary_params = super()._get_default_auxiliary_params()
+        default_auxiliary_params.update({"valid_raw_types": ["int", "float", "category"]})
+        return default_auxiliary_params
+
+
+class ChimeraBoostE10Model(ChimeraBoostModel):
+    """Deliberate variant: the exact default config + n_ensembles=10 (internal
+    averaging of 10 boosting runs). A distinct method so it sits ALONGSIDE the
+    default ChimeraBoost entry on the leaderboard, never replacing it."""
+
+    ag_key = "CHIMERAE10"
+    ag_name = "ChimeraBoost_e10"
+
+    def _set_default_params(self):
+        super()._set_default_params()  # identical default config ...
+        self._set_default_param_value("n_ensembles", 10)  # ... + this one knob
+        # ensemble_n_jobs left at 1: the 10 members run sequentially, each using
+        # all threads (thread_count=-1); avoids core oversubscription. ~10x train time.
+
+
+def get_configs_for_chimera_e10():
+    """Single experiment: default config + n_ensembles=10, bagged, Lite."""
+    from autogluon.common.space import Int
+
+    from tabarena.utils.config_utils import ConfigGenerator
+
+    gen = ConfigGenerator(
+        model_cls=ChimeraBoostE10Model,
+        manual_configs=[{}],
+        search_space={"n_estimators": Int(100, 1000)},
+    )
+    return gen.generate_all_bag_experiments(
+        num_random_configs=0, fold_fitting_strategy="sequential_local"
+    )
+
+
+def get_configs_for_chimera(*, num_random_configs: int = 0):
+    """Experiment configs for ChimeraBoost. Default: a single default config (no HPO),
+    which is the cheapest way to get a first Elo placement on TabArena-Lite."""
+    from autogluon.common.space import Int
+
+    from tabarena.utils.config_utils import ConfigGenerator
+
+    manual_configs = [{}]  # one default config
+    search_space = {"n_estimators": Int(100, 1000)}  # only sampled if num_random_configs>0
+
+    gen = ConfigGenerator(
+        model_cls=ChimeraBoostModel,
+        manual_configs=manual_configs,
+        search_space=search_space,
+    )
+    return gen.generate_all_bag_experiments(
+        num_random_configs=num_random_configs, fold_fitting_strategy="sequential_local"
+    )
+
+
+class ChimeraBoostTunedModel(ChimeraBoostModel):
+    """Tuned variant — distinct ag_name so it appears as a separate leaderboard entry."""
+
+    ag_key = "CHIMERATUNED"
+    ag_name = "ChimeraBoost_tuned"
+
+    def _set_default_params(self):
+        # Fixed tree budget for every tuned config; early stopping picks the
+        # effective count, so low-lr configs aren't truncated by the 500 cap
+        # the default entry uses.
+        self._set_default_param_value("n_estimators", 1500)
+        super()._set_default_params()
+
+
+def get_configs_for_chimera_tuned(*, num_random_configs: int = 200):
+    """Random HP configs for the tuned TabArena entry (default 200, the
+    TabArena convention for tuned methods).
+
+    Search-space design (pre-registered from dev-side evidence only — Grinsztajn
+    / OpenML / PMLB studies; never from TabArena results):
+    * Core capacity/regularization knobs with known per-dataset variance:
+      learning_rate, depth, l2_leaf_reg, min_child_weight, subsample, colsample,
+      leaf_estimation_iterations, max_bins.
+    * The default-OFF research flags that were KILLED as defaults precisely
+      because each helps only a narrow slice of datasets (see
+      benchmarks/research/SUMMARY.md) — per-task HPO is the regime where
+      narrow-sweet-spot levers earn their keep: linear_leaves (regression wins
+      pol/abalone; default only auto-on for binary), onehot_low_card,
+      cat_aware_binning, cat_combinations_selective (hard-capped at 20 pairs;
+      the plain cat_combinations flag is deliberately EXCLUDED — explicit True
+      bypasses the auto-rule's <=1000-pair resource guard and would explode on
+      high-cardinality tasks), and hs_lambda (null at depth 6 but designed to
+      make deeper trees safe — searchable jointly with depth here).
+    * n_estimators stays fixed (1500 cap + early stopping): searching a budget
+      cap under ES only adds noise.
+    """
+    from autogluon.common.space import Categorical, Int, Real
+
+    from tabarena.utils.config_utils import ConfigGenerator
+
+    manual_configs = [{}]  # include the default config too
+    search_space = {
+        "learning_rate": Real(0.03, 0.3, log=True),
+        "depth": Int(4, 8),
+        "l2_leaf_reg": Real(0.1, 10.0, log=True),
+        "min_child_weight": Real(0.0, 8.0),
+        "subsample": Real(0.5, 1.0),
+        "colsample": Real(0.5, 1.0),
+        "leaf_estimation_iterations": Int(1, 5),
+        "max_bins": Categorical(128, 254),
+        "linear_leaves": Categorical(False, True),
+        "onehot_low_card": Categorical(False, True),
+        "cat_aware_binning": Categorical(False, True),
+        "cat_combinations_selective": Categorical(False, True),
+        "hs_lambda": Real(0.0, 4.0),
+    }
+
+    gen = ConfigGenerator(
+        model_cls=ChimeraBoostTunedModel,
+        manual_configs=manual_configs,
+        search_space=search_space,
+    )
+    return gen.generate_all_bag_experiments(
+        num_random_configs=num_random_configs, fold_fitting_strategy="sequential_local"
+    )

--- a/benchmarks/tabarena/run_chimera_e10.py
+++ b/benchmarks/tabarena/run_chimera_e10.py
@@ -1,0 +1,38 @@
+"""Run TabArena-Lite for ChimeraBoost_e10 (default config + n_ensembles=10).
+
+All 51 tasks are already cached locally, so this is pure offline compute
+(no OpenML). ~10x the default run's wall time (the 10 internal ensemble members
+train sequentially).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import openml
+import pandas as pd
+from chimeraboost_tabarena_model import get_configs_for_chimera_e10
+
+from tabarena.benchmark.experiment import run_experiments_new
+
+OUTPUT_DIR = r"A:\code\tabarena_out\chimera_e10"
+
+
+def _task_ids_from_csv() -> list[int]:
+    import tabarena as _ta
+    csv = Path(_ta.__file__).parent / "nips2025_utils" / "metadata" / "task_metadata_tabarena51.csv"
+    return pd.read_csv(csv)["tid"].tolist()
+
+
+def main():
+    openml.config.set_root_cache_directory(r"A:\code\openml")
+    task_ids = _task_ids_from_csv()
+    run_experiments_new(
+        output_dir=OUTPUT_DIR,
+        model_experiments=get_configs_for_chimera_e10(),
+        tasks=task_ids,
+        repetitions_mode="TabArena-Lite",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/tabarena/run_chimera_e10_eval.py
+++ b/benchmarks/tabarena/run_chimera_e10_eval.py
@@ -1,0 +1,41 @@
+"""Evaluate ChimeraBoost_e10 (default + n_ensembles=10) -> Elo.
+
+Mirrors run_chimera_eval.py but for the e10 method/output dir. Baseline pool is
+already cached from the default eval, so this is fast.
+"""
+from __future__ import annotations
+
+# Windows shim: TabArena calls os.sched_getaffinity (Linux-only) to count CPUs.
+import os
+if not hasattr(os, "sched_getaffinity"):
+    os.sched_getaffinity = lambda pid=0: set(range(os.cpu_count() or 1))
+
+from tabarena.nips2025_utils.end_to_end_single import (
+    EndToEndResultsSingle,
+    EndToEndSingle,
+)
+from tabarena.website.website_format import format_leaderboard
+
+PATH_RAW = r"A:\code\tabarena_out\chimera_e10"
+FIG_OUTPUT_DIR = r"A:\code\tabarena_out\evals\chimera_e10"
+METHOD = "ChimeraBoost_e10"  # == ChimeraBoostE10Model.ag_name
+
+if __name__ == "__main__":
+    end_to_end = EndToEndSingle.from_path_raw(path_raw=PATH_RAW)
+    _ = end_to_end.to_results()
+
+    end_to_end_results = EndToEndResultsSingle.from_cache(method=METHOD)
+    leaderboard = end_to_end_results.compare_on_tabarena(
+        only_valid_tasks=True, output_dir=FIG_OUTPUT_DIR
+    )
+    leaderboard_website = format_leaderboard(leaderboard)
+    md = leaderboard_website.to_markdown(index=False)
+    out_md = r"A:\code\tabarena_out\evals\chimera_e10_leaderboard.md"
+    with open(out_md, "w", encoding="utf-8") as fh:
+        fh.write(md)
+    leaderboard_website.to_csv(r"A:\code\tabarena_out\evals\chimera_e10_leaderboard.csv", index=False)
+    print(f"leaderboard written to {out_md}")
+    try:
+        print(md)
+    except UnicodeEncodeError:
+        print(md.encode("ascii", "replace").decode("ascii"))

--- a/benchmarks/tabarena/run_chimera_eval.py
+++ b/benchmarks/tabarena/run_chimera_eval.py
@@ -1,0 +1,45 @@
+"""Evaluate ChimeraBoost against the TabArena(-Lite) leaderboard -> Elo.
+
+Run AFTER run_chimera_lite.py has produced result artifacts in OUTPUT_DIR.
+Mirrors the official run_evaluate_model.py.
+"""
+from __future__ import annotations
+
+# Windows shim: TabArena calls os.sched_getaffinity (Linux-only) to count CPUs.
+import os
+if not hasattr(os, "sched_getaffinity"):
+    os.sched_getaffinity = lambda pid=0: set(range(os.cpu_count() or 1))
+
+from tabarena.nips2025_utils.end_to_end_single import (
+    EndToEndResultsSingle,
+    EndToEndSingle,
+)
+from tabarena.website.website_format import format_leaderboard
+
+PATH_RAW = r"A:\code\tabarena_out\chimera"
+FIG_OUTPUT_DIR = r"A:\code\tabarena_out\evals\chimera"
+METHOD = "ChimeraBoost"  # == ChimeraBoostModel.ag_name
+
+if __name__ == "__main__":
+    # 1. Load raw artifacts, process + cache results for our method.
+    end_to_end = EndToEndSingle.from_path_raw(path_raw=PATH_RAW)
+    _ = end_to_end.to_results()
+
+    # 2. Compare against the TabArena baseline pool -> leaderboard with Elo.
+    end_to_end_results = EndToEndResultsSingle.from_cache(method=METHOD)
+    leaderboard = end_to_end_results.compare_on_tabarena(
+        only_valid_tasks=True, output_dir=FIG_OUTPUT_DIR
+    )
+    leaderboard_website = format_leaderboard(leaderboard)
+    md = leaderboard_website.to_markdown(index=False)
+    out_md = r"A:\code\tabarena_out\evals\chimera_leaderboard.md"
+    with open(out_md, "w", encoding="utf-8") as fh:
+        fh.write(md)
+    # Save CSV too for easy ChimeraBoost-row extraction.
+    leaderboard_website.to_csv(r"A:\code\tabarena_out\evals\chimera_leaderboard.csv", index=False)
+    print(f"leaderboard written to {out_md}")
+    # Console print guarded against Windows charmap codec.
+    try:
+        print(md)
+    except UnicodeEncodeError:
+        print(md.encode("ascii", "replace").decode("ascii"))

--- a/benchmarks/tabarena/run_chimera_lite.py
+++ b/benchmarks/tabarena/run_chimera_lite.py
@@ -1,0 +1,52 @@
+"""Run TabArena-Lite for the custom ChimeraBoost model.
+
+Usage (from this directory, with the tabarena venv):
+    python run_chimera_lite.py --limit 2     # smoke test on 2 tasks
+    python run_chimera_lite.py               # full 51-task TabArena-Lite
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import openml
+import pandas as pd
+from chimeraboost_tabarena_model import get_configs_for_chimera
+
+from tabarena.benchmark.experiment import run_experiments_new
+
+OUTPUT_DIR = r"A:\code\tabarena_out\chimera"
+
+# Local task metadata ships with the repo — use it instead of the live API
+# (openml.study.get_suite("tabarena-v0.1") 503/502s transiently).
+def _task_ids_from_csv() -> list[int]:
+    import tabarena as _ta
+    csv = Path(_ta.__file__).parent / "nips2025_utils" / "metadata" / "task_metadata_tabarena51.csv"
+    return pd.read_csv(csv)["tid"].tolist()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=None,
+                    help="run only the first N tasks (smoke test); default = all 51")
+    args = ap.parse_args()
+
+    # Keep the OpenML dataset cache off C: (only ~4 GB free there).
+    openml.config.set_root_cache_directory(r"A:\code\openml")
+
+    task_ids = _task_ids_from_csv()
+    if args.limit:
+        task_ids = task_ids[: args.limit]
+
+    model_experiments = get_configs_for_chimera(num_random_configs=0)
+
+    run_experiments_new(
+        output_dir=OUTPUT_DIR,
+        model_experiments=model_experiments,
+        tasks=task_ids,
+        repetitions_mode="TabArena-Lite",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/tabarena/run_chimera_tuned.py
+++ b/benchmarks/tabarena/run_chimera_tuned.py
@@ -1,0 +1,58 @@
+"""Run FULL TabArena (all folds/repeats) with 200 random HP configs (tuned entry).
+
+Usage (from this directory, with the tabarena venv + A: env vars set):
+    python run_chimera_tuned.py --limit 2    # smoke test: 2 tasks
+    python run_chimera_tuned.py              # full 51-task run
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import openml
+import pandas as pd
+from chimeraboost_tabarena_model import get_configs_for_chimera_tuned
+
+from tabarena.benchmark.experiment import run_experiments_new
+from tabarena.nips2025_utils.fetch_metadata import load_curated_task_metadata
+
+OUTPUT_DIR = r"A:\code\tabarena_out\chimera_tuned"
+
+
+def _task_ids_from_csv() -> list[int]:
+    import tabarena as _ta
+    csv = Path(_ta.__file__).parent / "nips2025_utils" / "metadata" / "task_metadata_tabarena51.csv"
+    return pd.read_csv(csv)["tid"].tolist()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=None,
+                    help="run only the first N tasks (smoke test); default = all 51")
+    ap.add_argument("--num-random-configs", type=int, default=200,
+                    help="number of random HP configs (default 200)")
+    args = ap.parse_args()
+
+    openml.config.set_root_cache_directory(r"A:\code\openml")
+
+    task_ids = _task_ids_from_csv()
+    if args.limit:
+        task_ids = task_ids[: args.limit]
+
+    tasks_metadata = load_curated_task_metadata()
+
+    model_experiments = get_configs_for_chimera_tuned(num_random_configs=args.num_random_configs)
+    print(f"Running {len(model_experiments)} model configs on {len(task_ids)} tasks "
+          f"(repetitions_mode='TabArena' = all folds/repeats)")
+
+    run_experiments_new(
+        output_dir=OUTPUT_DIR,
+        model_experiments=model_experiments,
+        tasks=task_ids,
+        repetitions_mode="TabArena",
+        tasks_metadata=tasks_metadata,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/tabarena/run_chimera_tuned_eval.py
+++ b/benchmarks/tabarena/run_chimera_tuned_eval.py
@@ -1,0 +1,41 @@
+"""Evaluate ChimeraBoost_tuned against the TabArena leaderboard -> Elo.
+
+Run AFTER run_chimera_tuned.py has produced result artifacts in OUTPUT_DIR.
+"""
+from __future__ import annotations
+
+import os
+if not hasattr(os, "sched_getaffinity"):
+    os.sched_getaffinity = lambda pid=0: set(range(os.cpu_count() or 1))
+
+from tabarena.nips2025_utils.end_to_end_single import (
+    EndToEndResultsSingle,
+    EndToEndSingle,
+)
+from tabarena.website.website_format import format_leaderboard
+
+PATH_RAW = r"A:\code\tabarena_out\chimera_tuned"
+FIG_OUTPUT_DIR = r"A:\code\tabarena_out\evals\chimera_tuned"
+METHOD = "ChimeraBoost_tuned"  # == ChimeraBoostTunedModel.ag_name
+
+if __name__ == "__main__":
+    end_to_end = EndToEndSingle.from_path_raw(path_raw=PATH_RAW)
+    _ = end_to_end.to_results()
+
+    end_to_end_results = EndToEndResultsSingle.from_cache(method=METHOD)
+    leaderboard = end_to_end_results.compare_on_tabarena(
+        only_valid_tasks=True, output_dir=FIG_OUTPUT_DIR
+    )
+    leaderboard_website = format_leaderboard(leaderboard)
+    md = leaderboard_website.to_markdown(index=False)
+    out_md = r"A:\code\tabarena_out\evals\chimera_tuned_leaderboard.md"
+    with open(out_md, "w", encoding="utf-8") as fh:
+        fh.write(md)
+    leaderboard_website.to_csv(
+        r"A:\code\tabarena_out\evals\chimera_tuned_leaderboard.csv", index=False
+    )
+    print(f"leaderboard written to {out_md}")
+    try:
+        print(md)
+    except UnicodeEncodeError:
+        print(md.encode("ascii", "replace").decode("ascii"))

--- a/benchmarks/tabarena/run_chimera_tuned_lite.py
+++ b/benchmarks/tabarena/run_chimera_tuned_lite.py
@@ -1,0 +1,54 @@
+"""Run TabArena-Lite (51 tasks, 1 fold each) with 200 random HP configs (tuned entry).
+
+Usage (from this directory, with the tabarena venv + A: env vars set):
+    python run_chimera_tuned_lite.py --limit 2    # smoke test: 2 tasks
+    python run_chimera_tuned_lite.py              # full 51-task run
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import openml
+import pandas as pd
+from chimeraboost_tabarena_model import get_configs_for_chimera_tuned
+
+from tabarena.benchmark.experiment import run_experiments_new
+
+OUTPUT_DIR = r"A:\code\tabarena_out\chimera_tuned_lite"
+
+
+def _task_ids_from_csv() -> list[int]:
+    import tabarena as _ta
+    csv = Path(_ta.__file__).parent / "nips2025_utils" / "metadata" / "task_metadata_tabarena51.csv"
+    return pd.read_csv(csv)["tid"].tolist()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=None,
+                    help="run only the first N tasks (smoke test); default = all 51")
+    ap.add_argument("--num-random-configs", type=int, default=200,
+                    help="number of random HP configs (default 200)")
+    args = ap.parse_args()
+
+    openml.config.set_root_cache_directory(r"A:\code\openml")
+
+    task_ids = _task_ids_from_csv()
+    if args.limit:
+        task_ids = task_ids[: args.limit]
+
+    model_experiments = get_configs_for_chimera_tuned(num_random_configs=args.num_random_configs)
+    print(f"Running {len(model_experiments)} model configs on {len(task_ids)} tasks "
+          f"(repetitions_mode='TabArena-Lite' = 1 fold each)")
+
+    run_experiments_new(
+        output_dir=OUTPUT_DIR,
+        model_experiments=model_experiments,
+        tasks=task_ids,
+        repetitions_mode="TabArena-Lite",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/tabarena/run_chimera_tuned_lite.py
+++ b/benchmarks/tabarena/run_chimera_tuned_lite.py
@@ -30,6 +30,11 @@ def main():
                     help="run only the first N tasks (smoke test); default = all 51")
     ap.add_argument("--num-random-configs", type=int, default=200,
                     help="number of random HP configs (default 200)")
+    ap.add_argument("--output-dir", default=OUTPUT_DIR,
+                    help="result dir. ALWAYS use a scratch dir for smoke runs: "
+                         "config names (r1..rN) are position-based, so cached "
+                         "smoke results would silently stand in for different "
+                         "configs in a full run.")
     args = ap.parse_args()
 
     openml.config.set_root_cache_directory(r"A:\code\openml")
@@ -43,7 +48,7 @@ def main():
           f"(repetitions_mode='TabArena-Lite' = 1 fold each)")
 
     run_experiments_new(
-        output_dir=OUTPUT_DIR,
+        output_dir=args.output_dir,
         model_experiments=model_experiments,
         tasks=task_ids,
         repetitions_mode="TabArena-Lite",

--- a/benchmarks/tabarena/run_chimera_tuned_lite_eval.py
+++ b/benchmarks/tabarena/run_chimera_tuned_lite_eval.py
@@ -1,0 +1,41 @@
+"""Evaluate ChimeraBoost_tuned (Lite) against the TabArena leaderboard -> Elo.
+
+Run AFTER run_chimera_tuned_lite.py has produced result artifacts.
+"""
+from __future__ import annotations
+
+import os
+if not hasattr(os, "sched_getaffinity"):
+    os.sched_getaffinity = lambda pid=0: set(range(os.cpu_count() or 1))
+
+from tabarena.nips2025_utils.end_to_end_single import (
+    EndToEndResultsSingle,
+    EndToEndSingle,
+)
+from tabarena.website.website_format import format_leaderboard
+
+PATH_RAW = r"A:\code\tabarena_out\chimera_tuned_lite"
+FIG_OUTPUT_DIR = r"A:\code\tabarena_out\evals\chimera_tuned_lite"
+METHOD = "ChimeraBoost_tuned"
+
+if __name__ == "__main__":
+    end_to_end = EndToEndSingle.from_path_raw(path_raw=PATH_RAW)
+    _ = end_to_end.to_results()
+
+    end_to_end_results = EndToEndResultsSingle.from_cache(method=METHOD)
+    leaderboard = end_to_end_results.compare_on_tabarena(
+        only_valid_tasks=True, output_dir=FIG_OUTPUT_DIR
+    )
+    leaderboard_website = format_leaderboard(leaderboard)
+    md = leaderboard_website.to_markdown(index=False)
+    out_md = r"A:\code\tabarena_out\evals\chimera_tuned_lite_leaderboard.md"
+    with open(out_md, "w", encoding="utf-8") as fh:
+        fh.write(md)
+    leaderboard_website.to_csv(
+        r"A:\code\tabarena_out\evals\chimera_tuned_lite_leaderboard.csv", index=False
+    )
+    print(f"leaderboard written to {out_md}")
+    try:
+        print(md)
+    except UnicodeEncodeError:
+        print(md.encode("ascii", "replace").decode("ascii"))


### PR DESCRIPTION
# What

Post-0.12.0 housekeeping + the TabArena tuned-entry tooling: durable copies of the
TabArena integration scripts (wrapper with native cat_features, default/e10/tuned
runners, eval), tuned search space v2 (core knobs + the default-off research flags
from benchmarks/research/SUMMARY.md), PMLB random-search study script, summarize
latest_json fix, PR template.

## Benchmark impact

- [x] No default behavior changes (benchmarks unaffected — chimeraboost/ untouched)

## Checklist

- [x] pytest green
- [x] TabArena-Lite untouched (tuned entry = in-protocol HPO, report-only; search
      space pre-registered from dev-side evidence)
- [x] CHANGELOG.md updated (n/a — no user-facing library change)
- [x] Docs updated (n/a)