### PR TITLE
TabArena submission: 0.13.0, model package, wrapper + review fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to ChimeraBoost are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.13.0] - 2026-06-15
 ### Changed
 - **Faster inference (~1.9×) and fit (~1.4×).** Predict-time bin assignment and
   the per-level leaf descent during tree building are now parallel numba kernels

--- a/benchmarks/knob_characterization.py
+++ b/benchmarks/knob_characterization.py
@@ -83,7 +83,6 @@ KNOBS = {
     "subsample":                  dict(values=[0.8, 0.5],           group="all"),
     "colsample":                  dict(values=[0.8, 0.5],           group="all"),
     "leaf_estimation_iterations": dict(values=[1, 3, 5, 10],        group="all"),
-    "hs_lambda":                  dict(values=[1.0, 5.0, 20.0],     group="all"),
     "max_bins":                   dict(values=[64, 128, 254],       group="all"),
     # Baseline patience is 50. "Better by Default" (arXiv 2407.04491) found
     # patience ~300 helps classifiers; probe whether it generalizes here.

--- a/benchmarks/random_search.py
+++ b/benchmarks/random_search.py
@@ -54,15 +54,13 @@ def sample_config(rng):
         min_child_weight=float(rng.choice([0.0, 1.0, 5.0, 20.0])),
         leaf_estimation_iterations=int(rng.choice([1, 3, 5, 10])),
         ordered_boosting=bool(rng.choice([False, True])),
-        hs_lambda=float(rng.choice([0.0, 0.5, 1.0])),
     )
 
 
 # Knobs treated as ordinal/continuous for the correlation analysis (ordered_boosting
 # is binary and handled separately).
 NUMERIC_KNOBS = ["learning_rate", "depth", "l2_leaf_reg", "max_bins", "subsample",
-                 "colsample", "min_child_weight", "leaf_estimation_iterations",
-                 "hs_lambda"]
+                 "colsample", "min_child_weight", "leaf_estimation_iterations"]
 
 
 def _fit_score(task, X, y, cat, cfg, seed, threads):
@@ -209,7 +207,7 @@ def analyze(payload):
     print("\n=== Marginal: mean rel_impr by knob value (pooled; 0% = ties default) ===")
     discrete = {"max_bins": [64, 128, 254], "subsample": [0.6, 0.8, 1.0],
                 "colsample": [0.6, 0.8, 1.0], "min_child_weight": [0.0, 1.0, 5.0, 20.0],
-                "leaf_estimation_iterations": [1, 3, 5, 10], "hs_lambda": [0.0, 0.5, 1.0]}
+                "leaf_estimation_iterations": [1, 3, 5, 10]}
     for knob, vals in discrete.items():
         parts = []
         for v in vals:

--- a/benchmarks/tabarena/README.md
+++ b/benchmarks/tabarena/README.md
@@ -11,7 +11,7 @@ are report-only and must never feed back into source or default choices.**
 | `chimeraboost_tabarena_model.py` | AutoGluon `AbstractModel` wrapper (native `cat_features` passed through) + config generators. Must stay a separate file — TabArena pickles the class. |
 | `run_chimera_lite.py` / `run_chimera_eval.py` | Default-config entry (1 config, 51 tasks) + Elo eval. |
 | `run_chimera_e10.py` / `run_chimera_e10_eval.py` | `n_ensembles=10` variant as a separate entry. |
-| `run_chimera_tuned_lite.py` / `run_chimera_tuned_lite_eval.py` | Tuned entry: default + 200 random configs (TabArena convention). Search space = core knobs + the default-off research flags (see `benchmarks/research/SUMMARY.md`). |
+| `run_chimera_tuned_lite.py` / `run_chimera_tuned_lite_eval.py` | Tuned entry: default + 200 random configs (TabArena convention). Search space = core capacity/regularization knobs + surviving categorical/leaf knobs (`cat_smoothing`, `cat_n_permutations`, `linear_leaves`/`linear_lambda`, `ordered_boosting`). The 8 default-off research flags were removed from the model in the June de-slop pass, so they are no longer searchable. |
 | `run_chimera_tuned.py` / `run_chimera_tuned_eval.py` | Full-repetitions variant of the tuned run (all folds/repeats). ~30x Lite cost; unused so far. |
 
 ## Environment (Windows box; keep everything off C:!)

--- a/benchmarks/tabarena/SUBMISSION.md
+++ b/benchmarks/tabarena/SUBMISSION.md
@@ -1,76 +1,69 @@
 # TabArena submission — ChimeraBoost (default entry)
 
-Ready-to-paste drafts for the two-step community submission. Step A = model
-integration issue (tabarena.ai/code). Step B = results PR
-(tabarena.ai/community-results). Submitting the **default** row first; the tuned
-row follows after the ~2–3-week full-tuned run.
+How models are *actually* added (per the OrionMSP PR #303 to autogluon/tabarena):
+a single **`[New Model]` pull request** to a fork of `github.com/autogluon/tabarena`
+that (1) adds the model package, (2) carries a concise description + confirmation
+statement, and (3) posts results in the PR. A maintainer reviews and verifies.
+We submit the **default** row first; the tuned row follows the full-tuned run.
 
-Status of the technical gates (all green as of 2026-06-15):
-- ✅ Public `AbstractModel` impl: [`chimeraboost_tabarena_model.py`](chimeraboost_tabarena_model.py); library at https://github.com/bbstats/chimeraboost (`pip install chimeraboost`).
-- ✅ Passes the default model unit test: [`model_unittest.py`](model_unittest.py) → 3/3 (binary/multiclass/regression) via AutoGluon `FitHelper`.
-- ✅ Default hyperparameters + HPO search space specified (below).
-- ✅ Promising results on TabArena-Lite (Elo 1211) and full TabArena (Elo 1220).
+## Technical gates (all green as of 2026-06-15)
+- ✅ Public `AbstractModel` impl — library https://github.com/bbstats/chimeraboost (`pip install chimeraboost`); wrapper [`chimeraboost_tabarena_model.py`](chimeraboost_tabarena_model.py).
+- ✅ Passes the default model unit test — [`model_unittest.py`](model_unittest.py) → 3/3 (binary/multiclass/regression) via AutoGluon `FitHelper`.
+- ✅ Default hyperparameters + HPO search space specified (in the package below).
+- ✅ Results: TabArena-Lite Elo 1211; full TabArena Elo 1220 (rank 39/70), 0 failures.
 
----
-
-## Step A — Model integration issue
-
-**Title:** Add model: ChimeraBoost (pure-Python CatBoost-inspired oblivious GBDT)
-
-**1. Public model implementation.**
-ChimeraBoost is a standalone gradient-boosting model (not an ensembling pipeline):
-oblivious/symmetric trees, histogram split-finding, ordered target-statistics for
-categoricals — implemented in pure Python + numba, no heavy deps. Library:
-https://github.com/bbstats/chimeraboost (`pip install chimeraboost`). AutoGluon
-`AbstractModel` wrapper: `benchmarks/tabarena/chimeraboost_tabarena_model.py`
-(`ag_key="CHIMERA"`, `ag_name="ChimeraBoost"`). Passes the default unit test
-(`model_unittest.py`, `FitHelper.fit_and_validate_dataset`, 3/3 problem types).
-
-**2. Preprocessing and hyperparameters.**
-- Preprocessing: AutoGluon `LabelEncoderFeatureGenerator` for categoricals; the
-  categorical column indices are passed to ChimeraBoost as `cat_features` so it
-  applies its native ordered-target-statistics encoding (numeric features passed
-  through; NaN routed to a missing bin).
-- Default hyperparameters: `n_estimators=500`, `early_stopping=True` (internal
-  validation split), `thread_count=-1`, `random_state=0`; all other knobs at
-  library defaults (depth=6, learning_rate auto, l2_leaf_reg=1.0, max_bins=128…).
-- HPO search space (200 random configs, TabArena convention):
-  `learning_rate` LogReal(0.03,0.3), `depth` Int(4,8), `l2_leaf_reg`
-  LogReal(0.1,10), `min_child_weight` Real(0,8), `subsample` Real(0.5,1),
-  `colsample` Real(0.5,1), `leaf_estimation_iterations` Int(1,5), `max_bins`
-  Cat(128,254), `linear_leaves` Cat(F,T), `linear_lambda` LogReal(0.1,10),
-  `cat_smoothing` LogReal(0.1,10), `cat_n_permutations` Int(1,8),
-  `ordered_boosting` Cat(F,T). (`n_estimators` fixed at 1500 + early stopping.)
-
-**3. Model verification.**
-TabArena-Lite default = Elo 1211; full TabArena default = Elo 1220 (rank 39/70),
-beating default XGBoost (1210) and LightGBM (1184), below CatBoost-default
-(1359), at the fastest tree-model train time on the board (0.59 s/1K). I am the
-original author of ChimeraBoost.
-
-**4. Maintenance commitment.**
-Preferred contact: GitHub @bbstats (issues on bbstats/chimeraboost). Pure-Python
-+ numba, no GPU/foundation-model deps → low version-conflict surface.
+## The PR contents
+1. **Model package** — `upstream_pr/chimeraboost/` (`model.py`, `hpo.py`, `info.py`, `__init__.py`), copied to `tabarena/tabarena/models/chimeraboost/` in your fork. Plus the public-class registration. See [`upstream_pr/REGISTER.md`](upstream_pr/REGISTER.md).
+2. **Results** — full-default leaderboard (Elo 1220) posted as a PR comment + a link to the raw results zip (host the `chimera_full` artifacts somewhere public, e.g. a release asset).
 
 ---
 
-## Step B — Results PR (default entry)
+## PR description (paste into the PR body)
 
-**Contents:**
-- (a) Results artifacts for ChimeraBoost (default), produced by the provided
-  TabArena code: `run_chimera_full.py` → `run_chimera_full_eval.py`
-  (full repetitions, all folds/repeats, 51 tasks, 816 fits, 0 failures).
-- (b) Reproducible pipeline: this repo's `benchmarks/tabarena/` (wrapper + run +
-  eval scripts) + the model-integration issue from Step A.
-- (c) Model description: https://github.com/bbstats/chimeraboost (README +
-  `docs/`).
-- (d) Attestation (verbatim):
-  > I confirm that these results were produced using the attached modeling
-  > pipeline and to the best of my knowledge, I have used the test data
-  > appropriately and have not manipulated the results.
-- (e) Verification requested: **yes** (re-run a sample of folds for the main
-  leaderboard).
+**Title:** `[New Model] ChimeraBoost`
 
