### PR TITLE
Scaling benchmarks

### DIFF
--- a/benchmarks/scaling_giant.py
+++ b/benchmarks/scaling_giant.py
@@ -1,0 +1,205 @@
+"""Train-time scaling benchmark on large synthetic data.
+
+Question: how does ChimeraBoost's FIT time scale vs the C++ heavyweights
+(LightGBM / XGBoost / sklearn-HGB / CatBoost) as n grows into the millions?
+
+This is a controlled COMPUTE comparison, not an accuracy one:
+* Fixed tree count (`--trees`, default 200), NO early stopping -> every library
+  builds the same-sized forest, so we measure pure build throughput, not who
+  stops earliest.
+* Default tree shape per library (ChimeraBoost depth 6 / oblivious, XGB max_depth
+  6, LGBM num_leaves 31, HGB max_leaf_nodes 31, CatBoost depth 6) — i.e. what a
+  user gets out of the box. Bin counts are each library's default (noted below).
+* All cores for everyone. numba is warmed up on a tiny fit BEFORE timing so
+  ChimeraBoost's one-off JIT compile is not charged to the first size.
+
+Reports wall-clock fit seconds, throughput (Mrows/s), and s/1K-rows per (size,
+model). Synthetic binary classification (make_classification), 30 numeric feats.
+
+Usage:
+    python scaling_giant.py --sizes 100000,300000,1000000 --trees 200
+    python scaling_giant.py --sizes 1000000,3000000,5000000 --models ChimeraBoost,LightGBM,XGBoost
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from datetime import datetime
+
+import numpy as np
+
+
+def _gen(n, n_features=30, seed=0):
+    from sklearn.datasets import make_classification
+    X, y = make_classification(
+        n_samples=n, n_features=n_features, n_informative=15, n_redundant=5,
+        n_clusters_per_class=2, class_sep=0.8, random_state=seed,
+    )
+    return X.astype(np.float32), y.astype(np.int32)
+
+
+def _fit_chimera(X, y, trees, threads):
+    from chimeraboost import ChimeraBoostClassifier
+    m = ChimeraBoostClassifier(
+        n_estimators=trees, learning_rate=0.1, depth=6,
+        early_stopping=False, thread_count=threads, random_state=0,
+    )
+    t = time.perf_counter()
+    m.fit(X, y)
+    return time.perf_counter() - t
+
+
+def _fit_lightgbm(X, y, trees, threads):
+    import lightgbm as lgb
+    m = lgb.LGBMClassifier(
+        n_estimators=trees, learning_rate=0.1, num_leaves=31,
+        n_jobs=threads, random_state=0, verbosity=-1,
+    )
+    t = time.perf_counter()
+    m.fit(X, y)
+    return time.perf_counter() - t
+
+
+def _fit_xgboost(X, y, trees, threads):
+    import xgboost as xgb
+    m = xgb.XGBClassifier(
+        n_estimators=trees, learning_rate=0.1, max_depth=6,
+        tree_method="hist", n_jobs=threads, random_state=0, verbosity=0,
+    )
+    t = time.perf_counter()
+    m.fit(X, y)
+    return time.perf_counter() - t
+
+
+def _fit_sklearn(X, y, trees, threads):
+    from sklearn.ensemble import HistGradientBoostingClassifier
+    # HGB parallelises via OpenMP (no n_jobs arg); threads set via env in main().
+    m = HistGradientBoostingClassifier(
+        max_iter=trees, learning_rate=0.1, max_leaf_nodes=31,
+        early_stopping=False, random_state=0,
+    )
+    t = time.perf_counter()
+    m.fit(X, y)
+    return time.perf_counter() - t
+
+
+def _fit_catboost(X, y, trees, threads):
+    from catboost import CatBoostClassifier
+    m = CatBoostClassifier(
+        n_estimators=trees, learning_rate=0.1, depth=6,
+        thread_count=threads, verbose=False, random_seed=0,
+    )
+    t = time.perf_counter()
+    m.fit(X, y)
+    return time.perf_counter() - t
+
+
+FITTERS = {
+    "ChimeraBoost": _fit_chimera,
+    "LightGBM": _fit_lightgbm,
+    "XGBoost": _fit_xgboost,
+    "sklearn_HGB": _fit_sklearn,
+    "CatBoost": _fit_catboost,
+}
+
+
+def _available(names):
+    ok = []
+    for n in names:
+        if n == "ChimeraBoost":
+            ok.append(n); continue
+        mod = {"LightGBM": "lightgbm", "XGBoost": "xgboost",
+               "sklearn_HGB": "sklearn", "CatBoost": "catboost"}[n]
+        try:
+            __import__(mod); ok.append(n)
+        except ImportError:
+            print(f"  (skip {n}: {mod} not installed)")
+    return ok
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--sizes", default="100000,300000,1000000",
+                    help="comma-separated row counts")
+    ap.add_argument("--trees", type=int, default=200)
+    ap.add_argument("--features", type=int, default=30)
+    ap.add_argument("--threads", type=int, default=0,
+                    help="thread budget per model (0 = all cores)")
+    ap.add_argument("--models", default=",".join(FITTERS))
+    ap.add_argument("--out", default=None, help="json output path")
+    args = ap.parse_args()
+
+    threads = args.threads or (os.cpu_count() or 1)
+    # HGB uses OpenMP threads, not an n_jobs arg.
+    os.environ["OMP_NUM_THREADS"] = str(threads)
+
+    sizes = [int(s) for s in args.sizes.split(",")]
+    models = _available([m.strip() for m in args.models.split(",")])
+    print(f"threads={threads}  trees={args.trees}  features={args.features}")
+    print(f"models={models}")
+    print(f"sizes={sizes}\n")
+
+    # Warm up every model (esp. ChimeraBoost's numba JIT) on a tiny fit so the
+    # one-off compile cost is not charged to the first real size.
+    print("warming up (JIT compile, import)...")
+    Xw, yw = _gen(2000, args.features, seed=99)
+    for name in models:
+        try:
+            FITTERS[name](Xw, yw, min(args.trees, 20), threads)
+        except Exception as e:
+            print(f"  warmup {name} failed: {e}")
+    print("warm.\n")
+
+    results = {}
+    for n in sizes:
+        print(f"=== n={n:,} ===")
+        X, y = _gen(n, args.features, seed=0)
+        for name in models:
+            try:
+                secs = FITTERS[name](X, y, args.trees, threads)
+                thrpt = n / secs / 1e6           # Mrows/s
+                s_per_1k = secs / (n / 1000.0)
+                results.setdefault(name, {})[n] = secs
+                print(f"  {name:14s} {secs:8.2f}s   {thrpt:6.3f} Mrows/s   "
+                      f"{s_per_1k:7.4f} s/1K")
+            except Exception as e:
+                print(f"  {name:14s} FAILED: {e}")
+        del X, y
+        print()
+
+    # Summary table: rows = sizes, cols = models (fit seconds).
+    print("\n===== FIT TIME (seconds) =====")
+    hdr = "rows".rjust(12) + "".join(m.rjust(14) for m in models)
+    print(hdr)
+    for n in sizes:
+        row = f"{n:12,}" + "".join(
+            f"{results.get(m, {}).get(n, float('nan')):14.2f}" for m in models)
+        print(row)
+
+    # Speedup vs ChimeraBoost (×: >1 means competitor is faster).
+    if "ChimeraBoost" in models:
+        print("\n===== SPEED RATIO vs ChimeraBoost (>1 = competitor faster) =====")
+        print(hdr)
+        for n in sizes:
+            cb = results.get("ChimeraBoost", {}).get(n)
+            cells = []
+            for m in models:
+                v = results.get(m, {}).get(n)
+                cells.append(f"{(cb / v):14.2f}" if (cb and v) else "nan".rjust(14))
+            print(f"{n:12,}" + "".join(cells))
+
+    out = args.out or os.path.join(
+        os.path.dirname(__file__), "results",
+        f"scaling-{datetime.now():%Y%m%d-%H%M%S}.json")
+    os.makedirs(os.path.dirname(out), exist_ok=True)
+    with open(out, "w") as f:
+        json.dump({"meta": vars(args), "threads": threads,
+                   "results": {m: {str(k): v for k, v in d.items()}
+                               for m, d in results.items()}}, f, indent=2)
+    print(f"\nsaved {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/scaling_predict.py
+++ b/benchmarks/scaling_predict.py
@@ -1,0 +1,112 @@
+"""Inference (predict) throughput at scale: ChimeraBoost vs the C++ heavyweights.
+
+Companion to scaling_giant.py (which measures FIT). Fits each model once on a
+fixed training set (200 trees, default shape), then times predict_proba on a
+large held-out batch — the metric that matters for serving. Reports rows/s.
+
+Usage:
+    python scaling_predict.py --train 200000 --predict 2000000 --trees 200
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import time
+
+import numpy as np
+from scaling_giant import _gen  # reuse the synthetic generator
+
+
+def _bench(name, fit_fn, predict_fn, Xtr, ytr, Xpred, trees, threads, reps=3):
+    model = fit_fn(Xtr, ytr, trees, threads)
+    predict_fn(model, Xpred[:1000])  # warm
+    best = min(_time(predict_fn, model, Xpred) for _ in range(reps))
+    return best
+
+
+def _time(predict_fn, model, X):
+    t = time.perf_counter()
+    predict_fn(model, X)
+    return time.perf_counter() - t
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--train", type=int, default=200000)
+    ap.add_argument("--predict", type=int, default=2000000)
+    ap.add_argument("--trees", type=int, default=200)
+    ap.add_argument("--features", type=int, default=30)
+    ap.add_argument("--threads", type=int, default=0)
+    args = ap.parse_args()
+    threads = args.threads or (os.cpu_count() or 1)
+    os.environ["OMP_NUM_THREADS"] = str(threads)
+
+    def cb_fit(X, y, trees, th):
+        from chimeraboost import ChimeraBoostClassifier
+        m = ChimeraBoostClassifier(n_estimators=trees, depth=6, learning_rate=0.1,
+                                   early_stopping=False, thread_count=th, random_state=0)
+        return m.fit(X, y)
+
+    def lgb_fit(X, y, trees, th):
+        import lightgbm as lgb
+        return lgb.LGBMClassifier(n_estimators=trees, num_leaves=31, learning_rate=0.1,
+                                  n_jobs=th, random_state=0, verbosity=-1).fit(X, y)
+
+    def xgb_fit(X, y, trees, th):
+        import xgboost as xgb
+        return xgb.XGBClassifier(n_estimators=trees, max_depth=6, learning_rate=0.1,
+                                 tree_method="hist", n_jobs=th, random_state=0,
+                                 verbosity=0).fit(X, y)
+
+    def hgb_fit(X, y, trees, th):
+        from sklearn.ensemble import HistGradientBoostingClassifier
+        return HistGradientBoostingClassifier(max_iter=trees, max_leaf_nodes=31,
+                                              learning_rate=0.1, early_stopping=False,
+                                              random_state=0).fit(X, y)
+
+    def cat_fit(X, y, trees, th):
+        from catboost import CatBoostClassifier
+        return CatBoostClassifier(n_estimators=trees, depth=6, learning_rate=0.1,
+                                  thread_count=th, verbose=False, random_seed=0).fit(X, y)
+
+    models = {
+        "ChimeraBoost": (cb_fit, lambda m, X: m.predict_proba(X)),
+        "LightGBM": (lgb_fit, lambda m, X: m.predict_proba(X)),
+        "XGBoost": (xgb_fit, lambda m, X: m.predict_proba(X)),
+        "sklearn_HGB": (hgb_fit, lambda m, X: m.predict_proba(X)),
+        "CatBoost": (cat_fit, lambda m, X: m.predict_proba(X)),
+    }
+    avail = {}
+    for n, v in models.items():
+        if n == "ChimeraBoost":
+            avail[n] = v; continue
+        mod = {"LightGBM": "lightgbm", "XGBoost": "xgboost",
+               "sklearn_HGB": "sklearn", "CatBoost": "catboost"}[n]
+        try:
+            __import__(mod); avail[n] = v
+        except ImportError:
+            print(f"(skip {n})")
+
+    print(f"train={args.train:,}  predict={args.predict:,}  trees={args.trees}  threads={threads}\n")
+    Xtr, ytr = _gen(args.train, args.features, seed=0)
+    Xpred, _ = _gen(args.predict, args.features, seed=1)
+
+    print(f"{'model':14s}{'predict s':>12s}{'Mrows/s':>12s}")
+    rows = {}
+    for name, (fit_fn, pred_fn) in avail.items():
+        try:
+            secs = _bench(name, fit_fn, pred_fn, Xtr, ytr, Xpred, args.trees, threads)
+            rows[name] = args.predict / secs / 1e6
+            print(f"{name:14s}{secs:12.3f}{rows[name]:12.3f}")
+        except Exception as e:
+            print(f"{name:14s} FAILED: {e}")
+
+    if "ChimeraBoost" in rows:
+        print("\npredict speed ratio (ChimeraBoost / competitor; >1 = ChimeraBoost faster):")
+        for name in avail:
+            if name != "ChimeraBoost" and name in rows:
+                print(f"  vs {name:12s} {rows['ChimeraBoost']/rows[name]:.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/chimeraboost/binning.py
+++ b/chimeraboost/binning.py
@@ -12,11 +12,45 @@ The histogram width for a feature is therefore (n_borders + 2).
 """
 
 import numpy as np
+from numba import njit, prange
 
 BIN_DTYPE = np.uint16
 # uint16 max is 65535; we reserve one slot for NaN, so the cap is 65534.
 # In practice 128-256 bins is the useful range; this guard just catches typos.
 _MAX_SUPPORTED_BINS = np.iinfo(BIN_DTYPE).max - 1
+
+
+@njit(cache=True, parallel=True)
+def _bin_matrix(X, borders_flat, offsets, out):
+    """Map every (row, feature) of X to its integer bin, in parallel over rows.
+
+    Equivalent to, per feature f with borders b = borders_flat[offsets[f]:offsets[f+1]]:
+        finite v -> np.searchsorted(b, v, side="right")   (count of borders <= v)
+        non-finite v (NaN / +-inf) -> len(b) + 1          (the NaN/missing bin)
+    Parallelised over rows so each thread reads a contiguous X row and writes a
+    contiguous `out` row (cache-friendly on the row-major matrices), replacing the
+    per-column single-threaded np.searchsorted loop.
+    """
+    n, nf = X.shape
+    for i in prange(n):
+        for f in range(nf):
+            lo = offsets[f]
+            hi = offsets[f + 1]
+            m = hi - lo                      # number of borders for feature f
+            v = X[i, f]
+            if not np.isfinite(v):
+                out[i, f] = m + 1            # NaN / inf -> missing bin
+            else:
+                # rightmost insertion point == count of borders <= v.
+                a = lo
+                b = hi
+                while a < b:
+                    mid = (a + b) // 2
+                    if borders_flat[mid] <= v:
+                        a = mid + 1
+                    else:
+                        b = mid
+                out[i, f] = a - lo
 
 
 def _feature_borders(col, max_bins):
@@ -55,6 +89,8 @@ class Binner:
         self.borders_ = None       # list of np.ndarray, one per feature
         self.n_bins_ = None        # np.ndarray int, width per feature
         self.bin_centers_ = None   # list of np.ndarray: representative value/bin
+        self._borders_flat = None  # contiguous borders for the numba kernel
+        self._offsets = None       # int64 (n_features+1) prefix offsets into flat
 
     def _max_bins_for(self, f):
         """Per-feature bin budget: a scalar applies to all features, an array
@@ -101,20 +137,31 @@ class Binner:
             [len(b) + 2 for b in self.borders_], dtype=np.int64
         )
         self.bin_centers_ = [self._centers_for(b) for b in self.borders_]
