### PR TITLE
Brier-gap program: attribution tooling + full lever verdicts (nothing ships)

### DIFF
--- a/benchmarks/HIGHCARD_PLAN.md
+++ b/benchmarks/HIGHCARD_PLAN.md
@@ -1,0 +1,158 @@
+# HC suite — real high-cardinality datasets for the decision stack
+
+Self-sufficient handoff (the PAYOFF.md convention): everything needed to
+implement this without its authoring session.
+
+## Why (state of the world, 2026-07-15)
+
+The Brier-gap program (benchmarks/synthgen/PAYOFF.md, results log inside)
+found that the CatBoost Brier gap lives entirely in entity-cat / high-card
+regimes: synth entity_strength Q4 = CatBoost 91% winrate at 5.2x
+concentration, while cats=none is dead flat. Grinsztajn — the suite that
+decides ships — has NO such datasets (its curation removes high-card cats
+and has 0 multiclass), so no lever targeting the gap can clear the protocol,
+and every ship to date has been selected on a suite blind to this regime.
+Ensembles proved the danger concretely: synth screen said 64W-24L, Grinsztajn
+said 7W-16L. Separately, decision-selection on one fixed 59-set suite
+accumulates composition overfitting (warning sign already on record:
+cross_features +1.5% 51W/8L on Grinsztajn, TabArena-Lite flat, OpenML gate
+only +0.4%).
+
+Fix: add a REAL high-card suite (`hc:`) to the decision tier. Not synthetic
+(the generator's prior must not vote on ships), not a Grinsztajn split (both
+halves inherit the same blind spots).
+
+Hard constraints (unchanged): pure Python loaders (sklearn fetch_openml is
+fine); TabArena sealed in every form — its DATASETS must not enter this
+suite; one benchmark at a time; script files, never `python -c`; C: has
+~4 GB free (put sklearn's cache on A:); trust file reads over scrolled
+stdout.
+
+## Step 0 — overlap audit (hard gate for every candidate)
+
+Build the exclusion lists BEFORE looking at any candidate's data:
+
+1. **TabArena dataset list** (names + OpenML dataset/task IDs). Source:
+   the local TabArena env/caches on `A:\code` (see `/tabarena` skill) — the
+   tabarena/tabrepo metadata enumerates tasks offline. Fallback: the task
+   list file in the TabArena GitHub repo. Dataset NAMES/IDs only — no
+   results of any kind are consulted; using the membership list to AVOID
+   contamination is the correct use of it.
+2. **Grinsztajn 59**: keys from `_add_grinsztajn_datasets` /
+   `benchmarks/data_cache/`.
+3. **OpenML one-shot gate panel (29 sets)**: `_add_openml_datasets` in
+   run_benchmarks.py. Overlap here would un-independent the gate.
+4. **PMLB 25**: the list in run_benchmarks.py.
+
+Match on OpenML dataset ID first, fuzzy name second (case/underscore/hyphen
+variants — "Amazon_employee_access" vs "amazon-employee-access").
+Deliverable: a candidate x {tabarena, grinsztajn, gate, pmlb} matrix
+committed into this file. Any TabArena, gate, or Grinsztajn hit = OUT.
+
+## Step 1 — candidate pool (verify EVERYTHING in-session; IDs from memory)
+
+Selection is by DATA PROPERTIES ONLY — n, d, task, cardinality, missingness
+— measured without fitting any model. No model result may influence
+inclusion/exclusion (else the suite is born cherry-picked). Degenerate
+exclusions allowed: load failure, constant target, exact duplicates.
+
+| Candidate | OpenML id (verify) | Task | Why |
+|---|---|---|---|
+| KDDCup09_appetency | 1111 | binary | 50k x 230, high-card cats, missing, 98/2 imbalance |
+| KDDCup09_churn | 1112 | binary | same family |
+| KDDCup09_upselling | 1114 | binary | same family |
+| kick (Don't Get Kicked) | 41162 | binary | 72k, vehicle model/trim/color, card ~1k |
+| Click_prediction_small | 1220 | binary | ad/site/user IDs (verify the version with raw cats) |
+| porto-seguro | 42742 | binary | 595k (subsample), ps_car_11_cat card ~104 |
+| airlines | 1169 | binary | 539k (subsample), carrier/airport codes card ~300 |
+| sf-police-incidents | 42344 | binary | 2.2M (subsample), address = extreme card |
+| open_payments | 42738 | binary | physician/company IDs (TabArena suspect — audit) |
+| Amazon_employee_access | 4135 | binary | RESOURCE card ~7k (TabArena suspect — audit) |
+| okcupid-stem | 42734 | 3-class | 50k, job/speaks/ethnicity cats |
+| Diabetes130US | 4541 | 3-class | 100k, diag codes card ~900 (TabArena suspect — audit) |
+| Traffic_violations | 42345 | 3-class | high-card (verify id/version) |
+| Allstate_Claims_Severity | 42571 | reg | 188k x 130 cats, card ~300 |
+| Mercedes_Benz | 42570 | reg | 4k x 376, X0-X8 cats |
+| KDD98 (UCI direct) | — | reg | classic high-card; heavy, optional |
+
+Target frozen suite: **N >= 12** after audit cuts, with >= 8 sets having
+max cardinality >= 50 on >= 1 feature, >= 2 regression-with-cats, and (if
+the multiclass columns land, see step 2) >= 3 multiclass-with-cats. If the
+audit kills too many, expand by property search on OpenML metadata
+(cardinality filters) BEFORE any model is fit — never after.
+
+Freeze = a `HC_DATASETS` list (name, openml id, task, subsample cap)
+committed to run_benchmarks.py + the rationale table here. After the first
+baseline run, the list only changes with a version bump (same discipline as
+synthgen freezes).
+
+## Step 2 — harness work
+
+1. `_add_highcard_datasets()` + `hc:<name>` keys + `--highcard` flag,
+   mirroring the Grinsztajn registration/run-only convention
+   (run_benchmarks.py ~line 1045). Loader: `fetch_openml(data_id=...,
+   as_frame=True)` -> cats from dtype, cached. Set `SCIKIT_LEARN_DATA=A:\code\sklearn_data`
+   (C: has no room). Subsample cap 100k rows, deterministic
+   per dataset (fixed seed, NOT the harness seed — splits must stay the only
+   seed-dependent thing; follow the existing builder pattern `(scale, rng)`).
+2. Big-set hygiene: KDD09/porto/sf-police are 50-500 MB fetches — first run
+   warm-caches serially (Grinsztajn HF-401 precedent); flaky network = just
+   relaunch.
+3. summarize.py: add `Multi F1%` / `Multi Brier%` columns rendered only when
+   multiclass records exist. **Blended-strength formula UNCHANGED** — the
+   north star (HarmonicMean of reg/binary columns) is a separate user
+   decision; these columns are report-only for now. Ripples: bench_status
+   caption, make_pareto ignores the new columns.
+4. Guards: near-solved analogs will appear (98/2 imbalance makes F1-macro
+   fragile and %-vs-best Brier can explode when best -> 0) — the existing
+   `skip_best_below` / NEAR_SOLVED guards apply per-column; verify they
+   fire, don't invent new ones preemptively.
+5. Tests: registration idempotent, loader smoke on the 2 smallest sets,
+   frozen-list-matches-doc assertion, a TabArena-overlap regression test
+   (frozen list x audited exclusion list = empty intersection).
+
+## Step 3 — baseline + shakedown (report-only, one session)
+
+1. `python benchmarks/run_benchmarks.py --highcard --seeds 3 --save
+   benchmarks/results/hc-baseline.txt` — all available models. Print the
+   aggregate table (always, unprompted).
+2. Shakedown read: near-solved artifacts, degenerate F1 on the imbalanced
+   sets, load flakes, per-model failures (XGB/LGBM native-cat paths on
+   card ~7k can be slow or OOM — record, don't fix).
+3. **First-read deliverable**: measured CatBoost-vs-ChimeraBoost gap on hc
+   (Brier winrate + %-of-best), compared against the synth entity-slice
+   prediction (entity Q4 = 91% CatBoost winrate). This doubles as the
+   fidelity test of SynthGen v2's entity-cat prior — feed the answer into
+   the v3 watch items in benchmarks/synthgen/PAYOFF.md either way.
+4. The suite is SHADOW (report-only) for this one session — it becomes a
+   co-decider only after the shakedown confirms no metric artifacts.
+
+## Step 4 — wire into the decision protocol
+
+After shakedown passes: /experiment tier 2 becomes "Grinsztajn + hc, with
+per-suite sign tests reported separately and a pooled union verdict."
+A change that wins only on one suite needs a mechanism story for why.
+Update: `.claude/skills/experiment/SKILL.md`, CLAUDE.md benchmark section,
+memory (algorithm history + a new hc-suite entry). Exact ship-rule weighting
+between the suites = Nathan's call at first live use, not hardcoded now.
+
+## Decision points reserved for Nathan
+
+- Ship-rule weighting Grinsztajn vs hc (step 4).
+- Whether multiclass enters the blended north star (step 2.3 keeps it out).
+- Whether KDD98 (heavy, license-awkward) is worth including.
+
+## Explicit non-goals
+
+No synthetic data in the decision tier. No Grinsztajn train/test split. No
+TabArena dataset reuse (audit is a hard gate). No OpenML-gate rotation here
+(separate program). No library changes. No north-star formula change.
+
+## Acceptance
+
+- [ ] Audit matrix committed; frozen list has zero TabArena/gate/Grinsztajn overlap
+- [ ] N >= 12 frozen by properties only; >= 8 sets max-card >= 50; >= 2 reg-with-cats
+- [ ] `--highcard` runs end-to-end; summarize renders (incl. multiclass columns if present)
+- [ ] hc-baseline.json on disk + aggregate table printed
+- [ ] First-read writeup: real hc gap vs synth entity prediction, logged in PAYOFF.md v3 watch items
+- [ ] Suite declared co-decider (or artifacts documented + fixes queued) + skill/docs/memory updated

--- a/benchmarks/brier_gap.py
+++ b/benchmarks/brier_gap.py
@@ -1,0 +1,154 @@
+"""Where does CatBoost's Brier edge over ChimeraBoost concentrate? (PAYOFF step 1)
+
+Reads ONE run_benchmarks JSON containing records for both models (the synv2
+full baseline) and slices the classification sets by the synth recipe meta.
+Per slice: head-to-head Brier winrate, mean excess Brier over the Bayes floor
+for both models, the mean paired gap, and mean MCB (CORP miscalibration) for
+both. The "conc" column is (share of the total summed gap carried by the
+slice) / (share of sets in the slice): >1 = the edge concentrates there.
+
+Usage:
+    python benchmarks/brier_gap.py benchmarks/results/synv2-full-baseline.json
+        [--ours ChimeraBoost] [--theirs CatBoost] [--min-n 12]
+"""
+import argparse
+
+import numpy as np
+
+import synth_report
+from synthgen.suites import CANARIES, VERSION
+
+EPS = 1e-9
+
+
+def _per_ds(per_model, model, key):
+    out = {}
+    for ds, mlist in per_model.get(model, {}).items():
+        vals = [m[key] for m in mlist if m.get(key) is not None]
+        if vals:
+            out[ds] = float(np.mean(vals))
+    return out
+
+
+def _quartile_specs(values_by_ds, prefix, universe):
+    """Quartile slices of a meta field over the datasets in `universe`."""
+    vals = np.array([values_by_ds[ds] for ds in universe])
+    if len(vals) < 8:
+        return []
+    qs = np.quantile(vals, [0.25, 0.5, 0.75])
+    edges = [(-np.inf, qs[0]), (qs[0], qs[1]), (qs[1], qs[2]), (qs[2], np.inf)]
+    return [(f"{prefix} Q{i}",
+             lambda ds, lo=lo, hi=hi: ds in universe
+             and lo <= values_by_ds[ds] < hi)
+            for i, (lo, hi) in enumerate(edges, 1)]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("run")
+    ap.add_argument("--ours", default="ChimeraBoost")
+    ap.add_argument("--theirs", default="CatBoost")
+    ap.add_argument("--min-n", type=int, default=12)
+    args = ap.parse_args()
+
+    metas, per_model = synth_report.load_run(args.run)
+    b_ours = _per_ds(per_model, args.ours, "brier")
+    b_them = _per_ds(per_model, args.theirs, "brier")
+    mcb_ours = _per_ds(per_model, args.ours, "calibration_mcb")
+    mcb_them = _per_ds(per_model, args.theirs, "calibration_mcb")
+    shared = sorted(set(b_ours) & set(b_them))
+    if not shared:
+        raise SystemExit(f"no classification sets shared by {args.ours} and "
+                         f"{args.theirs} in {args.run}")
+
+    def synth(ds, f):
+        return metas[ds]["synth"].get(f)
+
+    def is_canary(ds):
+        return (synth(ds, "gen_version") == VERSION
+                and synth(ds, "recipe_id") in CANARIES)
+
+    entity_sets = {ds for ds in shared if (synth(ds, "n_cat_entity") or 0) > 0}
+    es = {ds: float(synth(ds, "entity_strength") or 0.0) for ds in shared}
+    noise = {ds: float(synth(ds, "noise_level") or 0.0) for ds in shared}
+    imb = {ds: float(synth(ds, "imbalance") or 0.0) for ds in shared}
+
+    specs = [
+        ("all", lambda ds: True),
+        ("task=binary", lambda ds: metas[ds]["task"] == "binary"),
+        ("task=multiclass", lambda ds: metas[ds]["task"] == "multiclass"),
+        ("canary", is_canary),
+        ("cats=none", lambda ds: synth(ds, "n_cat") == 0),
+        ("cats=mixed", lambda ds: 0 < synth(ds, "cat_fraction") < 1.0),
+        ("cats=all", lambda ds: synth(ds, "cat_fraction") >= 1.0),
+        ("cats=entity", lambda ds: ds in entity_sets),
+        ("card>8", lambda ds: synth(ds, "max_cardinality") > 8),
+        ("card>16", lambda ds: synth(ds, "max_cardinality") > 16),
+        ("n<2000", lambda ds: synth(ds, "n") < 2000),
+        ("n>=2000", lambda ds: synth(ds, "n") >= 2000),
+        ("depth<=2", lambda ds: synth(ds, "interaction_depth") <= 2),
+        ("depth>=3", lambda ds: synth(ds, "interaction_depth") >= 3),
+        ("saturated", lambda ds: synth(ds, "saturated")),
+        ("imbalance>0.7", lambda ds: imb[ds] > 0.7),
+        ("missing>0", lambda ds: synth(ds, "missing_fraction") > 0),
+        ("irrelevant>0.3", lambda ds: synth(ds, "irrelevant_fraction") > 0.3),
+    ]
+    specs += _quartile_specs(es, "entity_str", entity_sets)
+    specs += _quartile_specs(noise, "noise", set(shared))
+    for kind in ("linear", "neural", "tree", "product", "plateau", "cellrule"):
+        specs.append((f"func={kind}",
+                      lambda ds, k=kind: synth(ds, "func_dominant") == k))
+
+    gap = {ds: b_ours[ds] - b_them[ds] for ds in shared}   # + = theirs better
+    total_gap = sum(gap.values())
+    n_all = len(shared)
+
+    print(f"Brier gap location: {args.ours} vs {args.theirs} over {n_all} "
+          f"classification sets [{args.run}]")
+    print(f"total summed Brier gap {total_gap:+.4f} "
+          f"(mean {total_gap / n_all:+.5f}/set; + = {args.theirs} better)\n")
+    hdr = (f"{'slice':16s} {'n':>4s} {'theyW%':>7s} {'xs ours':>8s} "
+           f"{'xs them':>8s} {'gap/set':>9s} {'conc':>6s} "
+           f"{'MCB ours':>9s} {'MCB them':>9s}")
+    print(hdr)
+
+    ranked = []
+    for label, pred in specs:
+        ds_in = [ds for ds in shared if pred(ds)]
+        if not ds_in:
+            continue
+        they_w = np.mean([gap[ds] > EPS for ds in ds_in])
+        xs_o = [b_ours[ds] - synth(ds, "bayes_brier") for ds in ds_in
+                if synth(ds, "bayes_brier") is not None]
+        xs_t = [b_them[ds] - synth(ds, "bayes_brier") for ds in ds_in
+                if synth(ds, "bayes_brier") is not None]
+        g = float(np.mean([gap[ds] for ds in ds_in]))
+        share = sum(gap[ds] for ds in ds_in) / total_gap if total_gap else 0.0
+        conc = share / (len(ds_in) / n_all)
+        mos = [mcb_ours[ds] for ds in ds_in if ds in mcb_ours]
+        mts = [mcb_them[ds] for ds in ds_in if ds in mcb_them]
+        mo = float(np.mean(mos)) if mos else float("nan")
+        mt = float(np.mean(mts)) if mts else float("nan")
+        xs_o_s = f"{np.mean(xs_o):8.4f}" if xs_o else "       -"
+        xs_t_s = f"{np.mean(xs_t):8.4f}" if xs_t else "       -"
+        print(f"{label:16s} {len(ds_in):4d} {they_w:7.0%} {xs_o_s} {xs_t_s} "
+              f"{g:+9.5f} {conc:6.2f} {mo:9.4f} {mt:9.4f}")
+        if label not in ("all", "canary") and len(ds_in) >= args.min_n:
+            ranked.append((label, len(ds_in), they_w, g, conc, mo - mt))
+
+    print(f"\nconcentration ranking (n>={args.min_n}, by conc = gap share / "
+          "set share):")
+    for label, n, w, g, conc, dmcb in sorted(ranked, key=lambda r: -r[4])[:6]:
+        print(f"  {label:16s} n={n:3d}  theyW {w:4.0%}  gap/set {g:+.5f}  "
+              f"conc {conc:5.2f}  dMCB(ours-them) {dmcb:+.4f}")
+    print("\nMCB-heavy slices (ours-them > +0.005 -> L4 calibration lever "
+          "unlocks there):")
+    hits = [r for r in ranked if r[5] > 0.005]
+    for label, n, w, g, conc, dmcb in sorted(hits, key=lambda r: -r[5]):
+        print(f"  {label:16s} n={n:3d}  dMCB {dmcb:+.4f}")
+    if not hits:
+        print("  none — refinement, not calibration, is the story everywhere")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/compare_runs.py
+++ b/benchmarks/compare_runs.py
@@ -11,6 +11,10 @@ deltas and a sign test (how many datasets NEW beats BASE).
 --model filters records to one model first. Without it, a multi-model JSON
 blends every model's records into the per-dataset mean (fine when both runs
 hold the other models fixed, but the deltas are diluted).
+--model-new names the NEW run's records when they differ (e.g. baseline
+ChimeraBoost vs an arm's ChimeraBoostEns2).
+--metric brier judges on Brier instead: classification sets only (regression
+records carry no Brier), oriented so NEW wins = lower Brier.
 """
 import argparse
 import json
@@ -19,14 +23,21 @@ from collections import defaultdict
 import numpy as np
 
 
-def per_dataset_primary(path, model=None):
+def per_dataset_metric(path, model=None, metric="primary"):
     recs = json.load(open(path))["records"]
+    sign = -1.0 if metric == "brier" else 1.0   # orient higher = better
     bucket = defaultdict(list)
     for r in recs:
         if model is not None and r["model"] != model:
             continue
-        bucket[r["dataset"]].append(r["metrics"]["primary"])
+        if r["metrics"].get(metric) is None:
+            continue
+        bucket[r["dataset"]].append(sign * r["metrics"][metric])
     return {ds: float(np.mean(v)) for ds, v in bucket.items()}
+
+
+def per_dataset_primary(path, model=None):
+    return per_dataset_metric(path, model, "primary")
 
 
 def main():
@@ -37,11 +48,17 @@ def main():
     ap.add_argument("new_label", nargs="?", default="NEW")
     ap.add_argument("--model", default=None,
                     help="restrict to one model's records (e.g. ChimeraBoost).")
+    ap.add_argument("--model-new", default=None,
+                    help="model name for the NEW run's records (default: --model).")
+    ap.add_argument("--metric", choices=["primary", "brier"], default="primary",
+                    help="judge metric; brier = classification only, "
+                         "oriented so NEW wins = lower Brier.")
     args = ap.parse_args()
     base_label, new_label = args.base_label, args.new_label
 
-    base = per_dataset_primary(args.base_path, args.model)
-    new = per_dataset_primary(args.new_path, args.model)
+    base = per_dataset_metric(args.base_path, args.model, args.metric)
+    new = per_dataset_metric(args.new_path, args.model_new or args.model,
+                             args.metric)
     shared = sorted(set(base) & set(new))
 
     wins = losses = ties = 0
@@ -62,10 +79,14 @@ def main():
         print(f"{ds:22s} {b:12.4f} {n:12.4f} {d:+12.4f}  {tag}  ({rel:+.2%})")
 
     n = len(shared)
+    mtag = args.model or ""
+    if args.model_new and args.model_new != args.model:
+        mtag = f"{mtag}->{args.model_new}"
     print(f"\n{new_label} vs {base_label}: {wins} wins / {losses} losses / {ties} ties  "
           f"(of {n} datasets)"
-          + (f"  [model={args.model}]" if args.model else ""))
-    print(f"mean relative change in primary: {np.mean(rel_deltas):+.3%}")
+          + (f"  [model={mtag}]" if mtag else ""))
+    print(f"mean relative change in {args.metric} (+ = better): "
+          f"{np.mean(rel_deltas):+.3%}")
     need = n // 2 + 1
     verdict = "PASS" if wins >= need else "FAIL"
     print(f"sign-test bar (> half = {need}+ wins): {verdict}")

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -521,7 +521,8 @@ PATIENCE = 50
 def _run_chimera(task, Xtr, ytr, Xte, yte, cat, threads, lr=None,
                  ordered_boosting=None, depth=6, subsample=1.0, mcw=None,
                  cat_combinations=None, leaf_estimation_iterations=None,
-                 linear_leaves=False, linear_lambda=1.0, cross_features=False):
+                 linear_leaves=False, linear_lambda=1.0, cross_features=False,
+                 cat_smoothing=None):
     t = time.time()
     Est = ChimeraBoostRegressor if task == "regression" else ChimeraBoostClassifier
     # None = use the class default. For ordered_boosting that's False (Reg) /
@@ -532,6 +533,8 @@ def _run_chimera(task, Xtr, ytr, Xte, yte, cat, threads, lr=None,
         kw["leaf_estimation_iterations"] = leaf_estimation_iterations
     if mcw is not None:
         kw["min_child_weight"] = mcw
+    if cat_smoothing is not None:
+        kw["cat_smoothing"] = cat_smoothing
     # None = use the class auto-default (on for all-categorical data); only force
     # it on when --chimera-cat-combinations is passed.
     if cat_combinations:
@@ -963,6 +966,10 @@ def main():
                     default=False, dest="cat_combinations",
                     help="enable 2-way categorical feature combinations "
                          "(default: off).")
+    ap.add_argument("--chimera-cat-smoothing", type=float, default=None,
+                    dest="cat_smoothing",
+                    help="Bayesian pseudocount in the ordered target-statistic "
+                         "denominator (default: None = class default 1.0).")
     ap.add_argument("--chimera-lei", type=int, default=None,
                     dest="leaf_estimation_iterations",
                     help="leaf estimation iterations: additional Newton steps to "
@@ -1102,6 +1109,7 @@ def main():
     chimera_cfg = dict(lr=args.lr, ordered_boosting=ob_override,
                        depth=args.chimera_depth, subsample=args.chimera_subsample,
                        mcw=args.chimera_mcw, cat_combinations=args.cat_combinations,
+                       cat_smoothing=args.cat_smoothing,
                        leaf_estimation_iterations=args.leaf_estimation_iterations,
                        linear_leaves="auto" if args.linear_leaves_auto
                        else ("off" if args.no_linear_leaves
@@ -1130,6 +1138,8 @@ def main():
           + ("  ordered_boosting=off" if not args.ordered_boosting else "")
           + (f"  subsample={args.chimera_subsample}" if args.chimera_subsample < 1.0 else "")
           + ("  cat_combinations=on" if args.cat_combinations else "")
+          + (f"  cat_smoothing={args.cat_smoothing}"
+             if args.cat_smoothing is not None else "")
           + (f"  synth={args.synth_suite}" if args.synth else "")
           + "\n")
 

--- a/benchmarks/synth_report.py
+++ b/benchmarks/synth_report.py
@@ -7,6 +7,10 @@ Modes (all read standard run_benchmarks --save JSONs, syn: datasets only):
   python benchmarks/synth_report.py BASE.json NEW.json [--model ChimeraBoost]
       A/B attribution: per-dataset primary deltas sliced by recipe factors,
       sign tests per slice, plus an OLS pass ranking factors by |t|.
+      --metric brier restricts to classification sets and judges on Brier
+      (sign flipped so + still means "arm better").
+      --model-new compares different model names across the runs (e.g.
+      baseline ChimeraBoost records vs an arm's ChimeraBoostEns2 records).
   python benchmarks/synth_report.py RUN.json --realism
       Cross-model ordering checks (is the suite shaped like real data?).
 
@@ -41,11 +45,26 @@ def load_run(path):
     return ds_meta, per
 
 
-def primary_means(per_model, model):
+def metric_means(per_model, model, metric="primary"):
+    """Per-dataset mean of `metric`, oriented so higher = better.
+
+    "brier" is lower-better, so it is negated; datasets whose records lack the
+    metric (regression sets have no Brier) are dropped, which restricts the
+    brier view to classification.
+    """
     if model not in per_model:
         raise SystemExit(f"model {model!r} not in run; have {sorted(per_model)}")
-    return {ds: float(np.mean([m["primary"] for m in v]))
-            for ds, v in per_model[model].items()}
+    sign = -1.0 if metric == "brier" else 1.0
+    out = {}
+    for ds, v in per_model[model].items():
+        vals = [m[metric] for m in v if m.get(metric) is not None]
+        if vals:
+            out[ds] = sign * float(np.mean(vals))
+    return out
+
+
+def primary_means(per_model, model):
+    return metric_means(per_model, model, "primary")
 
 
 # ---------------------------------------------------------------------------
@@ -217,6 +236,13 @@ def main():
     ap.add_argument("base")
     ap.add_argument("new", nargs="?", default=None)
     ap.add_argument("--model", default="ChimeraBoost")
+    ap.add_argument("--model-new", default=None,
+                    help="model name for the NEW run's records (default: "
+                         "--model). Lets an ensemble arm compare e.g. base "
+                         "ChimeraBoost vs new ChimeraBoostEns2.")
+    ap.add_argument("--metric", choices=["primary", "brier"], default="primary",
+                    help="A/B judge metric. brier = classification sets only, "
+                         "delta sign flipped so + means the arm is better.")
     ap.add_argument("--realism", action="store_true")
     args = ap.parse_args()
 
@@ -232,9 +258,12 @@ def main():
         return
     metas_new, per_new = load_run(args.new)
     metas.update(metas_new)
-    base = primary_means(per_model, args.model)
-    new = primary_means(per_new, args.model)
-    print(f"A/B attribution: {args.base} -> {args.new} [model={args.model}]\n")
+    model_new = args.model_new or args.model
+    base = metric_means(per_model, args.model, args.metric)
+    new = metric_means(per_new, model_new, args.metric)
+    tag = args.model if model_new == args.model else f"{args.model}->{model_new}"
+    print(f"A/B attribution: {args.base} -> {args.new} "
+          f"[model={tag}, metric={args.metric}]\n")
     ab_report(metas, base, new)
 
 

--- a/benchmarks/synth_report.py
+++ b/benchmarks/synth_report.py
@@ -110,16 +110,16 @@ def _bucket_specs(metas):
     return specs
 
 
-def _rel_delta(base, new):
+def _rel_delta(base, new, denom_floor=1e-12):
     out = {}
     for ds in set(base) & set(new):
         b = base[ds]
-        out[ds] = (new[ds] - b) / max(abs(b), 1e-12)
+        out[ds] = (new[ds] - b) / max(abs(b), denom_floor)
     return out
 
 
-def ab_report(metas, base, new):
-    deltas = _rel_delta(base, new)
+def ab_report(metas, base, new, denom_floor=1e-12):
+    deltas = _rel_delta(base, new, denom_floor)
     if not deltas:
         raise SystemExit("no shared syn: datasets between the two runs")
     print(f"{'slice':18s} {'n':>4s} {'W-L-T':>9s} {'mean d':>9s} {'p':>7s}")
@@ -264,7 +264,11 @@ def main():
     tag = args.model if model_new == args.model else f"{args.model}->{model_new}"
     print(f"A/B attribution: {args.base} -> {args.new} "
           f"[model={tag}, metric={args.metric}]\n")
-    ab_report(metas, base, new)
+    # Brier can be ~0 on saturated sets (model at the floor); an unfloored
+    # relative delta there explodes and swamps every mean. 0.01 caps the
+    # per-set delta while leaving ordinary sets (brier >> 0.01) untouched.
+    ab_report(metas, base, new, denom_floor=0.01 if args.metric == "brier"
+              else 1e-12)
 
 
 if __name__ == "__main__":

--- a/benchmarks/synthgen/PAYOFF.md
+++ b/benchmarks/synthgen/PAYOFF.md
@@ -111,6 +111,41 @@ Grinsztajn — kill on the screen, never tune the library on synth.
 - Any DEFAULT change that ships: refresh `images/pareto.png` (`/pareto`) and
   get user sign-off on speed trades.
 
+## Results log (2026-07-15, branch brier-refinement)
+
+- **Step 0 shipped**: `synth_report.py`/`compare_runs.py` `--metric brier`
+  + `--model-new`; `--chimera-cat-smoothing` harness flag; brier rel-delta
+  denominator floored at 0.01 (saturated sets sit at Brier ~0 and exploded
+  the means). Tests extended (planted Brier slice, zero-floor case).
+- **Step 1 verdict** (`brier_gap.py` on synv2-full-baseline): the gap is
+  CATEGORICAL. cats=none dead flat (+0.0001/set, 54% winrate). Concentration:
+  entity_strength Q4 conc 5.24 (CatBoost 91% winrate), card>16 3.70,
+  saturated/cellrule 3.88, cats=entity 3.03. No MCB-heavy slice -> L4
+  calibration LOCKED OUT (refinement, not calibration, everywhere).
+  Pre-registration flipped L3 ahead of L1.
+- **L3 cat_smoothing KILLED** (x{0.25,2,4,8,16} full dose curve): mechanism
+  real (entity_strength top OLS factor every arm, t=+5.1 at cs4) but the
+  clf-Brier sign test never clears p<=0.2 (best: all 19W-15L p=0.61; binary
+  15W-7L p=0.13 at cs4), the dose curve is non-monotone around the default
+  (cs2 reads -0.68%), and cs16 buys Brier with an accuracy breach (F1 entity
+  -1.44%, reg -1.40%). Magnitude ceiling ~+0.2% binary Brier = not worth a
+  PMLB retune.
+- **L2 leaf_estimation_iterations KILLED**: premise was wrong (clf default
+  is already 3; 1 is the regressor's). lei=5: Brier 9W-15L, entity slice
+  -2.1% (p=0.049 AGAINST); lei=2: 12W-12L noise. Multiclass path ignores lei
+  entirely (0-0-34 exact ties, both arms).
+- **L1 ensembles PROMOTED off the screen**: Ens2 clf-Brier 64W-24L p<0.001
+  (binary +2.89%); Ens5 82W-6L (binary +7.54%), accuracy also up (+0.82%
+  p<0.001, reg +2.09%). Canary clean (F1 exact ties; canary Brier worse =
+  safe direction; bootstrap thinning hurts near-floor sets, explains the
+  negative slice means under floored rel-deltas). Screen percent-of-best:
+  Ens2 Bin Brier% 93.4 vs CatBoost 93.5 at 4.4x vs 81.6x (gap CLOSED);
+  Ens5 95.9 (BEATS CatBoost) at 11.2x, Reg RMSE% 96.0->98.0.
+- **Next**: Grinsztajn A/B (baseline `merged-crossfeat-20260713.json` —
+  its ChimeraBoost records match today's cross_features-on default; the
+  22:45 sibling is flag-off) -> OpenML one-shot -> Pareto evidence; the
+  n_ensembles default flip (1->2?) is the user's speed-trade call.
+
 ## Generator v3 watch items (do NOT act now; only at the next re-freeze)
 
 - mcw1 arm disagreed in v2: its pre-registered small-n clf slice shrank to 10

--- a/benchmarks/synthgen/PAYOFF.md
+++ b/benchmarks/synthgen/PAYOFF.md
@@ -141,13 +141,39 @@ Grinsztajn — kill on the screen, never tune the library on synth.
   negative slice means under floored rel-deltas). Screen percent-of-best:
   Ens2 Bin Brier% 93.4 vs CatBoost 93.5 at 4.4x vs 81.6x (gap CLOSED);
   Ens5 95.9 (BEATS CatBoost) at 11.2x, Reg RMSE% 96.0->98.0.
-- **Next**: Grinsztajn A/B (baseline `merged-crossfeat-20260713.json` —
-  its ChimeraBoost records match today's cross_features-on default; the
-  22:45 sibling is flag-off) -> OpenML one-shot -> Pareto evidence; the
-  n_ensembles default flip (1->2?) is the user's speed-trade call.
+- **L1 KILLED at Grinsztajn (the decision suite; screen verdict REVERSED).**
+  Baseline `merged-crossfeat-20260713.json` (flag-on ChimeraBoost = today's
+  default; same-run control 0W-0L-59T bit-identical, clean A/B). Ens2 Brier
+  7W-16L mean -1.15% FAIL (bootstrap-thinned members + in-bag ES cost more
+  than 2-way averaging recovers on real data); Ens2 primary 23W-36L FAIL.
+  Ens5 Brier 12W-11L coin flip; Ens5 primary 43W-16L +1.89% decisive but at
+  43.1x slowdown = Pareto-dominated as a default (opt-in n_ensembles already
+  ships). OpenML one-shot NOT burned (nothing to ship). Synth speed ratios
+  DO NOT transfer: Ens2 read 4.4x-vs-CatBoost-81.6x on synth, 17.2x-vs-11.8x
+  (slower than CatBoost) on Grinsztajn.
+- **PROGRAM CONCLUSION**: the Bin Brier gap in the target table is a
+  SYNTH-SUITE phenomenon (entity cats / high card / cellrule — regimes
+  Grinsztajn lacks). On Grinsztajn, post-cross_features ChimeraBoost is
+  ALREADY #1 on Bin Brier (98.4 vs CatBoost 95.4). Every pre-registered
+  lever is now killed or non-transferring; nothing ships from this program.
+  Residual honest options, all deferred: (a) treat the entity-cat Brier gap
+  as a documented suite blind spot (v3 watch item below), (b) an ensemble
+  variant with shared held-out ES instead of in-bag (new lever, would need
+  its own program; cf. the 2026-07-08 GES data-tax kill), (c) revisit only
+  if a real-data suite with entity cats enters the decision stack (TabArena
+  stays sealed).
 
 ## Generator v3 watch items (do NOT act now; only at the next re-freeze)
 
+- **Suite-vs-decision-stack divergence (2026-07-15, from this program):** the
+  v2 entity-cat/high-card Brier gap vs CatBoost is real IN-SUITE but has no
+  expression on Grinsztajn (no entity cats there), so no lever targeting it
+  can clear the decision protocol. Either v3 justifies the entity-cat weight
+  against harvested real-data marginals (is 44/137 clf sets with entity cats
+  representative?), or the decision stack gains a real high-card suite;
+  until then, treat in-suite entity-slice gaps as report-only color, not
+  targets. Also: synth speed ratios are NOT decision-grade (CatBoost 50-80x
+  slow on synth vs 11.8x on Grinsztajn — tiny-set anomaly).
 - mcw1 arm disagreed in v2: its pre-registered small-n clf slice shrank to 10
   sets under the 0.35 small-n cap (W5-L5 +0.41%). Either widen the slice
   definition (n<3000?) or seed more small-n clf sets.

--- a/benchmarks/synthgen/PAYOFF.md
+++ b/benchmarks/synthgen/PAYOFF.md
@@ -1,0 +1,125 @@
+# The payoff program — closing the classification-Brier gap with the v2 suite
+
+Self-sufficient handoff (the V2.md convention): everything needed to run this
+program without its authoring session.
+
+## State of the world (2026-07-15)
+
+- SynthGen v2 SHIPPED: branch `synthgen-v2`, PR #16 (open; #15 merged). Gate
+  7/9 + canary clean; all V2.md acceptance lines met. Verdicts in
+  `benchmarks/synthgen/V2.md` + README.
+- Baselines on disk (gitignored, KEEP them — they are the reusable A/B bases):
+  `benchmarks/results/synv2-baseline.json` (screen, 136 sets, ~15 min/arm)
+  and `synv2-full-baseline.json` (full, 211 sets, ~1 h).
+- **The target** (percent-of-best table, `summarize.py synv2-full-baseline.json`):
+
+  | Model | Reg RMSE% | Bin F1% | Bin Brier% | Bin Calib (MCB) | Speed |
+  |---|---|---|---|---|---|
+  | ChimeraBoost | **97.1** | 98.9 | 92.8 | 6.41m | 2.5× |
+  | CatBoost | 94.9 | **99.5** | **96.5** | 6.38m | 73.9× |
+
+  Bin Brier% 92.8 vs 96.5 is the biggest remaining accuracy-column gap
+  (v1 read 91.4 vs 98.1; the entity cats narrowed it but did not close it).
+- **Free diagnostic already in hand:** MCB (CORP miscalibration) is TIED
+  (6.41 vs 6.38). CatBoost's Brier edge is REFINEMENT — sharper probabilities
+  — not calibration. Calibration-flavored levers are therefore deprioritized
+  until attribution says otherwise (pre-registered below).
+
+Hard constraints (unchanged): pure Python (numpy/numba/sklearn); TabArena
+sealed in every form; one benchmark at a time; script files, never
+`python -c`; synth never ships anything alone — Grinsztajn decides, OpenML
+one-shot gates. Trust file reads over scrolled console output.
+
+## Already ruled out — do NOT re-run (see `benchmarks/research/SUMMARY.md`)
+
+Seven CatBoost-mechanism ports, seven kills (C1 one-hot, C3 selective combos,
+C4 cat-aware binning, G1 forest leaf refit, G2 mass-adaptive shrinkage, G3
+adaptive leaf-estimation, G4 ordered+leaf); their flags were REMOVED from the
+library (2026-06-15). C2 per-tree TS permutation deferred by architecture.
+Also dead: broad HP random search (anti-generalizes, PMLB study),
+tail-averaging, lr probe. Knob characterization says defaults are excellent on
+real data BUT the cat knobs were blind there — Grinsztajn has almost no
+high-card cats. **v2's entity cats are the first instrument that can actually
+see them.** That is what this program exploits.
+
+## Step 0 — tooling (~30 min, no benchmark)
+
+`synth_report.py` and `backtest.py` judge on `metrics["primary"]` (F1 for
+clf). A Brier-targeted sweep needs Brier attribution:
+
+- Add `--metric {primary,brier}` to `synth_report.py` A/B mode: with `brier`,
+  restrict to classification sets and use `metrics["brier"]` (lower=better —
+  flip the delta sign so + still means "arm better"). Slices/OLS unchanged.
+- Add `--model-new` (defaults to `--model`) so the L1 ensemble arm can compare
+  baseline `ChimeraBoost` records against arm `ChimeraBoostEns2` records.
+- Extend `tests/test_synth_report.py` with a planted Brier-slice effect.
+- Optional: same flags on `compare_runs.py` if a sign-test headline is wanted.
+
+## Step 1 — locate the gap (~0 cost, JSONs exist)
+
+Script over `synv2-full-baseline.json`: per-slice CatBoost-vs-ChimeraBoost
+Brier winrate + mean excess-Brier-vs-floor for both models, sliced by the
+synth meta (cats=entity / entity_strength quartiles / card>8 / n<2000 /
+depth / noise_level / imbalance / func_dominant). Output: the 2–3 slices
+where CatBoost's Brier edge concentrates. Pre-registration: the lever whose
+signature matches the located gap runs first; a lever that wins ONLY outside
+those slices is suspect (variance, not mechanism).
+
+## Step 2 — pre-registered lever queue (screen arms, ~15 min each)
+
+Run each as one screen arm vs `synv2-baseline.json`; judge with
+`synth_report.py BASE NEW --metric brier` + canary/car-analog sanity; kill
+fast. Expected-value order:
+
+- **L1 small probability ensembles** (`n_ensembles=2`, then 5; harness
+  runners exist: `--models ChimeraBoost ChimeraBoostEns2 CatBoost ...` —
+  the Ens2/Ens5/Ens10 model names in `run_benchmarks.py:744`). Averaging
+  probabilities is the classic refinement lever and the library already
+  ships it. Judged on Brier AND blended
+  strength: ens2 ≈ 2× fit cost → ~5× total slowdown, still ~15× faster than
+  CatBoost here. If it closes ≥half the Brier gap at ens2, this is the
+  headline candidate; the ship decision is a Pareto call (user decides the
+  speed trade, cross_features precedent).
+- **L2 `leaf_estimation_iterations` 2 and 3** (default 1): extra Newton steps
+  sharpen leaf probabilities — the refinement mechanism. Expected signature:
+  clf Brier gains on deep/noisy sets; canary slice must stay flat; watch
+  fit-time (should be ~+few %/step).
+- **L3 `cat_smoothing` sweep ×{0.25, 4, 16} of default**: per-level TS prior
+  strength. First real test now that entity cats + rare levels exist.
+  Expected signature: gains concentrated on cats=entity / high
+  entity_strength / card>8, ~ties elsewhere. If the entity slice moves >1%
+  either direction, follow with a finer sweep before judging.
+- **L4 (conditional) calibration flavored** (temperature/isotonic on the
+  internal early-stopping split, post-fit): ONLY if step 1 finds an MCB-heavy
+  slice (e.g. small-n or high-imbalance) — the aggregate says calibration is
+  tied, so opening this without slice evidence is dredging.
+
+Kill criterion per lever: clf-Brier sign test not favorable (or p>0.2) on the
+screen, OR canary slice positive, OR reg/F1 collateral regression >0.3%
+overall. Promote criterion: favorable sign test with a slice story matching
+step 1, canary clean → `/experiment` (Grinsztajn decides, OpenML gates; PMLB
+only if the winner is an HP retune). Budget: ~1 h screen time per idea vs ~6 h
+Grinsztajn — kill on the screen, never tune the library on synth.
+
+## Bookkeeping
+
+- Branch off `main` AFTER PR #16 merges (levers touch library src; don't
+  stack on the synthgen-v2 branch).
+- Screen arms: `python benchmarks/run_benchmarks.py --synth --seeds 3
+  --save benchmarks/results/brier-<lever>.txt <flags>` — the `--synth`
+  default suite is already `screen`; always print the aggregate table.
+- Any DEFAULT change that ships: refresh `images/pareto.png` (`/pareto`) and
+  get user sign-off on speed trades.
+
+## Generator v3 watch items (do NOT act now; only at the next re-freeze)
+
+- mcw1 arm disagreed in v2: its pre-registered small-n clf slice shrank to 10
+  sets under the 0.35 small-n cap (W5-L5 +0.41%). Either widen the slice
+  definition (n<3000?) or seed more small-n clf sets.
+- depth4 is a not-win but not yet a strict loss (W61-L57 −0.11%) — if v3
+  wants the flip to decisive, push the depth/width prior further.
+- Saturated REGRESSION sets sit far from ceiling (rmse_ratio 8–15 in the
+  canary re-verification log) — none qualify as canaries; reg canaries need a
+  different construction (fewer cells or higher noise floor) if wanted.
+- Entity-cat cardinality center is floored at 8 (see `emit._entity_column`);
+  revisit against harvested marginals if the card>8 realism margin drifts.

--- a/tests/test_synth_report.py
+++ b/tests/test_synth_report.py
@@ -142,6 +142,27 @@ def test_brier_mode_recovers_planted_slice_and_skips_regression(tmp_path):
     assert by_label["all"][5] > 0
 
 
+def test_brier_denom_floor_tames_zero_base(tmp_path):
+    """A saturated set with base Brier ~0 must not explode the slice means."""
+    metas = _metas()
+    primary = {ds: 0.70 for ds in metas}
+    ds0 = sorted(metas)[0]
+    base_brier = {ds: (0.0 if ds == ds0 else 0.20) for ds in metas}
+    new_brier = {ds: (0.004 if ds == ds0 else 0.20) for ds in metas}
+    pb = _fake_run(str(tmp_path), "b.json", primary, metas,
+                   brier_by_ds=base_brier)
+    pn = _fake_run(str(tmp_path), "n.json", primary, metas,
+                   brier_by_ds=new_brier)
+    m, per_b = synth_report.load_run(pb)
+    _, per_n = synth_report.load_run(pn)
+    base = synth_report.metric_means(per_b, "ChimeraBoost", "brier")
+    new = synth_report.metric_means(per_n, "ChimeraBoost", "brier")
+    rows = synth_report.ab_report(m, base, new, denom_floor=0.01)
+    all_row = {r[0]: r for r in rows}["all"]
+    # unfloored this would be -4e9%; floored it is -0.004/0.01/8 = -5%
+    assert abs(all_row[5]) < 0.10
+
+
 def test_model_new_compares_across_model_names(tmp_path):
     metas = _metas()
     primary = {ds: 0.70 for ds in metas}

--- a/tests/test_synth_report.py
+++ b/tests/test_synth_report.py
@@ -10,18 +10,26 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "benchmarks"))
 import synth_report
 
 
-def _fake_run(tmp_path, name, primary_by_ds, metas):
+def _fake_run(tmp_path, name, primary_by_ds, metas, brier_by_ds=None,
+              model="ChimeraBoost"):
+    def _metrics(ds, p, brier_scale=1.0):
+        if metas[ds]["task"] == "regression":
+            # regression records carry NO brier key (mirrors run_benchmarks)
+            return {"primary": p, "rmse": -p}
+        b = (brier_by_ds or {}).get(ds, 0.2)
+        return {"primary": p, "brier": b * brier_scale, "rmse": 1.0}
+
     data = {
         "config": {"seeds": 1},
         "datasets": metas,
         "records": [
-            {"dataset": ds, "model": "ChimeraBoost", "seed": 0,
-             "metrics": {"primary": p, "brier": 0.2, "rmse": 1.0},
+            {"dataset": ds, "model": model, "seed": 0,
+             "metrics": _metrics(ds, p),
              "fit_time": 0.1, "best_iter": 10}
             for ds, p in primary_by_ds.items()
         ] + [
             {"dataset": ds, "model": "LightGBM", "seed": 0,
-             "metrics": {"primary": p * 0.9, "brier": 0.25, "rmse": 1.1},
+             "metrics": _metrics(ds, p * 0.9, brier_scale=1.25),
              "fit_time": 0.05, "best_iter": 10}
             for ds, p in primary_by_ds.items()
         ],
@@ -82,3 +90,69 @@ def test_model_filter_isolates_chimera(tmp_path):
     prim_l = synth_report.primary_means(per, "LightGBM")
     assert all(abs(prim_c[ds] - 0.70) < 1e-12 for ds in prim_c)
     assert all(abs(prim_l[ds] - 0.63) < 1e-12 for ds in prim_l)
+
+
+def _metas_with_reg():
+    """The 8 binary sets plus 2 regression sets (which carry no Brier)."""
+    metas = _metas()
+    for i in range(8, 10):
+        metas[f"syn:v1/{i:03d}"] = {
+            "task": "regression", "n_train": 1500, "n_total": 2000,
+            "n_features": 10, "has_cats": False,
+            "synth": {"gen_version": "v1", "recipe_id": i, "task": "regression",
+                      "n": 3000, "d": 10, "interaction_depth": 3,
+                      "cat_fraction": 0.0, "n_cat": 0, "max_cardinality": 0,
+                      "irrelevant_fraction": 0.2, "noise_level": 0.3,
+                      "missing_fraction": 0.0, "imbalance": 0.5,
+                      "saturated": False, "func_dominant": "neural",
+                      "bayes_brier": None, "noise_sigma": 1.0, "n_classes": 0},
+        }
+    return metas
+
+
+def test_brier_mode_recovers_planted_slice_and_skips_regression(tmp_path):
+    metas = _metas_with_reg()
+    primary = {ds: (0.70 if metas[ds]["task"] == "binary" else -1.5)
+               for ds in metas}
+    base_brier = {ds: 0.20 for ds in metas if metas[ds]["task"] == "binary"}
+    # plant: Brier drops (improves) only on the deep-interaction half
+    new_brier = {ds: (0.16 if metas[ds]["synth"]["interaction_depth"] >= 3
+                      else 0.20) for ds in base_brier}
+    pb = _fake_run(str(tmp_path), "base.json", primary, metas,
+                   brier_by_ds=base_brier)
+    pn = _fake_run(str(tmp_path), "new.json", primary, metas,
+                   brier_by_ds=new_brier)
+
+    m, per_b = synth_report.load_run(pb)
+    _, per_n = synth_report.load_run(pn)
+    base = synth_report.metric_means(per_b, "ChimeraBoost", "brier")
+    new = synth_report.metric_means(per_n, "ChimeraBoost", "brier")
+    # regression sets carry no Brier -> excluded from the brier view
+    assert all(m[ds]["task"] == "binary" for ds in base)
+    assert len(base) == 8
+
+    rows = synth_report.ab_report(m, base, new)
+    by_label = {r[0]: r for r in rows}
+    label, n, w, l, t, mean_d, p = by_label["depth>=3"]
+    assert (w, l) == (4, 0) and mean_d > 0.15   # (0.20-0.16)/0.20 = +20% rel
+    label, n, w, l, t, mean_d, p = by_label["depth<=2"]
+    assert (w, l) == (0, 0)
+    assert "task=regression" not in by_label
+    # the planted improvement must read as POSITIVE (sign flipped for brier)
+    assert by_label["all"][5] > 0
+
+
+def test_model_new_compares_across_model_names(tmp_path):
+    metas = _metas()
+    primary = {ds: 0.70 for ds in metas}
+    pb = _fake_run(str(tmp_path), "b.json", primary, metas)   # brier 0.20
+    pn = _fake_run(str(tmp_path), "n.json", primary, metas,
+                   brier_by_ds={ds: 0.18 for ds in metas},
+                   model="ChimeraBoostEns2")
+    _, per_b = synth_report.load_run(pb)
+    _, per_n = synth_report.load_run(pn)
+    base = synth_report.metric_means(per_b, "ChimeraBoost", "brier")
+    new = synth_report.metric_means(per_n, "ChimeraBoostEns2", "brier")
+    assert len(base) == len(new) == len(metas)
+    assert all(abs(base[ds] - (-0.20)) < 1e-12 for ds in base)
+    assert all(abs(new[ds] - (-0.18)) < 1e-12 for ds in new)


### PR DESCRIPTION
Executes benchmarks/synthgen/PAYOFF.md end to end on the v2 suite.

**Tooling (the durable part):**
- synth_report.py / compare_runs.py: --metric brier (classification-only, sign-flipped so + = arm better) and --model-new (compare ensemble-arm records against plain baseline records); brier rel-delta denominator floored at 0.01 (saturated sets sit at Brier ~0 and exploded slice means).
- run_benchmarks.py: --chimera-cat-smoothing passthrough.
- benchmarks/brier_gap.py: slices the CatBoost-vs-ChimeraBoost Brier gap by recipe meta (winrate, excess-vs-floor, MCB, concentration) on one run JSON.
- tests: planted Brier-slice recovery, cross-model comparison, zero-floor case.

**Program verdicts (logged in PAYOFF.md):**
- Gap located: 100% categorical (entity_strength Q4 conc 5.2x, CatBoost 91% winrate; numerics dead flat; no MCB-heavy slice, so calibration levers stay locked out).
- L3 cat_smoothing x{0.25,2,4,8,16}: mechanism real (entity t=+5.1) but never clears the sign test; killed.
- L2 leaf_estimation_iterations: premise wrong (clf default is already 3); lei=5 hurts cats; killed.
- L1 probability ensembles: screen said yes (Ens2 64W-24L p<0.001), Grinsztajn reversed it (Ens2 Brier 7W-16L, -1.15%; control bit-identical). Ens5 is +1.9% primary at 43x = dominated as a default. OpenML one-shot not burned.
- Conclusion: the target Brier gap is a synth-suite phenomenon (entity cats, which Grinsztajn lacks); post-cross_features we are already #1 on Grinsztajn Bin Brier (98.4 vs CatBoost 95.4). Divergence recorded as a v3 watch item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)