-**Not in this PR (follow-up):** the tuned entry — pending the full 201-config
+ChimeraBoost is a pure-Python, CatBoost-inspired oblivious gradient-boosting
+library (numba-backed; no GPU / heavy deps). It supports binary, multiclass,
+regression, and quantile regression. This PR adds it to TabArena as a CPU config
+model (default entry; a tuned entry will follow).
+
+**Notes**
+- Standalone model (not an ensembling pipeline). Native categorical handling via
+  ordered target statistics; categoricals are passed through AutoGluon's
+  `LabelEncoderFeatureGenerator` then marked as `cat_features`.
+- Passes the default model unit test (`FitHelper.fit_and_validate_dataset`) on
+  toy binary / multiclass / regression.
+- Default config: `n_estimators=500`, `early_stopping=True`, `thread_count=-1`,
+  `random_state=0`; all other knobs at library defaults.
+
+**Misc**
+- Codebase: https://github.com/bbstats/chimeraboost
+- PyPI: https://pypi.org/project/chimeraboost
+- Docs: https://bbstats.github.io/chimeraboost
+- Inspirations: CatBoost (ordered TS, oblivious trees), XGBoost, LightGBM (see repo README).
+
+By submitting this pull request, I confirm that you can use, modify, copy, and
+redistribute this contribution, under the terms of your choice.
+
+---
+
+## Results to post as a PR comment
+
+Full TabArena (all folds/repeats), default config, produced by the provided
+TabArena code (`run_chimera_full.py` → `run_chimera_full_eval.py`):
+
+| Model (default) | Elo | Train s/1K |
+|---|---|---|
+| CatBoost (default) | 1359 | 6.83 |
+| **ChimeraBoost (default)** | **1220** (+47/−58) | **0.59** |
+| XGBoost (default) | 1210 | 1.94 |
+| LightGBM (default) | 1184 | 1.96 |
+
+51 tasks, 816 fits, 0 failures. ChimeraBoost beats default XGBoost and LightGBM,
+trails CatBoost, at the fastest tree-model train time on the board. Raw results:
+`<link to chimera_full artifacts zip>`. Request: please verify (re-run a sample
+of folds) for the main leaderboard.
+
+**Follow-up (not in this PR):** the tuned entry — pending the full 201-config
 tuned run on the fixed search space (`run_chimera_tuned.py`, fresh
-`chimera_tuned_full` dir).
+`chimera_tuned_full` dir; ~2–3 weeks of pausable compute).

--- a/benchmarks/tabarena/SUBMISSION.md
+++ b/benchmarks/tabarena/SUBMISSION.md
@@ -13,7 +13,7 @@ We submit the **default** row first; the tuned row follows the full-tuned run.
 - ✅ Results: TabArena-Lite Elo 1211; full TabArena Elo 1220 (rank 39/70), 0 failures.
 
 ## The PR contents
-1. **Model package** — `upstream_pr/chimeraboost/` (`model.py`, `hpo.py`, `info.py`, `__init__.py`), copied to `tabarena/tabarena/models/chimeraboost/` in your fork. Plus the public-class registration. See [`upstream_pr/REGISTER.md`](upstream_pr/REGISTER.md).
+1. **Model package** — `upstream_pr/chimeraboost/` (`model.py`, `hpo.py`, `info.py`, `__init__.py`), copied to `packages/tabarena/src/tabarena/models/chimeraboost/` in your fork (upstream is now a src-layout). Plus the public-class registration. See [`upstream_pr/REGISTER.md`](upstream_pr/REGISTER.md). Validated in the fork: discovery + unit test 3/3.
 2. **Results** — full-default leaderboard (Elo 1220) posted as a PR comment + a link to the raw results zip (host the `chimera_full` artifacts somewhere public, e.g. a release asset).
 
 ---

--- a/benchmarks/tabarena/SUBMISSION.md
+++ b/benchmarks/tabarena/SUBMISSION.md
@@ -1,0 +1,76 @@
+# TabArena submission — ChimeraBoost (default entry)
+
+Ready-to-paste drafts for the two-step community submission. Step A = model
+integration issue (tabarena.ai/code). Step B = results PR
+(tabarena.ai/community-results). Submitting the **default** row first; the tuned
+row follows after the ~2–3-week full-tuned run.
+
+Status of the technical gates (all green as of 2026-06-15):
+- ✅ Public `AbstractModel` impl: [`chimeraboost_tabarena_model.py`](chimeraboost_tabarena_model.py); library at https://github.com/bbstats/chimeraboost (`pip install chimeraboost`).
+- ✅ Passes the default model unit test: [`model_unittest.py`](model_unittest.py) → 3/3 (binary/multiclass/regression) via AutoGluon `FitHelper`.
+- ✅ Default hyperparameters + HPO search space specified (below).
+- ✅ Promising results on TabArena-Lite (Elo 1211) and full TabArena (Elo 1220).
+
+---
+
+## Step A — Model integration issue
+
+**Title:** Add model: ChimeraBoost (pure-Python CatBoost-inspired oblivious GBDT)
+
+**1. Public model implementation.**
+ChimeraBoost is a standalone gradient-boosting model (not an ensembling pipeline):
+oblivious/symmetric trees, histogram split-finding, ordered target-statistics for
+categoricals — implemented in pure Python + numba, no heavy deps. Library:
+https://github.com/bbstats/chimeraboost (`pip install chimeraboost`). AutoGluon
+`AbstractModel` wrapper: `benchmarks/tabarena/chimeraboost_tabarena_model.py`
+(`ag_key="CHIMERA"`, `ag_name="ChimeraBoost"`). Passes the default unit test
+(`model_unittest.py`, `FitHelper.fit_and_validate_dataset`, 3/3 problem types).
+
+**2. Preprocessing and hyperparameters.**
+- Preprocessing: AutoGluon `LabelEncoderFeatureGenerator` for categoricals; the
+  categorical column indices are passed to ChimeraBoost as `cat_features` so it
+  applies its native ordered-target-statistics encoding (numeric features passed
+  through; NaN routed to a missing bin).
+- Default hyperparameters: `n_estimators=500`, `early_stopping=True` (internal
+  validation split), `thread_count=-1`, `random_state=0`; all other knobs at
+  library defaults (depth=6, learning_rate auto, l2_leaf_reg=1.0, max_bins=128…).
+- HPO search space (200 random configs, TabArena convention):
+  `learning_rate` LogReal(0.03,0.3), `depth` Int(4,8), `l2_leaf_reg`
+  LogReal(0.1,10), `min_child_weight` Real(0,8), `subsample` Real(0.5,1),
+  `colsample` Real(0.5,1), `leaf_estimation_iterations` Int(1,5), `max_bins`
+  Cat(128,254), `linear_leaves` Cat(F,T), `linear_lambda` LogReal(0.1,10),
+  `cat_smoothing` LogReal(0.1,10), `cat_n_permutations` Int(1,8),
+  `ordered_boosting` Cat(F,T). (`n_estimators` fixed at 1500 + early stopping.)
+
+**3. Model verification.**
+TabArena-Lite default = Elo 1211; full TabArena default = Elo 1220 (rank 39/70),
+beating default XGBoost (1210) and LightGBM (1184), below CatBoost-default
+(1359), at the fastest tree-model train time on the board (0.59 s/1K). I am the
+original author of ChimeraBoost.
+
+**4. Maintenance commitment.**
+Preferred contact: GitHub @bbstats (issues on bbstats/chimeraboost). Pure-Python
++ numba, no GPU/foundation-model deps → low version-conflict surface.
+
+---
+
+## Step B — Results PR (default entry)
+
+**Contents:**
+- (a) Results artifacts for ChimeraBoost (default), produced by the provided
+  TabArena code: `run_chimera_full.py` → `run_chimera_full_eval.py`
+  (full repetitions, all folds/repeats, 51 tasks, 816 fits, 0 failures).
+- (b) Reproducible pipeline: this repo's `benchmarks/tabarena/` (wrapper + run +
+  eval scripts) + the model-integration issue from Step A.
+- (c) Model description: https://github.com/bbstats/chimeraboost (README +
+  `docs/`).
+- (d) Attestation (verbatim):
+  > I confirm that these results were produced using the attached modeling
+  > pipeline and to the best of my knowledge, I have used the test data
+  > appropriately and have not manipulated the results.
+- (e) Verification requested: **yes** (re-run a sample of folds for the main
+  leaderboard).
+
+**Not in this PR (follow-up):** the tuned entry — pending the full 201-config
+tuned run on the fixed search space (`run_chimera_tuned.py`, fresh
+`chimera_tuned_full` dir).