+        self._build_flat_borders()
         return self
+
+    def _build_flat_borders(self):
+        """Flatten the ragged per-feature borders into one contiguous array plus
+        offsets, so the numba kernel can index feature f's borders as
+        borders_flat[offsets[f]:offsets[f+1]]. Cached on the instance."""
+        lens = [len(b) for b in self.borders_]
+        self._offsets = np.zeros(len(self.borders_) + 1, dtype=np.int64)
+        self._offsets[1:] = np.cumsum(lens)
+        self._borders_flat = (np.concatenate(self.borders_).astype(np.float64)
+                              if self.borders_ else np.zeros(0, dtype=np.float64))
 
     def transform(self, X):
         """Map a float matrix to integer bin indices; NaNs go to the top bin."""
-        X = np.asarray(X, dtype=np.float64)
+        X = np.ascontiguousarray(X, dtype=np.float64)
         n_samples, n_features = X.shape
+        # Lazily (re)build the flat border layout if missing — e.g. when borders_
+        # were set without going through fit().
+        if getattr(self, "_borders_flat", None) is None or \
+                len(self._offsets) != n_features + 1:
+            self._build_flat_borders()
         out = np.empty((n_samples, n_features), dtype=BIN_DTYPE)
-        for f in range(n_features):
-            col = X[:, f]
-            borders = self.borders_[f]
-            nan_bin = len(borders) + 1
-            binned = np.searchsorted(borders, col, side="right").astype(BIN_DTYPE)
-            binned[~np.isfinite(col)] = nan_bin
-            out[:, f] = binned
+        if n_samples:
+            _bin_matrix(X, self._borders_flat, self._offsets, out)
         return out
 
     def fit_transform(self, X):

