### PR TITLE
Release 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to ChimeraBoost are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.14.0] - 2026-07-07
 ### Added
 - **Conformal quantile calibration.** `loss="Quantile"` predictions now include
   a split-conformal offset (`quantile_offset_`) fitted on the early-stopping

--- a/chimeraboost/__init__.py
+++ b/chimeraboost/__init__.py
@@ -20,4 +20,4 @@ __all__ = [
     "ChimeraBoostRegressor",
     "ChimeraBoostClassifier",
 ]
-__version__ = "0.13.1"
+__version__ = "0.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chimeraboost"
-version = "0.13.1"
+version = "0.14.0"
 description = "CatBoost-inspired gradient boosting in pure Python with a numba backend"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Version bump + CHANGELOG date for the PR #11 batch: parallel linear-leaf kernels (binary fits 1.4-1.8x faster, bit-identical), conformal quantile calibration (tail coverage restored to nominal; quantile predictions change vs 0.13.1 by design), colsample histogram skip, importances- under-early-stopping fix, core ordered_boosting default alignment.

Minor version because quantile predictions and feature_importances_ are behavior-visible changes; RMSE/MAE/classification predictions are bit-identical to 0.13.1.

Dist built + twine check PASSED + clean-venv smoke test (classifier, quantile incl. the conformal offset) on the installed wheel.

# What

<!-- 1-3 sentences: what changed and why. Link issues if any. -->

## Benchmark impact

<!-- Pick one: -->
- [ ] No default behavior changes (benchmarks unaffected)
- [ ] Default/algorithm change — Grinsztajn + OpenML-gate evidence attached (sign test, before/after aggregate table)

## Checklist

- [ ] `pytest` green
- [ ] TabArena-Lite untouched (sealed holdout — results are report-only, never a reason for a change)
- [ ] CHANGELOG.md updated (user-facing changes)
- [ ] Docs updated (API/parameter changes)