--- a/benchmarks/tabarena/chimeraboost_tabarena_model.py
+++ b/benchmarks/tabarena/chimeraboost_tabarena_model.py
@@ -113,6 +113,48 @@ class ChimeraBoostModel(AbstractModel):
         num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
         return num_cpus, 0
 
+    def _estimate_memory_usage(self, X: pd.DataFrame, **kwargs) -> int:
+        return self.estimate_memory_usage_static(
+            X=X,
+            problem_type=self.problem_type,
+            num_classes=self.num_classes,
+            hyperparameters=self._get_model_params(),
+            **kwargs,
+        )
+
+    @classmethod
+    def _estimate_memory_usage_static(
+        cls,
+        *,
+        X: pd.DataFrame,
+        hyperparameters: dict | None = None,
+        num_classes: int | None = 1,
+        **kwargs,
+    ) -> int:
+        """Conservative peak-fit RAM estimate (bytes) for fold-parallel scheduling.
+
+        ChimeraBoost is a CPU GBDT; peak memory is dominated by O(n_samples *
+        n_features) terms — the input matrix, the quantized bin codes, and a few
+        per-row stat buffers (gradients, hessians, predictions, the validation
+        copy). The oblivious trees themselves are negligible (2**depth leaves *
+        n_estimators * a few bytes). We deliberately over-estimate (a 3x factor
+        on the input matrix + a 1 GB baseline) so the scheduler packs fewer folds
+        rather than risk OOM.
+        """
+        n, p = int(X.shape[0]), int(X.shape[1])
+        k = max(int(num_classes or 1), 1)
+        cell = 8  # float64 / object-pointer width
+        data = n * p * cell          # input matrix (object array when cats present)
+        binned = n * p * 2           # quantized bin codes (uint8/uint16)
+        stats = n * k * cell * 6     # grad / hess / pred / weight / val buffers
+        hist = p * 256 * 2 * cell    # transient per-level histograms
+        baseline = 1_000_000_000     # python + numba + autogluon overhead
+        return int(baseline + 3 * data + binned + stats + hist)
+
+    @classmethod
+    def _class_tags(cls) -> dict:
+        return {"can_estimate_memory_usage_static": True}
+
 
 class ChimeraBoostE10Model(ChimeraBoostModel):
     """Deliberate variant: the exact default config + n_ensembles=10 (internal

--- a/benchmarks/tabarena/chimeraboost_tabarena_model.py
+++ b/benchmarks/tabarena/chimeraboost_tabarena_model.py
@@ -161,18 +161,22 @@ def get_configs_for_chimera_tuned(*, num_random_configs: int = 200):
     * Core capacity/regularization knobs with known per-dataset variance:
       learning_rate, depth, l2_leaf_reg, min_child_weight, subsample, colsample,
       leaf_estimation_iterations, max_bins.
-    * The default-OFF research flags that were KILLED as defaults precisely
-      because each helps only a narrow slice of datasets (see
-      benchmarks/research/SUMMARY.md) — per-task HPO is the regime where
-      narrow-sweet-spot levers earn their keep: linear_leaves (regression wins
-      pol/abalone; default only auto-on for binary), onehot_low_card,
-      cat_aware_binning, cat_combinations_selective (hard-capped at 20 pairs;
-      the plain cat_combinations flag is deliberately EXCLUDED — explicit True
+    * Categorical-handling knobs that exist in current source: cat_smoothing
+      (ordered-TS pseudocount) and cat_n_permutations (anti-leakage averaging).
+      The raw cat_combinations flag is deliberately EXCLUDED — explicit True
       bypasses the auto-rule's <=1000-pair resource guard and would explode on
-      high-cardinality tasks), and hs_lambda (null at depth 6 but designed to
-      make deeper trees safe — searchable jointly with depth here).
+      high-cardinality tasks; combinations stay on the adaptive auto default.
+    * linear_leaves (regression wins pol/abalone; default only auto-on for
+      binary) searched jointly with its regularizer linear_lambda.
+    * ordered_boosting (CatBoost-style ordered target stats) — default off, a
+      per-task lever for leakage-sensitive small data.
     * n_estimators stays fixed (1500 cap + early stopping): searching a budget
       cap under ES only adds noise.
+
+    NOTE: the 8 default-off research flags (onehot_low_card, cat_aware_binning,
+    cat_combinations_selective, hs_lambda, …) were REMOVED from the model in the
+    June de-slop pass (benchmarks/research/SUMMARY.md), so they are no longer
+    searchable — passing them now raises TypeError at construction.
     """
     from autogluon.common.space import Categorical, Int, Real
 
@@ -189,10 +193,10 @@ def get_configs_for_chimera_tuned(*, num_random_configs: int = 200):
         "leaf_estimation_iterations": Int(1, 5),
         "max_bins": Categorical(128, 254),
         "linear_leaves": Categorical(False, True),