--- a/tests/test_chimeraboost.py
+++ b/tests/test_chimeraboost.py
@@ -9,6 +9,38 @@ from sklearn.metrics import roc_auc_score, mean_squared_error
 from chimeraboost import ChimeraBoostRegressor, ChimeraBoostClassifier
 
 
+def test_binning_transform_matches_searchsorted_reference():
+    """The njit row-parallel binning kernel must be bit-identical to the old
+    per-column np.searchsorted(side='right') logic, including NaN/+-inf routing to
+    the missing bin and few-distinct/constant columns. Guards the predict-time
+    binning speedup (the kernel is ~half of inference cost)."""
+    from chimeraboost.binning import Binner, BIN_DTYPE
+
+    def reference(binner, X):
+        X = np.asarray(X, dtype=np.float64)
+        out = np.empty(X.shape, dtype=BIN_DTYPE)
+        for f in range(X.shape[1]):
+            col = X[:, f]
+            borders = binner.borders_[f]
+            binned = np.searchsorted(borders, col, side="right").astype(BIN_DTYPE)
+            binned[~np.isfinite(col)] = len(borders) + 1
+            out[:, f] = binned
+        return out
+
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(4000, 10))
+    X[:, 2] = rng.integers(0, 4, size=4000)          # few distinct values
+    X[:, 5] = 1.0                                      # constant column
+    X[rng.integers(0, 4000, 300), rng.integers(0, 10, 300)] = np.nan
+    X[rng.integers(0, 4000, 100), rng.integers(0, 10, 100)] = np.inf
+    X[rng.integers(0, 4000, 100), rng.integers(0, 10, 100)] = -np.inf
+
+    bn = Binner(max_bins=64).fit(X)
+    assert np.array_equal(bn.transform(X), reference(bn, X))
+    assert np.array_equal(bn.transform(X[:1]), reference(bn, X[:1]))  # single row
+    assert bn.transform(X[:0]).shape == (0, 10)                       # empty
+
+
 def test_regressor_beats_mean_baseline():
     X, y = load_diabetes(return_X_y=True)
     Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.2, random_state=0)


### PR DESCRIPTION
# What

Adds giant-data scaling benchmarks (`benchmarks/scaling_giant.py` train,
`scaling_predict.py` predict), and — motivated by what they exposed —
parallelizes the predict-time binning transform with an njit row-parallel
kernel, making inference ~1.9× faster (parity with LightGBM).

## Benchmark impact

- [x] Default/algorithm change — but it's a pure-speed change with **bit-identical
      output** (new regression test `test_binning_transform_matches_searchsorted_reference`
      covers NaN/±inf/few-distinct/constant/single-row/empty). No accuracy change,
      so the Grinsztajn/OpenML numbers are untouched.

## Checklist

- [x] pytest green (125 passing)
- [x] TabArena-Lite untouched (no decision used it; speed-only change)
- [ ] CHANGELOG.md updated  ← worth a line: "1.9× faster inference via parallel binning"
- [x] Docs updated (n/a — internal, no API change)
