### PR TITLE
Parallelize per-level leaf descent (njit) -> ~1.4x faster fit

### DIFF
--- a/chimeraboost/tree.py
+++ b/chimeraboost/tree.py
@@ -46,6 +46,21 @@ def _build_histograms_into(Xb, grad, hess, leaf, n_leaves, hist):
 
 
 @njit(cache=True, parallel=True)
+def _descend_leaves(leaf, Xf, t):
+    """Push every sample one level deeper, in place: leaf = (leaf<<1) + (Xf > t).
+
+    Replaces the per-level numpy expression
+    ``leaf = (leaf << 1) + (Xb[f] > t).astype(np.int64)`` which allocated several
+    n-sample temporaries (the bool mask, its int64 cast, the shifted array, the
+    sum) on every one of the (max_depth x n_trees) level steps — measured at ~⅓
+    of total fit time. One parallel pass over the contiguous feature row, no
+    temporaries; bit-identical bucketing.
+    """
+    for i in prange(leaf.shape[0]):
+        leaf[i] = (leaf[i] << 1) + (1 if Xf[i] > t else 0)
+
+
+@njit(cache=True, parallel=True)
 def _best_split(hist, n_bins_per_feature, l2, feat_mask, min_child_weight,
                 n_leaves):
     """Find the (feature, threshold) with the highest total gain.
@@ -698,8 +713,9 @@ def build_oblivious_tree(Xb, grad, hess, n_bins_per_feature,
         splits_thr.append(t)
         splits_gain.append(gain)
         # Push each sample one bit deeper from the just-chosen split. Xb[f] is
-        # a contiguous row, so this re-bucketing reads sequentially.
-        leaf = (leaf << 1) + (Xb[f] > t).astype(np.int64)
+        # a contiguous row, so this re-bucketing reads sequentially. In-place
+        # njit pass (no per-level n-sample temporaries); see _descend_leaves.
+        _descend_leaves(leaf, Xb[f], t)
 
     sf = np.array(splits_feat, dtype=np.int64)
     st = np.array(splits_thr, dtype=np.int64)

--- a/tests/test_chimeraboost.py
+++ b/tests/test_chimeraboost.py
@@ -9,6 +9,26 @@ from sklearn.metrics import roc_auc_score, mean_squared_error
 from chimeraboost import ChimeraBoostRegressor, ChimeraBoostClassifier
 
 
+def test_descend_leaves_matches_numpy_reference():
+    """The in-place njit per-level leaf descent must equal the old numpy
+    expression `(leaf<<1) + (Xf > t).astype(int64)` exactly, across leaf depths,
+    bin values and thresholds (incl. t=-1 and t at the max bin). Guards the
+    fit-time speedup (the descent was ~1/3 of fit)."""
+    from chimeraboost.tree import _descend_leaves
+
+    rng = np.random.default_rng(0)
+    for _ in range(300):
+        n = int(rng.integers(1, 6000))
+        d = int(rng.integers(0, 6))
+        leaf = rng.integers(0, 1 << d, size=n).astype(np.int64)
+        Xf = rng.integers(0, 260, size=n).astype(np.uint16)
+        t = int(rng.integers(-1, 260))
+        ref = (leaf << 1) + (Xf > t).astype(np.int64)
+        got = leaf.copy()
+        _descend_leaves(got, Xf, t)
+        assert np.array_equal(ref, got)
+
+
 def test_binning_transform_matches_searchsorted_reference():
     """The njit row-parallel binning kernel must be bit-identical to the old
     per-column np.searchsorted(side='right') logic, including NaN/+-inf routing to


### PR DESCRIPTION
# What
Parallelize the per-level leaf descent in build_oblivious_tree with an njit
in-place kernel. Profiling showed the old numpy `leaf = (leaf<<1) + (Xb[f]>t)
.astype(int64)` was ~1/3 of fit time (4 n-sample allocations per level-step).

## Benchmark impact
- [x] Speed-only, bit-identical output (300-trial randomized equivalence test);
      Grinsztajn/OpenML numbers untouched.

## Checklist
- [x] pytest green (125)
- [x] TabArena-Lite untouched (speed-only)
- [ ] CHANGELOG.md — worth a line: "~1.4x faster fit via parallelized leaf descent"
- [x] Docs (n/a)