-        "onehot_low_card": Categorical(False, True),
-        "cat_aware_binning": Categorical(False, True),
-        "cat_combinations_selective": Categorical(False, True),
-        "hs_lambda": Real(0.0, 4.0),
+        "linear_lambda": Real(0.1, 10.0, log=True),
+        "cat_smoothing": Real(0.1, 10.0, log=True),
+        "cat_n_permutations": Int(1, 8),
+        "ordered_boosting": Categorical(False, True),
     }
 
     gen = ConfigGenerator(

--- a/benchmarks/tabarena/chimeraboost_tabarena_model.py
+++ b/benchmarks/tabarena/chimeraboost_tabarena_model.py
@@ -6,11 +6,11 @@ MUST live in its own file (not the run script) because TabArena pickles it.
 """
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING
 
-import numpy as np
+from autogluon.common.utils.resource_utils import ResourceManager
 from autogluon.core.models import AbstractModel
-from autogluon.features import LabelEncoderFeatureGenerator
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -21,34 +21,33 @@ class ChimeraBoostModel(AbstractModel):
 
     ag_key = "CHIMERA"
     ag_name = "ChimeraBoost"
+    seed_name = "random_state"  # AutoGluon injects the framework seed here
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self._feature_generator = None
-
-    def _preprocess(self, X: pd.DataFrame, is_train=False, **kwargs) -> np.ndarray:
-        """Label-encode categoricals and hand the model an object matrix while
-        recording which columns are categorical, so ChimeraBoost applies its
-        NATIVE ordered-target-statistics encoding (and auto cat_combinations on
-        all-categorical data) rather than seeing cats as plain numbers."""
+    def _preprocess(self, X: pd.DataFrame, is_train=False, **kwargs) -> pd.DataFrame:
+        """Pass the frame straight to ChimeraBoost with categoricals marked by
+        name. ChimeraBoost factorizes them with its native ordered-target-
+        statistics encoding and routes NaN to a dedicated missing bin, so we do
+        NOT label-encode or impute here (both would discard signal)."""
         X = super()._preprocess(X, **kwargs)
         if is_train:
-            self._feature_generator = LabelEncoderFeatureGenerator(verbosity=0)
-            self._feature_generator.fit(X=X)
-            # Positions of the categorical columns in the final column order,
-            # passed verbatim as cat_features to ChimeraBoost. Computed once on
-            # train and reused at predict (column order is identical).
-            self._cat_indices = [X.columns.get_loc(c)
-                                 for c in self._feature_generator.features_in]
-        if self._feature_generator.features_in:
-            X = X.copy()
-            X[self._feature_generator.features_in] = self._feature_generator.transform(X=X)
-        # object dtype: cat columns stay integer-coded categories (ChimeraBoost
-        # factorizes them), numeric columns stay float. fillna(0) for numerics;
-        # the label encoder already maps unseen/NaN cats to a reserved code.
-        return X.fillna(0).to_numpy(dtype=object)
+            # category-dtype columns (AutoGluon marks them; valid_raw_types keeps
+            # them as 'category'); recorded once and reused at predict.
+            self._cat_col_names = list(X.select_dtypes(include="category").columns)
+        return X
 
-    def _fit(self, X, y, num_cpus: int = 1, **kwargs):
+    def _fit(
+        self,
+        X: pd.DataFrame,
+        y: pd.Series,
+        X_val: pd.DataFrame = None,
+        y_val: pd.Series = None,
+        time_limit: float | None = None,
+        num_cpus: int = 1,
+        num_gpus: float = 0,
+        verbosity: int = 2,
+        **kwargs,
+    ):
+        start_time = time.time()
         if self.problem_type in ["regression"]:
             from chimeraboost import ChimeraBoostRegressor
 
@@ -58,25 +57,44 @@ class ChimeraBoostModel(AbstractModel):
 
             model_cls = ChimeraBoostClassifier
 
-        X = self.preprocess(X, y=y, is_train=True)
+        X = self.preprocess(X, is_train=True)
         params = self._get_model_params()
+        # Run on the CPU budget TabArena allocates (thread_count<0 => all cores).
+        params["thread_count"] = num_cpus
         # Tuned configs may sample linear_leaves=True, which raises on multiclass;
         # None = auto (binary on, multiclass off) keeps the config valid everywhere.
         if self.problem_type == "multiclass" and params.get("linear_leaves") is True:
             params["linear_leaves"] = None
         self.model = model_cls(**params)
-        # early_stopping=True with no eval_set => ChimeraBoost auto-splits a
-        # validation fraction internally and stops on it. cat_features triggers
-        # native ordered-TS encoding + (on all-cat data) auto cat_combinations.
-        cat = self._cat_indices or None
-        self.model.fit(X, y, cat_features=cat)
+
+        cat = self._cat_col_names or None
+        # Use TabArena's validation split for early stopping when provided (don't
+        # carve a second holdout out of the training data); else ChimeraBoost
+        # auto-splits internally via early_stopping=True.
+        eval_set = None
+        if X_val is not None and y_val is not None:
+            X_val = self.preprocess(X_val)
+            eval_set = (X_val, y_val)
+
+        fit_kwargs = {}
+        # Honor TabArena's time budget via a wall-clock callback (unsupported with
+        # bagging, where members fit in worker processes).
+        if time_limit is not None and params.get("n_ensembles") in (None, 1):
+            deadline = start_time + time_limit
+
+            def _time_stop(iteration, train_loss, val_loss, model):
+                return time.time() >= deadline
+
+            fit_kwargs["callbacks"] = _time_stop
+
+        self.model.fit(X, y, cat_features=cat, eval_set=eval_set, **fit_kwargs)
 
     def _set_default_params(self):
         default_params = {
-            "n_estimators": 500,
+            # Cap only: early stopping picks the real count and the auto learning
+            # rate is pinned at 0.1 under ES, so a high cap is LR-neutral headroom.
+            "n_estimators": 10000,
             "early_stopping": True,
-            "thread_count": -1,
-            "random_state": 0,
         }
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
@@ -85,6 +103,15 @@ class ChimeraBoostModel(AbstractModel):
         default_auxiliary_params = super()._get_default_auxiliary_params()
         default_auxiliary_params.update({"valid_raw_types": ["int", "float", "category"]})
         return default_auxiliary_params
+
+    @classmethod
+    def supported_problem_types(cls) -> list[str] | None:
+        return ["binary", "multiclass", "regression"]
+
+    def _get_default_resources(self) -> tuple[int, int]:
+        # Physical cores only (matches RealMLP/XRFM); ChimeraBoost is CPU-only.
+        num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
+        return num_cpus, 0
 
 
 class ChimeraBoostE10Model(ChimeraBoostModel):
@@ -99,7 +126,7 @@ class ChimeraBoostE10Model(ChimeraBoostModel):
         super()._set_default_params()  # identical default config ...
         self._set_default_param_value("n_ensembles", 10)  # ... + this one knob
         # ensemble_n_jobs left at 1: the 10 members run sequentially, each using
-        # all threads (thread_count=-1); avoids core oversubscription. ~10x train time.
+        # all allocated threads; avoids core oversubscription. ~10x train time.
 
 
 def get_configs_for_chimera_e10():
@@ -139,17 +166,13 @@ def get_configs_for_chimera(*, num_random_configs: int = 0):
 
 
 class ChimeraBoostTunedModel(ChimeraBoostModel):
-    """Tuned variant — distinct ag_name so it appears as a separate leaderboard entry."""
+    """Tuned variant — distinct ag_name so it appears as a separate leaderboard entry.
+
+    Inherits the n_estimators=10000 cap from the base; early stopping picks the
+    effective count, so low-lr tuned configs aren't truncated."""
 
     ag_key = "CHIMERATUNED"
     ag_name = "ChimeraBoost_tuned"
-
-    def _set_default_params(self):
-        # Fixed tree budget for every tuned config; early stopping picks the
-        # effective count, so low-lr configs aren't truncated by the 500 cap
-        # the default entry uses.
-        self._set_default_param_value("n_estimators", 1500)
-        super()._set_default_params()
 
 
 def get_configs_for_chimera_tuned(*, num_random_configs: int = 200):
@@ -170,7 +193,7 @@ def get_configs_for_chimera_tuned(*, num_random_configs: int = 200):
       binary) searched jointly with its regularizer linear_lambda.
     * ordered_boosting (CatBoost-style ordered target stats) — default off, a
       per-task lever for leakage-sensitive small data.
-    * n_estimators stays fixed (1500 cap + early stopping): searching a budget
+    * n_estimators stays fixed (10000 cap + early stopping): searching a budget
       cap under ES only adds noise.
 
     NOTE: the 8 default-off research flags (onehot_low_card, cat_aware_binning,

--- a/benchmarks/tabarena/model_unittest.py
+++ b/benchmarks/tabarena/model_unittest.py
@@ -1,0 +1,55 @@
+"""TabArena/AutoGluon default model unit test for ChimeraBoostModel.
+
+This is the Part-A integration gate ("must pass the default unit test for
+TabArena models"): AutoGluon's FitHelper loads a toy dataset, fits the model
+through a TabularPredictor, and validates fit -> predict -> refit_full ->
+save/load for each problem type.
+
+Run in the tabarena venv from this directory:
+    & A:\\code\\tabarena\\.venv\\Scripts\\python.exe model_unittest.py
+Not named test_*.py on purpose: it needs autogluon, which the base-env pytest
+suite (tests/) does not have.
+"""
+from __future__ import annotations
+
+import os
+
+# Windows shim: AutoGluon/tabarena call os.sched_getaffinity (Linux-only).
+if not hasattr(os, "sched_getaffinity"):
+    os.sched_getaffinity = lambda pid=0: set(range(os.cpu_count() or 1))
+
+from autogluon.tabular.testing import FitHelper
+
+from chimeraboost_tabarena_model import ChimeraBoostModel
+
+DATASETS = ["toy_binary", "toy_multiclass", "toy_regression"]
+
+
+def main() -> int:
+    model_cls = ChimeraBoostModel
+    fit_args = dict(hyperparameters={model_cls: {}})
+    failures = []
+    for ds in DATASETS:
+        try:
+            FitHelper.fit_and_validate_dataset(
+                dataset_name=ds,
+                fit_args=fit_args,
+                refit_full=True,
+                raise_on_model_failure=True,
+            )
+            print(f"PASS: {ds}")
+        except Exception as e:  # noqa: BLE001 - report-all harness
+            failures.append((ds, repr(e)))
+            print(f"FAIL: {ds} -> {e!r}")
+    print("=" * 60)
+    if failures:
+        print(f"UNIT TEST FAILED ({len(failures)}/{len(DATASETS)}):")
+        for ds, err in failures:
+            print(f"  {ds}: {err}")
+        return 1
+    print(f"UNIT TEST PASSED ({len(DATASETS)}/{len(DATASETS)} problem types)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/tabarena/run_chimera_full.py
+++ b/benchmarks/tabarena/run_chimera_full.py
@@ -1,0 +1,60 @@
+"""Run FULL TabArena (all folds/repeats) with the single DEFAULT config.
+
+This is the default-entry counterpart to run_chimera_tuned.py — the run that
+produces the leaderboard row for tabarena.ai (the Lite scripts are pre-flight
+only). Writes to its OWN output dir so it never collides with the Lite cache.
+
+Usage (from this directory, with the tabarena venv + A: env vars set):
+    python run_chimera_full.py --limit 1    # smoke: 1 task, full repetitions
+    python run_chimera_full.py              # full 51-task run
+Safe to kill and relaunch: each (task, fold, repeat) result is cached; a re-run
+skips completed work and refits only what's missing.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import openml
+import pandas as pd
+from chimeraboost_tabarena_model import get_configs_for_chimera
+
+from tabarena.benchmark.experiment import run_experiments_new
+from tabarena.nips2025_utils.fetch_metadata import load_curated_task_metadata
+
+OUTPUT_DIR = r"A:\code\tabarena_out\chimera_full"
+
+
+def _task_ids_from_csv() -> list[int]:
+    import tabarena as _ta
+    csv = Path(_ta.__file__).parent / "nips2025_utils" / "metadata" / "task_metadata_tabarena51.csv"
+    return pd.read_csv(csv)["tid"].tolist()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=None,
+                    help="run only the first N tasks (smoke test); default = all 51")
+    args = ap.parse_args()
+
+    openml.config.set_root_cache_directory(r"A:\code\openml")
+
+    task_ids = _task_ids_from_csv()
+    if args.limit:
+        task_ids = task_ids[: args.limit]
+
+    model_experiments = get_configs_for_chimera(num_random_configs=0)
+    print(f"Running {len(model_experiments)} config on {len(task_ids)} tasks "
+          f"(repetitions_mode='TabArena' = all folds/repeats)")
+
+    run_experiments_new(
+        output_dir=OUTPUT_DIR,
+        model_experiments=model_experiments,
+        tasks=task_ids,
+        repetitions_mode="TabArena",
+        tasks_metadata=load_curated_task_metadata(),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/tabarena/run_chimera_full_eval.py
+++ b/benchmarks/tabarena/run_chimera_full_eval.py
@@ -1,0 +1,47 @@
+"""Evaluate the FULL (all folds/repeats) default ChimeraBoost run -> Elo.
+
+Run AFTER run_chimera_full.py. Reads chimera_full raw artifacts and writes its
+OWN leaderboard files so the Lite result (chimera_leaderboard.*) is preserved.
+
+NOTE: the processed cache `~/.cache/tabarena/artifacts/ChimeraBoost` is keyed by
+method name and is shared with the Lite eval. Clear it before running this so
+to_results() rebuilds from the chimera_full raw rather than loading stale Lite
+results (the precache gotcha).
+"""
+from __future__ import annotations
+
+# Windows shim: TabArena calls os.sched_getaffinity (Linux-only) to count CPUs.
+import os
+if not hasattr(os, "sched_getaffinity"):
+    os.sched_getaffinity = lambda pid=0: set(range(os.cpu_count() or 1))
+
+from tabarena.nips2025_utils.end_to_end_single import (
+    EndToEndResultsSingle,
+    EndToEndSingle,
+)
+from tabarena.website.website_format import format_leaderboard
+
+PATH_RAW = r"A:\code\tabarena_out\chimera_full"
+FIG_OUTPUT_DIR = r"A:\code\tabarena_out\evals\chimera_full"
+METHOD = "ChimeraBoost"  # == ChimeraBoostModel.ag_name
+
+if __name__ == "__main__":
+    end_to_end = EndToEndSingle.from_path_raw(path_raw=PATH_RAW)
+    _ = end_to_end.to_results()
+
+    end_to_end_results = EndToEndResultsSingle.from_cache(method=METHOD)
+    leaderboard = end_to_end_results.compare_on_tabarena(
+        only_valid_tasks=True, output_dir=FIG_OUTPUT_DIR
+    )
+    leaderboard_website = format_leaderboard(leaderboard)
+    md = leaderboard_website.to_markdown(index=False)
+    out_md = r"A:\code\tabarena_out\evals\chimera_full_leaderboard.md"
+    with open(out_md, "w", encoding="utf-8") as fh:
+        fh.write(md)
+    leaderboard_website.to_csv(
+        r"A:\code\tabarena_out\evals\chimera_full_leaderboard.csv", index=False)
+    print(f"leaderboard written to {out_md}")
+    try:
+        print(md)
+    except UnicodeEncodeError:
+        print(md.encode("ascii", "replace").decode("ascii"))

--- a/benchmarks/tabarena/run_chimera_tuned.py
+++ b/benchmarks/tabarena/run_chimera_tuned.py
@@ -16,7 +16,10 @@ from chimeraboost_tabarena_model import get_configs_for_chimera_tuned
 from tabarena.benchmark.experiment import run_experiments_new
 from tabarena.nips2025_utils.fetch_metadata import load_curated_task_metadata
 
-OUTPUT_DIR = r"A:\code\tabarena_out\chimera_tuned"
+# Fresh dir for the fixed (post-de-slop) search space. The old chimera_tuned /
+# chimera_tuned_lite dirs hold killed-flag-space caches whose r-config IDs would
+# collide and silently load stale results — never reuse them for this run.
+OUTPUT_DIR = r"A:\code\tabarena_out\chimera_tuned_full"
 
 
 def _task_ids_from_csv() -> list[int]:

--- a/benchmarks/tabarena/upstream_pr/REGISTER.md
+++ b/benchmarks/tabarena/upstream_pr/REGISTER.md
@@ -3,17 +3,21 @@
 These files are the model package for a `[New Model]` PR to
 `github.com/autogluon/tabarena` (the OrionMSP PR #303 is the template).
 
+> Path note: upstream switched to a **src-layout**. The models dir is now
+> `packages/tabarena/src/tabarena/models/` (was `tabarena/tabarena/models/`).
+> The import path is unchanged (`tabarena.models.…`); only the file location moved.
+
 ## 1. Copy the package
 
-Copy the `chimeraboost/` dir to `tabarena/tabarena/models/chimeraboost/` in your
-fork. Auto-discovery (`tabarena/models/_registry.py::discover_models`) imports
-each `models/<name>/info.py` and registers its `<name>_info`, so the package is
-picked up without further wiring for the benchmark.
+Copy the `chimeraboost/` dir to `packages/tabarena/src/tabarena/models/chimeraboost/`
+in your fork. Auto-discovery (`tabarena/models/_registry.py::discover_models`)
+imports each `models/<name>/info.py` and registers its `<name>_info`, so the
+package is picked up without further wiring for the benchmark.
 
 ## 2. Register the public class export
 
 For the public API surface (mirrors every other model), add `ChimeraBoostModel`
-to `tabarena/tabarena/models/__init__.py`:
+to `packages/tabarena/src/tabarena/models/__init__.py`:
 
 - In the `TYPE_CHECKING` block:
   ```python

--- a/benchmarks/tabarena/upstream_pr/REGISTER.md
+++ b/benchmarks/tabarena/upstream_pr/REGISTER.md
@@ -1,0 +1,53 @@
+# Wiring ChimeraBoost into a tabarena fork
+
+These files are the model package for a `[New Model]` PR to
+`github.com/autogluon/tabarena` (the OrionMSP PR #303 is the template).
+
+## 1. Copy the package
+
+Copy the `chimeraboost/` dir to `tabarena/tabarena/models/chimeraboost/` in your
+fork. Auto-discovery (`tabarena/models/_registry.py::discover_models`) imports
+each `models/<name>/info.py` and registers its `<name>_info`, so the package is
+picked up without further wiring for the benchmark.
+
+## 2. Register the public class export
+
+For the public API surface (mirrors every other model), add `ChimeraBoostModel`
+to `tabarena/tabarena/models/__init__.py`:
+
+- In the `TYPE_CHECKING` block:
+  ```python
+  from tabarena.models.chimeraboost.model import ChimeraBoostModel
+  ```
+- In `_LAZY_CLASSES`:
+  ```python
+  "ChimeraBoostModel": "tabarena.models.chimeraboost.model",
+  ```
+
+## 3. Declare the pip dependency
+
+ChimeraBoost is pip-installable (`pip install chimeraboost`); `pip_extra` in
+`info.py` already declares it. Add it wherever the repo lists optional model
+extras (e.g. the `pyproject.toml` model-extras group), matching how other
+config models are listed.
+
+## 4. Sanity-check in the fork
+
+```python
+from tabarena.models import discover_models
+reg = discover_models()
+assert "ChimeraBoost" in {m.method_metadata.method for m in reg.values()}
+
+# default model unit test (AutoGluon FitHelper), all 3 problem types:
+#   see benchmarks/tabarena/model_unittest.py in the chimeraboost repo
+```
+
+## Notes
+* `model.py` here is identical to `benchmarks/tabarena/chimeraboost_tabarena_model.py`'s
+  `ChimeraBoostModel` (the E10 / tuned subclasses and run-script config helpers
+  are not part of the upstream package).
+* `hpo.py` carries the tuned search space (for the later tuned row); the default
+  row uses only `manual_configs=[{}]`.
+* Metadata fields left unset (`has_raw/has_processed/has_results`, `s3_*`,
+  `cache_type`) are filled by maintainers when result artifacts are hosted in the
+  official pool.

--- a/benchmarks/tabarena/upstream_pr/chimeraboost/__init__.py
+++ b/benchmarks/tabarena/upstream_pr/chimeraboost/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from tabarena.models.chimeraboost.hpo import gen_chimeraboost
+from tabarena.models.chimeraboost.info import (
+    chimeraboost_info,
+    chimeraboost_method_metadata,
+)
+
+__all__ = ["gen_chimeraboost", "chimeraboost_info", "chimeraboost_method_metadata"]

--- a/benchmarks/tabarena/upstream_pr/chimeraboost/hpo.py
+++ b/benchmarks/tabarena/upstream_pr/chimeraboost/hpo.py
@@ -16,8 +16,9 @@ Search-space notes:
 * linear_leaves (regression wins; default only auto-on for binary) searched
   jointly with its regularizer linear_lambda.
 * ordered_boosting (CatBoost-style ordered target stats), default off.
-* Tuned configs use a fixed n_estimators=1500 + early stopping (searching a
-  budget cap under ES only adds noise).
+* Tuned configs use a fixed n_estimators=10000 + early stopping (searching a
+  budget cap under ES only adds noise; LR is pinned at 0.1 under ES so a high
+  cap is free headroom).
 """
 from __future__ import annotations
 
@@ -27,7 +28,7 @@ from tabarena.models.chimeraboost.model import ChimeraBoostModel
 from tabarena.utils.config_utils import ConfigGenerator
 
 _SEARCH_SPACE = {
-    "n_estimators": Categorical(1500),  # fixed budget for tuned configs (+ ES)
+    "n_estimators": Categorical(10000),  # fixed budget for tuned configs (+ ES)
     "learning_rate": Real(0.03, 0.3, log=True),
     "depth": Int(4, 8),
     "l2_leaf_reg": Real(0.1, 10.0, log=True),

--- a/benchmarks/tabarena/upstream_pr/chimeraboost/hpo.py
+++ b/benchmarks/tabarena/upstream_pr/chimeraboost/hpo.py
@@ -1,0 +1,62 @@
+"""HPO config generator for ChimeraBoost.
+
+manual_configs=[{}] is the single default config (the default leaderboard row).
+The search space is the tuned entry's HPO budget (TabArena convention: 200 random
+configs). Pre-registered from dev-side evidence only (Grinsztajn / OpenML / PMLB),
+never from TabArena results.
+
+Search-space notes:
+* Core capacity/regularization knobs with known per-dataset variance:
+  learning_rate, depth, l2_leaf_reg, min_child_weight, subsample, colsample,
+  leaf_estimation_iterations, max_bins.
+* Categorical-handling knobs: cat_smoothing (ordered-TS pseudocount),
+  cat_n_permutations (anti-leakage averaging). The raw cat_combinations flag is
+  EXCLUDED — explicit True bypasses the auto-rule's <=1000-pair resource guard
+  and would explode on high-cardinality tasks.
+* linear_leaves (regression wins; default only auto-on for binary) searched
+  jointly with its regularizer linear_lambda.
+* ordered_boosting (CatBoost-style ordered target stats), default off.
+* Tuned configs use a fixed n_estimators=1500 + early stopping (searching a
+  budget cap under ES only adds noise).
+"""
+from __future__ import annotations
+
+from autogluon.common.space import Categorical, Int, Real
+
+from tabarena.models.chimeraboost.model import ChimeraBoostModel
+from tabarena.utils.config_utils import ConfigGenerator
+
+_SEARCH_SPACE = {
+    "n_estimators": Categorical(1500),  # fixed budget for tuned configs (+ ES)
+    "learning_rate": Real(0.03, 0.3, log=True),
+    "depth": Int(4, 8),
+    "l2_leaf_reg": Real(0.1, 10.0, log=True),
+    "min_child_weight": Real(0.0, 8.0),
+    "subsample": Real(0.5, 1.0),
+    "colsample": Real(0.5, 1.0),
+    "leaf_estimation_iterations": Int(1, 5),
+    "max_bins": Categorical(128, 254),
+    "linear_leaves": Categorical(False, True),
+    "linear_lambda": Real(0.1, 10.0, log=True),
+    "cat_smoothing": Real(0.1, 10.0, log=True),
+    "cat_n_permutations": Int(1, 8),
+    "ordered_boosting": Categorical(False, True),
+}
+
+gen_chimeraboost = ConfigGenerator(
+    model_cls=ChimeraBoostModel,
+    manual_configs=[{}],
+    search_space=_SEARCH_SPACE,
+)
+
+
+if __name__ == "__main__":
+    from tabarena.benchmark.experiment import YamlExperimentSerializer
+
+    print(
+        YamlExperimentSerializer.to_yaml_str(
+            experiments=gen_chimeraboost.generate_all_bag_experiments(
+                num_random_configs=0
+            ),
+        ),
+    )

--- a/benchmarks/tabarena/upstream_pr/chimeraboost/info.py
+++ b/benchmarks/tabarena/upstream_pr/chimeraboost/info.py
@@ -25,5 +25,5 @@ chimeraboost_info = ModelInfo(
     model_cls=ChimeraBoostModel,
     search_space=gen_chimeraboost,
     method_metadata=chimeraboost_method_metadata,
-    pip_extra=("chimeraboost",),
+    pip_extra=("chimeraboost>=0.13.0",),
 )

--- a/benchmarks/tabarena/upstream_pr/chimeraboost/info.py
+++ b/benchmarks/tabarena/upstream_pr/chimeraboost/info.py
@@ -25,5 +25,5 @@ chimeraboost_info = ModelInfo(
     model_cls=ChimeraBoostModel,
     search_space=gen_chimeraboost,
     method_metadata=chimeraboost_method_metadata,
-    pip_extra=("chimeraboost>=0.13.0",),
+    pip_extra=("chimeraboost",),
 )

--- a/benchmarks/tabarena/upstream_pr/chimeraboost/info.py
+++ b/benchmarks/tabarena/upstream_pr/chimeraboost/info.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from tabarena.models._method_metadata import MethodMetadata
+from tabarena.models._model_info import ModelInfo
+from tabarena.models.chimeraboost.hpo import gen_chimeraboost
+from tabarena.models.chimeraboost.model import ChimeraBoostModel
+
+chimeraboost_method_metadata = MethodMetadata(
+    method="ChimeraBoost",
+    display_name="ChimeraBoost",
+    method_type="config",
+    compute="cpu",
+    date="2026-06-15",
+    ag_key="CHIMERA",
+    config_default="ChimeraBoost_c1_BAG_L1",
+    can_hpo=True,
+    is_bag=False,
+    verified=False,
+    reference_url="https://github.com/bbstats/chimeraboost",
+    # has_raw/has_processed/has_results + s3_bucket/s3_prefix/cache_type are set by
+    # the maintainers when the result artifacts are hosted in the official pool.
+)
+
+chimeraboost_info = ModelInfo(
+    model_cls=ChimeraBoostModel,
+    search_space=gen_chimeraboost,
+    method_metadata=chimeraboost_method_metadata,
+    pip_extra=("chimeraboost",),
+)

--- a/benchmarks/tabarena/upstream_pr/chimeraboost/model.py
+++ b/benchmarks/tabarena/upstream_pr/chimeraboost/model.py
@@ -113,3 +113,45 @@ class ChimeraBoostModel(AbstractModel):
         # Physical cores only (matches RealMLP/XRFM); ChimeraBoost is CPU-only.
         num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
         return num_cpus, 0
+
+    def _estimate_memory_usage(self, X: pd.DataFrame, **kwargs) -> int:
+        return self.estimate_memory_usage_static(
+            X=X,
+            problem_type=self.problem_type,
+            num_classes=self.num_classes,
+            hyperparameters=self._get_model_params(),
+            **kwargs,
+        )
+
+    @classmethod
+    def _estimate_memory_usage_static(
+        cls,
+        *,
+        X: pd.DataFrame,
+        hyperparameters: dict | None = None,
+        num_classes: int | None = 1,
+        **kwargs,
+    ) -> int:
+        """Conservative peak-fit RAM estimate (bytes) for fold-parallel scheduling.
+
+        ChimeraBoost is a CPU GBDT; peak memory is dominated by O(n_samples *
+        n_features) terms — the input matrix, the quantized bin codes, and a few
+        per-row stat buffers (gradients, hessians, predictions, the validation
+        copy). The oblivious trees themselves are negligible (2**depth leaves *
+        n_estimators * a few bytes). We deliberately over-estimate (a 3x factor
+        on the input matrix + a 1 GB baseline) so the scheduler packs fewer folds
+        rather than risk OOM.
+        """
+        n, p = int(X.shape[0]), int(X.shape[1])
+        k = max(int(num_classes or 1), 1)
+        cell = 8  # float64 / object-pointer width
+        data = n * p * cell          # input matrix (object array when cats present)
+        binned = n * p * 2           # quantized bin codes (uint8/uint16)
+        stats = n * k * cell * 6     # grad / hess / pred / weight / val buffers
+        hist = p * 256 * 2 * cell    # transient per-level histograms
+        baseline = 1_000_000_000     # python + numba + autogluon overhead
+        return int(baseline + 3 * data + binned + stats + hist)
+
+    @classmethod
+    def _class_tags(cls) -> dict:
+        return {"can_estimate_memory_usage_static": True}

--- a/benchmarks/tabarena/upstream_pr/chimeraboost/model.py
+++ b/benchmarks/tabarena/upstream_pr/chimeraboost/model.py
@@ -1,0 +1,88 @@
+"""ChimeraBoost TabArena model: a pure-Python, CatBoost-inspired, numba-backed
+oblivious gradient-boosting library (https://github.com/bbstats/chimeraboost).
+
+Drop this package at `tabarena/tabarena/models/chimeraboost/` in a fork of
+autogluon/tabarena (see ../REGISTER.md). The model class MUST live in its own
+file (not the run script) because TabArena pickles it.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from autogluon.core.models import AbstractModel
+from autogluon.features import LabelEncoderFeatureGenerator
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+class ChimeraBoostModel(AbstractModel):
+    """ChimeraBoost as an AutoGluon/TabArena model (scikit-learn style API)."""
+
+    ag_key = "CHIMERA"
+    ag_name = "ChimeraBoost"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._feature_generator = None
+
+    def _preprocess(self, X: pd.DataFrame, is_train=False, **kwargs) -> np.ndarray:
+        """Label-encode categoricals and hand the model an object matrix while
+        recording which columns are categorical, so ChimeraBoost applies its
+        NATIVE ordered-target-statistics encoding (and auto cat_combinations on
+        all-categorical data) rather than seeing cats as plain numbers."""
+        X = super()._preprocess(X, **kwargs)
+        if is_train:
+            self._feature_generator = LabelEncoderFeatureGenerator(verbosity=0)
+            self._feature_generator.fit(X=X)
+            # Positions of the categorical columns in the final column order,
+            # passed verbatim as cat_features to ChimeraBoost. Computed once on
+            # train and reused at predict (column order is identical).
+            self._cat_indices = [X.columns.get_loc(c)
+                                 for c in self._feature_generator.features_in]
+        if self._feature_generator.features_in:
+            X = X.copy()
+            X[self._feature_generator.features_in] = self._feature_generator.transform(X=X)
+        # object dtype: cat columns stay integer-coded categories (ChimeraBoost
+        # factorizes them), numeric columns stay float. fillna(0) for numerics;
+        # the label encoder already maps unseen/NaN cats to a reserved code.
+        return X.fillna(0).to_numpy(dtype=object)
+
+    def _fit(self, X, y, num_cpus: int = 1, **kwargs):
+        if self.problem_type in ["regression"]:
+            from chimeraboost import ChimeraBoostRegressor
+
+            model_cls = ChimeraBoostRegressor
+        else:  # 'binary' and 'multiclass'
+            from chimeraboost import ChimeraBoostClassifier
+
+            model_cls = ChimeraBoostClassifier
+
+        X = self.preprocess(X, y=y, is_train=True)
+        params = self._get_model_params()
+        # Tuned configs may sample linear_leaves=True, which raises on multiclass;
+        # None = auto (binary on, multiclass off) keeps the config valid everywhere.
+        if self.problem_type == "multiclass" and params.get("linear_leaves") is True:
+            params["linear_leaves"] = None
+        self.model = model_cls(**params)
+        # early_stopping=True with no eval_set => ChimeraBoost auto-splits a
+        # validation fraction internally and stops on it. cat_features triggers
+        # native ordered-TS encoding + (on all-cat data) auto cat_combinations.
+        cat = self._cat_indices or None
+        self.model.fit(X, y, cat_features=cat)
+
+    def _set_default_params(self):
+        default_params = {
+            "n_estimators": 500,
+            "early_stopping": True,
+            "thread_count": -1,
+            "random_state": 0,
+        }
+        for param, val in default_params.items():
+            self._set_default_param_value(param, val)
+
+    def _get_default_auxiliary_params(self) -> dict:
+        default_auxiliary_params = super()._get_default_auxiliary_params()
+        default_auxiliary_params.update({"valid_raw_types": ["int", "float", "category"]})
+        return default_auxiliary_params

--- a/benchmarks/tabarena/upstream_pr/chimeraboost/model.py
+++ b/benchmarks/tabarena/upstream_pr/chimeraboost/model.py
@@ -1,17 +1,17 @@
 """ChimeraBoost TabArena model: a pure-Python, CatBoost-inspired, numba-backed
 oblivious gradient-boosting library (https://github.com/bbstats/chimeraboost).
 
-Drop this package at `tabarena/tabarena/models/chimeraboost/` in a fork of
+Drop this package at `tabarena/.../models/chimeraboost/` in a fork of
 autogluon/tabarena (see ../REGISTER.md). The model class MUST live in its own
 file (not the run script) because TabArena pickles it.
 """
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING
 
-import numpy as np
+from autogluon.common.utils.resource_utils import ResourceManager
 from autogluon.core.models import AbstractModel
-from autogluon.features import LabelEncoderFeatureGenerator
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -22,34 +22,33 @@ class ChimeraBoostModel(AbstractModel):
 
     ag_key = "CHIMERA"
     ag_name = "ChimeraBoost"
+    seed_name = "random_state"  # AutoGluon injects the framework seed here
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self._feature_generator = None
-
-    def _preprocess(self, X: pd.DataFrame, is_train=False, **kwargs) -> np.ndarray:
-        """Label-encode categoricals and hand the model an object matrix while
-        recording which columns are categorical, so ChimeraBoost applies its
-        NATIVE ordered-target-statistics encoding (and auto cat_combinations on
-        all-categorical data) rather than seeing cats as plain numbers."""
+    def _preprocess(self, X: pd.DataFrame, is_train=False, **kwargs) -> pd.DataFrame:
+        """Pass the frame straight to ChimeraBoost with categoricals marked by
+        name. ChimeraBoost factorizes them with its native ordered-target-
+        statistics encoding and routes NaN to a dedicated missing bin, so we do
+        NOT label-encode or impute here (both would discard signal)."""
         X = super()._preprocess(X, **kwargs)
         if is_train:
-            self._feature_generator = LabelEncoderFeatureGenerator(verbosity=0)
-            self._feature_generator.fit(X=X)
-            # Positions of the categorical columns in the final column order,
-            # passed verbatim as cat_features to ChimeraBoost. Computed once on
-            # train and reused at predict (column order is identical).
-            self._cat_indices = [X.columns.get_loc(c)
-                                 for c in self._feature_generator.features_in]
-        if self._feature_generator.features_in:
-            X = X.copy()
-            X[self._feature_generator.features_in] = self._feature_generator.transform(X=X)
-        # object dtype: cat columns stay integer-coded categories (ChimeraBoost
-        # factorizes them), numeric columns stay float. fillna(0) for numerics;
-        # the label encoder already maps unseen/NaN cats to a reserved code.
-        return X.fillna(0).to_numpy(dtype=object)
+            # category-dtype columns (AutoGluon marks them; valid_raw_types keeps
+            # them as 'category'); recorded once and reused at predict.
+            self._cat_col_names = list(X.select_dtypes(include="category").columns)
+        return X
 
-    def _fit(self, X, y, num_cpus: int = 1, **kwargs):
+    def _fit(
+        self,
+        X: pd.DataFrame,
+        y: pd.Series,
+        X_val: pd.DataFrame = None,
+        y_val: pd.Series = None,
+        time_limit: float | None = None,
+        num_cpus: int = 1,
+        num_gpus: float = 0,
+        verbosity: int = 2,
+        **kwargs,
+    ):
+        start_time = time.time()
         if self.problem_type in ["regression"]:
             from chimeraboost import ChimeraBoostRegressor
 
@@ -59,25 +58,44 @@ class ChimeraBoostModel(AbstractModel):
 
             model_cls = ChimeraBoostClassifier
 
-        X = self.preprocess(X, y=y, is_train=True)
+        X = self.preprocess(X, is_train=True)
         params = self._get_model_params()
+        # Run on the CPU budget TabArena allocates (thread_count<0 => all cores).
+        params["thread_count"] = num_cpus
         # Tuned configs may sample linear_leaves=True, which raises on multiclass;
         # None = auto (binary on, multiclass off) keeps the config valid everywhere.
         if self.problem_type == "multiclass" and params.get("linear_leaves") is True:
             params["linear_leaves"] = None
         self.model = model_cls(**params)
-        # early_stopping=True with no eval_set => ChimeraBoost auto-splits a
-        # validation fraction internally and stops on it. cat_features triggers
-        # native ordered-TS encoding + (on all-cat data) auto cat_combinations.
-        cat = self._cat_indices or None
-        self.model.fit(X, y, cat_features=cat)
+
+        cat = self._cat_col_names or None
+        # Use TabArena's validation split for early stopping when provided (don't
+        # carve a second holdout out of the training data); else ChimeraBoost
+        # auto-splits internally via early_stopping=True.
+        eval_set = None
+        if X_val is not None and y_val is not None:
+            X_val = self.preprocess(X_val)
+            eval_set = (X_val, y_val)
+
+        fit_kwargs = {}
+        # Honor TabArena's time budget via a wall-clock callback (unsupported with
+        # bagging, where members fit in worker processes).
+        if time_limit is not None and params.get("n_ensembles") in (None, 1):
+            deadline = start_time + time_limit
+
+            def _time_stop(iteration, train_loss, val_loss, model):
+                return time.time() >= deadline
+
+            fit_kwargs["callbacks"] = _time_stop
+
+        self.model.fit(X, y, cat_features=cat, eval_set=eval_set, **fit_kwargs)
 
     def _set_default_params(self):
         default_params = {
-            "n_estimators": 500,
+            # Cap only: early stopping picks the real count and the auto learning
+            # rate is pinned at 0.1 under ES, so a high cap is LR-neutral headroom.
+            "n_estimators": 10000,
             "early_stopping": True,
-            "thread_count": -1,
-            "random_state": 0,
         }
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
@@ -86,3 +104,12 @@ class ChimeraBoostModel(AbstractModel):
         default_auxiliary_params = super()._get_default_auxiliary_params()
         default_auxiliary_params.update({"valid_raw_types": ["int", "float", "category"]})
         return default_auxiliary_params
+
+    @classmethod
+    def supported_problem_types(cls) -> list[str] | None:
+        return ["binary", "multiclass", "regression"]
+
+    def _get_default_resources(self) -> tuple[int, int]:
+        # Physical cores only (matches RealMLP/XRFM); ChimeraBoost is CPU-only.
+        num_cpus = ResourceManager.get_cpu_count(only_physical_cores=True)
+        return num_cpus, 0

--- a/chimeraboost/__init__.py
+++ b/chimeraboost/__init__.py
@@ -20,4 +20,4 @@ __all__ = [
     "ChimeraBoostRegressor",
     "ChimeraBoostClassifier",
 ]
-__version__ = "0.12.0"
+__version__ = "0.13.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chimeraboost"
-version = "0.12.0"
+version = "0.13.0"
 description = "CatBoost-inspired gradient boosting in pure Python with a numba backend"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_tabarena_search_space.py
+++ b/tests/test_tabarena_search_space.py
@@ -1,0 +1,54 @@
+"""Guard against config drift in the TabArena tuned search space.
+
+The de-slop pass removed several research flags from the model (e.g. hs_lambda,
+onehot_low_card). The tuned wrapper's search space referenced them and would have
+crashed every HPO config with TypeError at construction. This test re-derives the
+search-space keys straight from the wrapper source (via AST, so it needs neither
+autogluon nor tabarena installed) and asserts each is a real constructor parameter
+of the ChimeraBoost estimators -- so any future param rename/removal fails here
+instead of mid-benchmark.
+"""
+import ast
+import inspect
+from pathlib import Path
+
+from chimeraboost import ChimeraBoostClassifier, ChimeraBoostRegressor
+
+WRAPPER = (Path(__file__).resolve().parent.parent
+           / "benchmarks" / "tabarena" / "chimeraboost_tabarena_model.py")
+
+
+def _tuned_search_space_keys() -> list[str]:
+    """Extract the string keys of the `search_space = {...}` dict literal inside
+    get_configs_for_chimera_tuned, without executing the module."""
+    tree = ast.parse(WRAPPER.read_text(encoding="utf-8"), filename=str(WRAPPER))
+    func = next(n for n in ast.walk(tree)
+                if isinstance(n, ast.FunctionDef)
+                and n.name == "get_configs_for_chimera_tuned")
+    for node in ast.walk(func):
+        if (isinstance(node, ast.Assign)
+                and any(isinstance(t, ast.Name) and t.id == "search_space"
+                        for t in node.targets)
+                and isinstance(node.value, ast.Dict)):
+            return [k.value for k in node.value.keys if isinstance(k, ast.Constant)]
+    raise AssertionError("search_space dict literal not found in wrapper")
+
+
+def _valid_params() -> set[str]:
+    return (set(inspect.signature(ChimeraBoostRegressor.__init__).parameters)
+            | set(inspect.signature(ChimeraBoostClassifier.__init__).parameters))
+
+
+def test_tuned_search_space_keys_are_real_params():
+    keys = _tuned_search_space_keys()
+    assert keys, "expected a non-empty tuned search space"
+    unknown = sorted(set(keys) - _valid_params())
+    assert not unknown, (
+        f"tuned search space references params absent from the model: {unknown}. "
+        "Update get_configs_for_chimera_tuned after a param rename/removal.")
+
+
+def test_raw_cat_combinations_flag_stays_excluded():
+    """Explicit cat_combinations=True bypasses the auto-rule's resource guard and
+    can explode on high-cardinality tasks; it must stay out of the search space."""
+    assert "cat_combinations" not in _tuned_search_space_keys()


### PR DESCRIPTION
Everything behind the TabArena submission (autogluon/tabarena#358):

- **Release 0.13.0** (version bump; CHANGELOG dated) — reconciles `main` with the published PyPI 0.13.0.
- **TabArena integration** under `benchmarks/tabarena/`: the AutoGluon `AbstractModel` wrapper, full-default run/eval scripts, the upstream model package (`upstream_pr/chimeraboost/`), `SUBMISSION.md`, and the official `model_unittest.py`.
- **Wrapper review fixes**: validation-split early stopping, native categoricals + NaN passthrough, `time_limit`, `num_cpus`/seed wiring, `n_estimators`→10000, and memory estimation.  Elo jumped from 1220 to 1259.
- **Guard test** for tuned search-space drift; retired the killed-flag references in dev scripts.