### PR TITLE
HC suite: real high-cardinality decision suite (--highcard)

### DIFF
--- a/.claude/skills/experiment/SKILL.md
+++ b/.claude/skills/experiment/SKILL.md
@@ -17,12 +17,25 @@ The validated 3-tier methodology (it shipped mcw-auto, linear-leaves, cross_feat
    recipe factor can express the idea. Known v1 biases (don't over-read): targets run slightly
    shallow (depth-4 arm disagrees), synthetic cats lack entity effects (CatBoost's high-card
    moat absent), mcw large-n slice leans positive — see `benchmarks/synthgen/README.md`.
-2. **Full Grinsztajn A/B** (the decision suite):
-   - Baseline: reuse the newest clean `benchmarks/results/*.json` if the field/seeds match, else run one.
-   - `python benchmarks/run_benchmarks.py --grinsztajn --seeds 3 --save` (flags for the variant:
-     see `--chimera-*` args in run_benchmarks.py).
-   - **Sequential only** — never two benchmarks at once. Progress: `python benchmarks/bench_status.py`.
-   - Compare: `python benchmarks/compare_runs.py BASE.json NEW.json` (per-dataset sign test).
+2. **Decision-suite A/B — Grinsztajn + HC (run BOTH, sign-test SEPARATELY):**
+   - Grinsztajn (the low/no-card, 0-multiclass suite):
+     `python benchmarks/run_benchmarks.py --grinsztajn --seeds 3 --save`.
+   - HC (the real high-cardinality suite: entity cats, high card, multiclass — the
+     regime Grinsztajn is blind to; `benchmarks/HIGHCARD_PLAN.md`):
+     `python benchmarks/run_benchmarks.py --highcard --seeds 3 --save`.
+     Confirmed 2026-07-15 to faithfully express the CatBoost high-card Brier moat
+     the synth entity prior predicted (86–88% CB Brier winrate; `hc_gap.py`).
+   - Baselines: reuse the newest clean `*.json` per suite if field/seeds match, else run one.
+     Variant flags: see `--chimera-*` args in run_benchmarks.py.
+   - **Sequential only** — never two benchmarks at once (HC's CatBoost fits run
+     50–240 s on card 7k–15k). Progress: `python benchmarks/bench_status.py`.
+   - Compare each suite: `python benchmarks/compare_runs.py BASE.json NEW.json`
+     (per-dataset sign test). **Report the two sign tests separately**, then a
+     pooled union verdict. A change that wins on only ONE suite needs a mechanism
+     story for why (e.g. a high-card lever helps HC but is inert on Grinsztajn).
+     Exact ship-rule weighting Grinsztajn vs HC = Nathan's call at first live use
+     (not hardcoded). HC multiclass Brier/F1 columns are report-only — the blended
+     north star (make_pareto) is unchanged.
 3. **Independent one-shot gate**: `--openml` (never re-run until it passes — it's one-shot to stay independent).
    PMLB (`--pmlb --pmlb-fold tune`) is only for HP tuning, with `holdout` as its confirm fold.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Pure-Python oblivious-tree GBDT (numpy + numba + sklearn only).
 - **Always print the aggregate results table after every benchmark run**, unprompted.
 
 ## Benchmarks
-- Decision suite: `python benchmarks/run_benchmarks.py --grinsztajn --seeds 3 --save` → `benchmarks/results/<stamp>.json` (gitignored). Independent gate: `--openml`. HP tuning: `--pmlb --pmlb-fold tune|holdout`.
+- Decision suites (run both, sign-test separately): `--grinsztajn` (low/no-card, no multiclass) and `--highcard` (real high-cardinality cats + multiclass — the regime Grinsztajn is blind to; see `benchmarks/HIGHCARD_PLAN.md`, `benchmarks/hc_gap.py`). `python benchmarks/run_benchmarks.py --grinsztajn --seeds 3 --save` → `benchmarks/results/<stamp>.json` (gitignored). Independent gate: `--openml`. HP tuning: `--pmlb --pmlb-fold tune|holdout`.
 - Mechanism probe (tier 1): `--synth` = frozen SynthGen prior-sampled suite (`benchmarks/synthgen/`, NO TabArena in any form incl. metadata). Attribute deltas: `benchmarks/synth_report.py BASE NEW`. Any generator change ⇒ VERSION bump + re-freeze + `benchmarks/synthgen/backtest.py` re-validation (gate ≥7/9 vs ledger).
 - Sign-test two runs: `python benchmarks/compare_runs.py BASE.json NEW.json [--model ChimeraBoost]`.
 - Progress / latest table: `python benchmarks/bench_status.py` (the `/bench` skill).

--- a/benchmarks/HIGHCARD_PLAN.md
+++ b/benchmarks/HIGHCARD_PLAN.md
@@ -150,9 +150,125 @@ TabArena dataset reuse (audit is a hard gate). No OpenML-gate rotation here
 
 ## Acceptance
 
-- [ ] Audit matrix committed; frozen list has zero TabArena/gate/Grinsztajn overlap
-- [ ] N >= 12 frozen by properties only; >= 8 sets max-card >= 50; >= 2 reg-with-cats
-- [ ] `--highcard` runs end-to-end; summarize renders (incl. multiclass columns if present)
-- [ ] hc-baseline.json on disk + aggregate table printed
-- [ ] First-read writeup: real hc gap vs synth entity prediction, logged in PAYOFF.md v3 watch items
-- [ ] Suite declared co-decider (or artifacts documented + fixes queued) + skill/docs/memory updated
+- [x] Audit matrix committed; frozen list has zero TabArena/gate/Grinsztajn overlap
+- [x] N >= 12 frozen by properties only; >= 8 sets max-card >= 50; >= 2 reg-with-cats
+- [x] `--highcard` runs end-to-end; summarize renders (incl. multiclass columns if present)
+- [x] hc-baseline.json on disk + aggregate table printed (14 sets, 3 seeds, 2026-07-15)
+- [x] First-read writeup: real hc gap vs synth entity prediction (CONFIRMED: 86–88% real vs 91% synth), logged in PAYOFF.md v3 watch items
+- [x] Suite declared co-decider (shadow this session; only artifact is `cjs` near-solved) + skill/CLAUDE.md/memory updated
+
+---
+
+# Audit results & frozen suite (implemented 2026-07-15)
+
+Exclusion lists used (NAMES/IDs only — no results consulted; membership used to
+AVOID contamination, the sanctioned use): **TabArena 51** from
+`.../tabarena/nips2025_utils/metadata/curated_tabarena_dataset_metadata.csv`
+(offline, on A:); **Grinsztajn 59** from `GRINSZTAJN_DATASETS`; **OpenML gate 29**
+from `OPENML_SUITE`; **PMLB 25** from `PMLB_DATASETS`. Match = OpenML id first,
+normalized/substring name second. Every candidate was verified against OpenML
+metadata and its true per-column cardinality measured on the 100k subsample
+WITHOUT fitting any model. The self-contained overlap regression test
+(`tests/test_highcard.py::test_no_suite_overlap`) re-checks the frozen 14 against
+all four lists on every run.
+
+## Step 0 — overlap audit (hard cuts)
+
+| Candidate | id | hit | verdict |
+|---|---|---|---|
+| KDDCup09_appetency | 1111 | TabArena exact (`kddcup09_appetency`, did 46939) | **OUT** |
+| KDDCup09_churn | 1112 | shares appetency's exact 50k×230 feature matrix (incl. the high-card cats) | **OUT** |
+| KDDCup09_upselling | 1114 | same identical feature matrix as TabArena appetency | **OUT** |
+| Amazon_employee_access | 4135 | TabArena exact **and** gate id 4135 (`Amazon_access`) | **OUT** |
+| Diabetes130US | 4541 | TabArena exact **and** Grinsztajn exact | **OUT** |
+| Allstate_Claims_Severity | 42571 | Grinsztajn `reg_cat` exact | **OUT** |
+| Mercedes_Benz | 42570 | Grinsztajn `reg_cat` exact (`Mercedes_Benz_Greener_Manufacturing`) | **OUT** |
+| airlines | 1169 | shares airline-delay domain + carrier/airport high-card cats with Grinsztajn `Airlines_DepDelay_1M` | **OUT** |
+
+The KDDCup09 trio share one identical 50k×230 feature matrix (byte-identical
+OpenML qualities: max card 15415, 8,024,152 missing); only the target differs and
+TabArena tests the appetency target — so tuning cat-handling on churn/upselling
+would leak the appetency mechanism. Name-matching can't see this; the reasoning is
+recorded. `airlines`↔`Airlines_DepDelay_1M` is a domain/cat overlap with the
+primary decision suite (Grinsztajn), cut to keep the suites independent.
+
+## Step 1 — property-based cuts (degenerate / not high-card / unstable)
+
+| Candidate | id | reason | verdict |
+|---|---|---|---|
+| Click_prediction_small | 1220/1216/1218/1219 | pre-encoded: 1 symbolic feature, max card 2 (no raw high-card cats in any OpenML version) | **OUT** |
+| open_payments | 42738 | empty/all-NaN target on load; 1 symbolic feature | **OUT** |
+| kdd_internet_usage | 4133 | target undefined + `who` is a pure ID column (card == n) | **OUT** |
+| KDDCup99 | 1113 | 18 classes in the 100k subsample with min_class_count=0 (zero-support) → stratified split / macro-F1 undefined | **OUT** |
+| avocado_sales | 41210 | OpenML marks the version INACTIVE (reproducibility) | **OUT** |
+| ipums_la_99-small | 378 | "high card" is mis-encoded continuous income (ftotinc/inctot as nominal), not entity cats | **OUT** |
+| nfl_games | 42143 | default target undefined; top cat `date` is semi-ID | **OUT** |
+| SpeedDating | 40536 | structural leakage: `dec`+`dec_o` functionally determine `match` → near-solved | **OUT** |
+| Census-Income (KDD) | 4535 | target undefined + income-prediction domain overlaps gate `adult` | **OUT** |
+| socmob | 541 | legit but redundant tiny (1156) low-card (17) reg filler; cut to keep suite tight | **CUT** |
+
+The audit killed BOTH clean reg-with-cats candidates (Allstate, Mercedes →
+Grinsztajn), so replacements were found by property search on OpenML metadata
+(`MaxNominalAttDistinctValues ≥ 50`, cardinality filters) BEFORE any fit —
+yielding `wine-reviews`, `colleges`, `kdd_ipums_la_97-small`, `cjs`. KDD98
+(id 23513, 25847-card reg) surfaced in that search but is DEFERRED (heavy +
+license-awkward — Nathan's call, per the plan).
+
+## Frozen HC suite — N=14
+
+Composition: **4 binary + 4 multiclass + 6 regression · 10 sets with max-card ≥ 50
+(incl. 3 high-card regressions) · 6 reg-with-cats · 4 multiclass-with-cats.** All
+fetched by OpenML id with a 100k deterministic subsample (random_state=0). This
+table is the source of truth; `tests/test_highcard.py::test_frozen_matches_doc`
+asserts it equals `HC_DATASETS`.
+
+| hc key | id | task | n (→100k sub) | n_cat | max card (feature) | note |
+|---|---|---|---|---|---|---|
+| hc:kick | 41162 | binary | 72,983 | 18 | 1063 (Model) | 88/12 imbalance, missing |
+| hc:porto-seguro | 42742 | binary | 595,212→100k | 31 | 104 (ps_car_11_cat) | 96/4 imbalance, missing |
+| hc:sf-police-incidents | 42344 | binary | 538,638→100k | 5 | 15165 (Address) | balanced |
+| hc:kdd_ipums_la_97-small | 993 | binary | 7,019 | 27 | 191 (occ1950) | occupation/industry codes |
+| hc:okcupid-stem | 42734 | multiclass | 50,789 | 17 | 7019 (speaks) | 3-class, missing |
+| hc:Traffic_violations | 42345 | multiclass | 70,340 | 19 | 3830 (Model) | 3-class; watch `Description` leak |
+| hc:cjs | 473 | multiclass | 2,796 | 2 | 57 (TREE) | 6-class, small |
+| hc:eucalyptus | 188 | multiclass | 736 | 5 | 27 (Sp) | 5-class, small low-card buffer |
+| hc:wine-reviews | 41275 | regression | 129,971→100k | 9 | 31959 (designation) / 15633 (winery) | points∈[80,100]; free-text `description`/`title` auto-dropped |
+| hc:colleges | 42727 | regression | 7,063 | 12 | 6039 (zip) / 59 (state) | pell-grant fraction |
+| hc:house_prices_nominal | 42563 | regression | 1,460 | 43 | 25 (Neighborhood) | Ames SalePrice |
+| hc:black_friday | 41540 | regression | 166,821→100k | 4 | 7 (Age) | low-card cats |
+| hc:employee_salaries | 42125 | regression | 9,228 | 8 | 2264 (date_first_hired) / 694 (division) | Montgomery salaries; `full_name` ID auto-dropped |
+| hc:Moneyball | 41021 | regression | 1,232 | 6 | 39 (Team) | small |
+
+Shakedown watch items for the baseline read (step 3): `Traffic_violations`
+(`Description`/`Charge` may leak the 3-class target → near-solved); `cjs`
+(all models ~1.0 F1 in the dry run → near-solved multiclass); `porto-seguro`
+(96/4 → macro-F1 fragile, %-of-best Brier can explode as best→0); competitor
+native-cat paths on card 7k–15k (`speaks`, `winery`, `Address`) slow (CatBoost
+~2 min/fit on wine-reviews) — record, don't fix.
+
+### Harness robustness fixes surfaced by the shakedown (not library changes)
+
+The first baseline runs exposed three loader/runner issues that the HC regime hits
+but the curated suites never did. All are infrastructure fixes (they let the
+benchmark COMPLETE and read correctly; they do not touch the library or bias any
+decision):
+
+1. **Per-model skip, not run-abort** (`_run_seed_task`): sklearn HGB has a hard
+   255-category cap and raises on high-card cats (`kick` card 1028, `sf-police`
+   13.8k, etc.); an uncaught raise aborted the whole 42-draw run. A runner that
+   raises is now recorded as skipped (`None`, printed `[skip]`), exactly like an
+   uninstalled competitor. sklearn is thus absent on the 6 card>255 sets and
+   present on the other 8 — an honest record of its structural high-card limit.
+2. **pandas-3.0 `str` dtype detected as categorical** (`_is_categorical_dtype`):
+   pandas 3.0 returns free-text columns as the new `str` dtype (repr `"str"`),
+   which the old `_is_cat` missed → text columns routed to the numeric branch →
+   `astype(float)` crash (`wine-reviews`). Also un-hid genuine string cats that
+   metadata had missed — `employee_salaries` is actually a **high-card** reg
+   (`date_first_hired` 2264, `division` 694), not the low-card (37) the OpenML
+   nominal-only metadata implied.
+3. **Near-unique cat columns dropped** (`_HIGHCARD_ID_FRAC = 0.9`, HC builder
+   only): row identifiers / free text (`wine-reviews` `description` 94% unique &
+   `title` 93%; `employee_salaries` `full_name` 99.9%) carry no repeated-level
+   signal — the opposite of the entity-cat regime — and only add noise + fit
+   cost, so the loader drops them. The threshold sits above every genuine
+   high-card cat (highest kept: colleges `zip` 85.5%).

--- a/benchmarks/hc_gap.py
+++ b/benchmarks/hc_gap.py
@@ -1,0 +1,133 @@
+"""HC first-read: the real CatBoost-vs-ChimeraBoost Brier gap on the HC suite,
+sliced by categorical cardinality, vs the SynthGen v2 entity-cat prediction.
+
+The Brier-gap program (synthgen/PAYOFF.md) found CatBoost's edge lives entirely
+in the entity-cat / high-card regime: synth entity_strength Q4 = 91% CatBoost
+Brier winrate at 5.2x gap concentration, while cats=none is dead flat. Grinsztajn
+has no such datasets, so that prediction had never been checked on real data.
+This reads the HC baseline and reports whether it holds -- the fidelity test of
+the v2 entity-cat prior (feed the answer into synthgen/PAYOFF.md v3 watch items).
+
+Usage:
+    python benchmarks/hc_gap.py benchmarks/results/hc-baseline.json
+        [--ours ChimeraBoost] [--theirs CatBoost]
+"""
+import argparse
+from collections import defaultdict
+
+import numpy as np
+
+import summarize
+
+EPS = 1e-9
+
+# Measured max categorical cardinality per hc dataset (on the 100k subsample;
+# from the Step-1 property audit -- benchmarks/HIGHCARD_PLAN.md). Used only to
+# SLICE the read, never to select datasets.
+HC_MAX_CARD = {
+    "hc:kick": 1063, "hc:porto-seguro": 104, "hc:sf-police-incidents": 15165,
+    "hc:kdd_ipums_la_97-small": 191, "hc:okcupid-stem": 7019,
+    "hc:Traffic_violations": 3830, "hc:cjs": 57, "hc:eucalyptus": 27,
+    "hc:wine-reviews": 31959, "hc:colleges": 6039, "hc:house_prices_nominal": 25,
+    "hc:black_friday": 7, "hc:employee_salaries": 2264, "hc:Moneyball": 39,
+}
+
+
+def _per_ds_metric(records, key):
+    b = defaultdict(lambda: defaultdict(list))
+    for r in records:
+        v = r["metrics"].get(key)
+        if v is not None:
+            b[r["dataset"]][r["model"]].append(v)
+    return {ds: {m: float(np.mean(vs)) for m, vs in ms.items()}
+            for ds, ms in b.items()}
+
+
+def _winrate_and_gap(per_ds, ds_list, ours, theirs, lower_better=True):
+    """Head-to-head over ds_list: (theirs winrate, mean gap ours-theirs, n)."""
+    wins_them, gaps = 0, []
+    n = 0
+    for ds in ds_list:
+        o = per_ds.get(ds, {}).get(ours)
+        t = per_ds.get(ds, {}).get(theirs)
+        if o is None or t is None:
+            continue
+        n += 1
+        gap = o - t if lower_better else t - o   # + = theirs better
+        gaps.append(gap)
+        if (t < o) if lower_better else (t > o):
+            wins_them += 1
+    wr = wins_them / n if n else float("nan")
+    return wr, (float(np.mean(gaps)) if gaps else float("nan")), n
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("run")
+    ap.add_argument("--ours", default="ChimeraBoost")
+    ap.add_argument("--theirs", default="CatBoost")
+    args = ap.parse_args()
+
+    data = summarize.load(args.run)
+    records, datasets = data["records"], data["datasets"]
+    brier = _per_ds_metric(records, "brier")
+    f1 = _per_ds_metric(records, "f1_macro")
+    rmse = _per_ds_metric(records, "rmse")
+
+    def task(ds):
+        return datasets[ds]["task"]
+
+    clf = [d for d in datasets if task(d) in ("binary", "multiclass")]
+    reg = [d for d in datasets if task(d) == "regression"]
+    hicard = [d for d in clf if HC_MAX_CARD.get(d, 0) >= 50]
+    xcard = [d for d in clf if HC_MAX_CARD.get(d, 0) >= 1000]
+    locard = [d for d in clf if HC_MAX_CARD.get(d, 0) < 50]
+
+    print(f"HC first-read: {args.ours} vs {args.theirs}   [{args.run}]")
+    print(f"{len(clf)} classification sets ({len(hicard)} max-card>=50, "
+          f"{len(xcard)} max-card>=1000), {len(reg)} regression\n")
+
+    print(f"{'slice':22s} {'n':>3s} {'CatB Brier win%':>16s} "
+          f"{'mean gap/set':>13s} {'CatB F1 win%':>13s}")
+    print("-" * 72)
+    for label, ds_list in [("all classification", clf),
+                           ("  binary", [d for d in clf if task(d) == "binary"]),
+                           ("  multiclass", [d for d in clf if task(d) == "multiclass"]),
+                           ("max-card >= 50", hicard),
+                           ("max-card >= 1000", xcard),
+                           ("max-card < 50", locard)]:
+        if not ds_list:
+            continue
+        bwr, bgap, n = _winrate_and_gap(brier, ds_list, args.ours, args.theirs, True)
+        fwr, _, _ = _winrate_and_gap(f1, ds_list, args.ours, args.theirs, False)
+        print(f"{label:22s} {n:3d} {bwr:15.0%} {bgap:+13.5f} {fwr:12.0%}")
+
+    # %-of-best Brier via the canonical summarize aggregation
+    cols, meta = summarize.aggregate(data)
+    print("\n% of best (100 = best model on that set, averaged):")
+    for c in ("Bin Brier%", "Multi Brier%", "Bin F1%", "Multi F1%", "Reg RMSE%"):
+        row = cols.get(c, {})
+        o, t = row.get(args.ours), row.get(args.theirs)
+        if o is None and t is None:
+            continue
+        os_ = f"{o:.1f}" if o is not None else "  -"
+        ts_ = f"{t:.1f}" if t is not None else "  -"
+        print(f"  {c:14s} {args.ours} {os_:>6s}   {args.theirs} {ts_:>6s}")
+
+    # regression head-to-head (RMSE), for completeness
+    rwr, rgap, rn = _winrate_and_gap(rmse, reg, args.ours, args.theirs, True)
+    print(f"\nregression RMSE: {args.theirs} win {rwr:.0%} over {rn} sets "
+          f"(mean gap/set {rgap:+.4f})")
+
+    # the fidelity verdict vs the synth entity prediction
+    bwr_hi, _, n_hi = _winrate_and_gap(brier, hicard, args.ours, args.theirs, True)
+    bwr_lo, _, n_lo = _winrate_and_gap(brier, locard, args.ours, args.theirs, True)
+    print("\n--- fidelity vs SynthGen v2 entity prediction ---")
+    print(f"synth predicted: entity_str Q4 = 91% CatBoost Brier winrate, "
+          f"cats=none flat (~50%)")
+    print(f"real HC:  max-card>=50 = {bwr_hi:.0%} CatBoost Brier winrate (n={n_hi});  "
+          f"max-card<50 = {bwr_lo:.0%} (n={n_lo})")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -161,6 +161,8 @@ def _task_of(ds_name):
         return GRINSZTAJN_TASKS[ds_name]
     if ds_name.startswith("pm:"):
         return PMLB_TASKS[ds_name]
+    if ds_name.startswith("hc:"):
+        return HC_TASKS[ds_name]
     if ds_name.startswith("syn:"):
         return SYN_TASKS[ds_name]
     return SYNTH_TASKS[ds_name]
@@ -216,6 +218,16 @@ OPENML_SUITE = {
 }
 
 
+def _is_categorical_dtype(dtype):
+    """True for a pandas dtype that should be treated as categorical. pandas 3.0
+    returns free-text columns as the new "str" dtype (repr "str"); object,
+    category, and pyarrow "string[...]" all mean categorical too. Missing "str"
+    silently routed text columns to the numeric branch -> astype(float) crash on
+    high-card free-text datasets."""
+    s = str(dtype).lower()
+    return s in ("category", "object", "str") or s.startswith("string")
+
+
 def _frame_to_dataset(X_df, y, cats, task):
     """Turn a (features DataFrame, target Series) into (X, y, cat_idx, task).
     Shared by the OpenML and Grinsztajn/HuggingFace builders.
@@ -226,10 +238,8 @@ def _frame_to_dataset(X_df, y, cats, task):
     bucket, so both see missing the same way. Numerics stay float.
     """
     if cats == "auto":
-        def _is_cat(dtype):
-            s = str(dtype).lower()
-            return s in ("category", "object") or s.startswith("string")
-        cat_idx = [i for i, c in enumerate(X_df.columns) if _is_cat(X_df[c].dtype)]
+        cat_idx = [i for i, c in enumerate(X_df.columns)
+                   if _is_categorical_dtype(X_df[c].dtype)]
     else:
         cat_idx = cats
 
@@ -460,6 +470,100 @@ def _add_synth_datasets():
     for key in synthgen.all_frozen_keys():
         DATASETS[key] = synthgen.make_builder(key)
         SYN_TASKS[key] = synthgen.task_of(key)
+
+
+# --------------------------------------------------------------------------
+# HC: REAL high-cardinality-categorical datasets (decision tier). Added so the
+# decision stack has a real-data expression of the entity-cat / high-card regime
+# where the CatBoost Brier gap lives: Grinsztajn curates high-card cats OUT and
+# has 0 multiclass, so no lever targeting that gap can clear the protocol on
+# Grinsztajn alone (see benchmarks/HIGHCARD_PLAN.md + synthgen/PAYOFF.md). This
+# suite is NEITHER synthetic (the generator's prior must not vote on ships) NOR a
+# Grinsztajn split (both halves would inherit the same blind spot).
+#
+# Every dataset passed a HARD overlap audit: zero intersection with TabArena (the
+# sealed holdout -- its DATASETS must never enter a decision suite), the
+# Grinsztajn 59, the OpenML one-shot gate (29), or the PMLB tuning suite (25),
+# matched by OpenML id AND normalized/substring name. Selection was by DATA
+# PROPERTIES ONLY (n, cardinality, task, missingness) measured WITHOUT fitting any
+# model; degenerate sets (undefined/empty target, zero-support classes, pure-ID
+# columns, structural target leakage, inactive OpenML versions) were dropped. The
+# audit matrix + rationale live in benchmarks/HIGHCARD_PLAN.md. The frozen list
+# only changes with a version bump + re-audit (synthgen-freeze discipline).
+#
+# Loaded via fetch_openml(as_frame=True); cats auto-detected from dtype; a 100k
+# deterministic subsample (random_state=0, NOT the harness seed -- the train/test
+# split stays the only seed-dependent step). Keys are "hc:<name>".
+# --------------------------------------------------------------------------
+HC_DATASETS = {
+    # binary, high-card real categoricals
+    "kick":                  dict(data_id=41162, task="binary"),      # Model card 1063
+    "porto-seguro":          dict(data_id=42742, task="binary"),      # ps_car_11_cat 104
+    "sf-police-incidents":   dict(data_id=42344, task="binary"),      # Address 15165
+    "kdd_ipums_la_97-small": dict(data_id=993,   task="binary"),      # occ/ind codes 191
+    # multiclass, the regime Grinsztajn lacks entirely
+    "okcupid-stem":          dict(data_id=42734, task="multiclass"),  # speaks 7019 (3-class)
+    "Traffic_violations":    dict(data_id=42345, task="multiclass"),  # Model 3830 (3-class)
+    "cjs":                   dict(data_id=473,   task="multiclass"),  # TREE 57 (6-class)
+    "eucalyptus":            dict(data_id=188,   task="multiclass"),  # Sp 27 (5-class)
+    # regression with categoricals
+    "wine-reviews":          dict(data_id=41275, task="regression"),  # winery 15633
+    "colleges":              dict(data_id=42727, task="regression"),  # zip 6039 / state 59
+    "house_prices_nominal":  dict(data_id=42563, task="regression"),  # Ames, Neighborhood 25
+    "black_friday":          dict(data_id=41540, task="regression"),  # low-card cats
+    "employee_salaries":     dict(data_id=42125, task="regression"),  # department 37
+    "Moneyball":             dict(data_id=41021, task="regression"),  # Team 39
+}
+HC_TASKS = {}   # "hc:<name>" -> task, filled at registration
+_HIGHCARD_MAX_ROWS = 100000
+# Categorical columns whose nunique/n exceeds this are row identifiers / free
+# text (e.g. wine-reviews' `description`/`title`, ~94% unique). They carry no
+# repeated-level signal -- the opposite of the entity-cat regime this suite
+# targets -- and only add noise + fit cost, so the loader drops them. The
+# threshold sits well above every genuine high-card cat in the frozen suite
+# (the highest is colleges' zip at ~0.855), so no real categorical is dropped.
+_HIGHCARD_ID_FRAC = 0.9
+# sklearn's OpenML cache lands on C: by default, which has ~4 GB free while
+# porto/sf-police/wine-reviews are 100-500 MB fetches, so default the cache to A:
+# (override with the standard SCIKIT_LEARN_DATA env var on a box where C: is fine).
+_HIGHCARD_DATA_HOME = os.environ.get("SCIKIT_LEARN_DATA") or r"A:\code\sklearn_data"
+
+
+def _make_highcard_builder(spec):
+    """Build a dataset-builder closure for one HC spec (fetched by data_id, with
+    a deterministic 100k subsample). Mirrors the Grinsztajn/PMLB builders."""
+    def builder(scale, rng):
+        from sklearn.datasets import fetch_openml
+        ds = fetch_openml(data_id=spec["data_id"], as_frame=True,
+                          data_home=_HIGHCARD_DATA_HOME)
+        frame = ds.frame
+        target = ds.target.name
+        # Deterministic subsample BEFORE the split (fixed seed 0, ignores the
+        # harness rng), so the train/test split stays the only seed-dependent step.
+        if len(frame) > _HIGHCARD_MAX_ROWS:
+            frame = frame.sample(_HIGHCARD_MAX_ROWS, random_state=0
+                                 ).reset_index(drop=True)
+        X_df = frame.drop(columns=[target])
+        # Drop near-unique categorical columns (row identifiers / free text).
+        n = len(X_df)
+        id_cols = [c for c in X_df.columns
+                   if _is_categorical_dtype(X_df[c].dtype)
+                   and X_df[c].nunique(dropna=True) > _HIGHCARD_ID_FRAC * n]
+        if id_cols:
+            X_df = X_df.drop(columns=id_cols)
+        return _frame_to_dataset(X_df, frame[target], "auto", spec["task"])
+    return builder
+
+
+def _add_highcard_datasets():
+    """Register the frozen HC suite into DATASETS as hc:<name>. Idempotent so
+    workers can call it once cheaply."""
+    if any(k.startswith("hc:") for k in DATASETS):
+        return
+    for name, spec in HC_DATASETS.items():
+        key = f"hc:{name}"
+        DATASETS[key] = _make_highcard_builder(spec)
+        HC_TASKS[key] = spec["task"]
 
 
 # --------------------------------------------------------------------------
@@ -775,7 +879,8 @@ def _run_seed_task(task):
     (ds_name, seed, meta, {model: (metrics, secs, best_iter) or None})."""
     global PATIENCE, ENSEMBLE_N
     (ds_name, seed, scale, threads, model_names, chimera_cfg, patience,
-     ensemble_n, need_openml, need_grinsztajn, need_pmlb, need_synth) = task
+     ensemble_n, need_openml, need_grinsztajn, need_pmlb, need_synth,
+     need_highcard) = task
     PATIENCE = patience
     ENSEMBLE_N = ensemble_n
     if need_openml:
@@ -786,6 +891,8 @@ def _run_seed_task(task):
         _add_pmlb_datasets()
     if need_synth:
         _add_synth_datasets()
+    if need_highcard:
+        _add_highcard_datasets()
 
     rng = np.random.default_rng(1000 + seed)
     X, y, cat, ttype = DATASETS[ds_name](scale, rng)
@@ -806,7 +913,19 @@ def _run_seed_task(task):
 
     out = {}
     for name, runner in _make_runners(model_names, chimera_cfg).items():
-        out[name] = runner(ttype, Xtr, ytr, Xte, yte, cat, threads)
+        try:
+            out[name] = runner(ttype, Xtr, ytr, Xte, yte, cat, threads)
+        except Exception as e:
+            # A model that structurally cannot handle a dataset -- e.g. sklearn
+            # HGB's hard 255-category cap on high-cardinality categoricals, or a
+            # competitor OOM on a huge cat -- is recorded as SKIPPED (None), not
+            # allowed to abort the whole run. Downstream aggregation already
+            # treats None as "did not run" (like an uninstalled competitor). The
+            # HC suite deliberately exercises regimes that break some native-cat
+            # paths (the plan's "record, don't fix"); the print keeps them visible.
+            print(f"  [skip] {name} on {ds_name} (seed {seed}): "
+                  f"{type(e).__name__}: {e}")
+            out[name] = None
     return ds_name, seed, meta, out
 
 
@@ -858,6 +977,7 @@ class _Progress:
                        f"grinsztajn={args.grinsztajn} "
                        f"pmlb={args.pmlb}"
                        f"{('/' + args.pmlb_fold) if args.pmlb_fold else ''} "
+                       f"highcard={args.highcard} "
                        f"depth={args.chimera_depth} "
                        f"lei={'default' if lei is None else lei} "
                        f"ob={'off' if not args.ordered_boosting else 'on'}")
@@ -923,6 +1043,11 @@ def main():
                          "--pmlb-fold to restrict to tune/holdout.")
     ap.add_argument("--pmlb-fold", choices=["tune", "holdout"], default=None,
                     help="with --pmlb, run only this fold (default: both).")
+    ap.add_argument("--highcard", action="store_true",
+                    help="run the frozen HC suite (real high-cardinality-"
+                         "categorical datasets; decision tier 2 alongside "
+                         "Grinsztajn). Fetched from OpenML, cached on A: "
+                         "(see SCIKIT_LEARN_DATA). See benchmarks/HIGHCARD_PLAN.md.")
     ap.add_argument("--synth", action="store_true",
                     help="run the frozen synthgen prior-sampled suite "
                          "(decision tier 1; see benchmarks/synthgen/).")
@@ -1070,6 +1195,16 @@ def main():
             for k in [k for k in DATASETS if not k.startswith(keep_fold)]:
                 del DATASETS[k]
 
+    # HC suite: same convention as Grinsztajn/PMLB — register, then (unless
+    # specific --datasets were named) run ONLY it.
+    need_highcard = args.highcard or bool(
+        args.datasets and any(d.startswith("hc:") for d in args.datasets))
+    if need_highcard:
+        _add_highcard_datasets()
+        if args.highcard and not args.datasets:
+            for k in [k for k in DATASETS if not k.startswith("hc:")]:
+                del DATASETS[k]
+
     # SynthGen suite: same convention — register, then (unless specific
     # --datasets were named) run ONLY the chosen frozen suite.
     need_synth = args.synth or bool(
@@ -1146,7 +1281,7 @@ def main():
     # Run every (dataset, seed) draw, in parallel processes unless jobs == 1.
     tasks = [(ds, s, args.scale, threads_per, model_names, chimera_cfg,
               PATIENCE, ENSEMBLE_N, need_openml, need_grinsztajn, need_pmlb,
-              need_synth)
+              need_synth, need_highcard)
              for ds in selected for s in range(args.seeds)]
     total_tasks = len(tasks)
 

--- a/benchmarks/summarize.py
+++ b/benchmarks/summarize.py
@@ -28,6 +28,12 @@ RESULTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "results"
 MODEL_ORDER = ["ChimeraBoost", "ChimeraBoostEns2", "ChimeraBoostEns5",
                "ChimeraBoostEns10", "CatBoost", "LightGBM", "sklearn_HGB", "XGBoost"]
 COLS = ["Reg RMSE%", "Bin F1%", "Bin Brier%", "Bin Calib", "Speed"]
+# Multiclass columns, rendered ONLY when the results contain multiclass datasets
+# (the HC suite adds them; Grinsztajn has none). They are report-only: the
+# blended north star (make_pareto) is unchanged and ignores these. Inserted
+# before Speed by _display_cols so Speed stays the last column.
+MULTI_COLS = ["Multi F1%", "Multi Brier%"]
+COL_W = 13
 
 # Regression datasets where the BEST model's NRMSE (best_RMSE / y_std) is below
 # this are "near-solved": every model nails them (R^2 ~ 1), so the "% vs best"
@@ -159,6 +165,11 @@ def aggregate(data):
         "Bin F1%": _pct_vs_best(f1, bin_ds, lower=False),
         "Bin Brier%": _pct_vs_best(brier, bin_ds, lower=True, skip_below=1e-3),
         "Bin Calib": _mean_over(cal, bin_ds),
+        # Multiclass columns use the SAME per-class-sum Brier and macro-F1 as the
+        # binary ones (run_benchmarks._compute_metrics computes both for K>2). The
+        # same near-solved Brier guard (skip_below) applies per column.
+        "Multi F1%": _pct_vs_best(f1, mul_ds, lower=False),
+        "Multi Brier%": _pct_vs_best(brier, mul_ds, lower=True, skip_below=1e-3),
         "Speed": _mult_vs_best(speed, all_ds),
     }
     cfg = data.get("config", {})
@@ -175,7 +186,8 @@ def aggregate(data):
 def _suite_label(ds_names):
     """Human label for the caption, inferred from dataset key prefixes."""
     tags = {"gr:": "Grinsztajn et al. (2022)", "pm:": "PMLB tuning suite",
-            "oml:": "OpenML suite", "syn:": "SynthGen suite"}
+            "oml:": "OpenML suite", "syn:": "SynthGen suite",
+            "hc:": "HC high-cardinality suite"}
     found = {label for pre, label in tags.items()
              if any(d.startswith(pre) for d in ds_names)}
     if not found:
@@ -185,14 +197,23 @@ def _suite_label(ds_names):
     return "Mixed suites"
 
 
+def _display_cols(meta):
+    """Column order for the table: the base five, with the two multiclass columns
+    inserted before Speed only when the run actually has multiclass datasets."""
+    cols = list(COLS)
+    if meta.get("n_mul", 0) > 0:
+        cols[cols.index("Speed"):cols.index("Speed")] = MULTI_COLS
+    return cols
+
+
 def _fmt(v, col):
     if v is None:
-        return f"{'--':>11}"
+        return f"{'--':>{COL_W}}"
     if col == "Bin Calib":
-        return f"{v * 1000:>10.2f}m"
+        return f"{v * 1000:>{COL_W - 1}.2f}m"
     if col == "Speed":
-        return f"{v:>10.1f}x"
-    return f"{v:>10.1f}%"
+        return f"{v:>{COL_W - 1}.1f}x"
+    return f"{v:>{COL_W - 1}.1f}%"
 
 
 def _models_present(cols):
@@ -207,14 +228,15 @@ def format_table(data, label=None):
     """Return a printable string for one results JSON."""
     cols, meta = aggregate(data)
     models = _models_present(cols)
+    show = _display_cols(meta)
     lines = []
     if label:
         lines.append(label)
-    hdr = f"{'Model':<22}" + "".join(f"{c:>11}" for c in COLS)
+    hdr = f"{'Model':<22}" + "".join(f"{c:>{COL_W}}" for c in show)
     lines.append(hdr)
     lines.append("-" * len(hdr))
     for m in models:
-        row = f"{m:<22}" + "".join(_fmt(cols[c].get(m), c) for c in COLS)
+        row = f"{m:<22}" + "".join(_fmt(cols[c].get(m), c) for c in show)
         lines.append(row)
     seeds = f" | {meta['seeds']} seeds" if meta.get("seeds") else ""
     cap = (f"{meta['suite']} — {meta['n_total']} datasets "
@@ -233,12 +255,15 @@ def format_table(data, label=None):
 def format_compare(base_data, new_data, base_label="BEFORE", new_label="AFTER",
                    focus="ChimeraBoost"):
     """Return before/after tables plus a per-column delta for `focus` model."""
-    base_cols, _ = aggregate(base_data)
-    new_cols, _ = aggregate(new_data)
+    base_cols, base_meta = aggregate(base_data)
+    new_cols, new_meta = aggregate(new_data)
     out = [format_table(base_data, f"=== {base_label} ==="), "",
            format_table(new_data, f"=== {new_label} ==="), "",
            f"=== {focus} delta ({new_label} vs {base_label}) ==="]
-    for c in COLS:
+    # Show whichever column set is richer (multiclass columns appear if either
+    # run has multiclass datasets).
+    show = _display_cols(base_meta if base_meta.get("n_mul") else new_meta)
+    for c in show:
         bv = base_cols[c].get(focus)
         nv = new_cols[c].get(focus)
         if bv is None or nv is None:

--- a/benchmarks/synthgen/PAYOFF.md
+++ b/benchmarks/synthgen/PAYOFF.md
@@ -174,8 +174,21 @@ Grinsztajn — kill on the screen, never tune the library on synth.
   until then, treat in-suite entity-slice gaps as report-only color, not
   targets. Also: synth speed ratios are NOT decision-grade (CatBoost 50-80x
   slow on synth vs 11.8x on Grinsztajn — tiny-set anomaly).
-## Generator v3 watch items (do NOT act now; only at the next re-freeze)
-
+  - **RESOLVED (2026-07-15): the entity-cat prior is CONFIRMED faithful.** The
+    decision stack gained the real high-card `hc` suite (14 sets, `--highcard`;
+    see `benchmarks/HIGHCARD_PLAN.md`, zero TabArena/Grinsztajn/gate overlap).
+    First-read (`benchmarks/hc_gap.py hc-baseline.json`): synth predicted
+    entity_str Q4 = **91%** CatBoost Brier winrate; real hc = **86%** (max-card
+    ≥50, 6/7) / **88%** (all 8 clf) / **100%** (multiclass, 4/4). Percent-of-best
+    Brier: CatBoost 99.8 vs ChimeraBoost 99.5 (binary), 100 vs 98.5 (multiclass).
+    So the regime is REAL on real data and REVERSES the Grinsztajn read (where CB
+    is ChimeraBoost's, 98.4 Brier vs CB 95.4) — Grinsztajn was simply blind to it.
+    The v2 entity-cat prior is a faithful predictor of the real-data gap; the
+    entity-cat weight does NOT need to be re-justified against marginals for
+    fidelity (it may still be re-weighted for representativeness). The gap
+    magnitude is small (mean +0.0029 Brier/set) and CatBoost pays 111x slowdown
+    for it, so it is a real-but-cheap-to-cede edge on the Pareto — but a lever
+    targeting high-card Brier can now be A/B'd on a suite that EXPRESSES it.
 - mcw1 arm disagreed in v2: its pre-registered small-n clf slice shrank to 10
   sets under the 0.35 small-n cap (W5-L5 +0.41%). Either widen the slice
   definition (n<3000?) or seed more small-n clf sets.

--- a/tests/test_highcard.py
+++ b/tests/test_highcard.py
@@ -1,0 +1,200 @@
+"""HC suite contracts: registration, frozen-list<->doc agreement, the sealed-
+holdout overlap regression test, loader smoke, and summarize's multiclass columns.
+
+The overlap test embeds the TabArena-51 dataset NAMES (names only, no results of
+any kind — using the membership list to AVOID contamination is the sanctioned use
+per benchmarks/HIGHCARD_PLAN.md and the sealed-holdout vow). Source of the names:
+tabarena/nips2025_utils/metadata/curated_tabarena_dataset_metadata.csv.
+"""
+import os
+import re
+import sys
+
+import pytest
+
+BENCH = os.path.join(os.path.dirname(__file__), "..", "benchmarks")
+sys.path.insert(0, BENCH)
+
+import run_benchmarks as rb  # noqa: E402
+import summarize  # noqa: E402
+
+PLAN_MD = os.path.join(BENCH, "HIGHCARD_PLAN.md")
+
+# TabArena 51 (openml_dataset_name column). NAMES ONLY — never any result.
+TABARENA_51 = [
+    "airfoil_self_noise", "Amazon_employee_access", "anneal",
+    "Another-Dataset-on-used-Fiat-500", "APSFailure", "bank-marketing",
+    "Bank_Customer_Churn", "Bioresponse", "blood-transfusion-service-center",
+    "churn", "coil2000_insurance_policies", "concrete_compressive_strength",
+    "credit-g", "credit_card_clients_default", "customer_satisfaction_in_airline",
+    "diabetes", "Diabetes130US", "diamonds", "E-CommereShippingData",
+    "Fitness_Club", "Food_Delivery_Time", "GiveMeSomeCredit",
+    "hazelnut-spread-contaminant-detection", "healthcare_insurance_expenses",
+    "heloc", "hiva_agnostic", "houses", "HR_Analytics_Job_Change_of_Data_Scientists",
+    "in_vehicle_coupon_recommendation", "Is-this-a-good-customer",
+    "kddcup09_appetency", "Marketing_Campaign", "maternal_health_risk",
+    "miami_housing", "MIC", "NATICUSdroid", "online_shoppers_intention",
+    "physiochemical_protein", "polish_companies_bankruptcy", "qsar-biodeg",
+    "QSAR-TID-11", "QSAR_fish_toxicity", "SDSS17", "seismic-bumps", "splice",
+    "students_dropout_and_academic_success", "superconductivity",
+    "taiwanese_bankruptcy_prediction", "website_phishing", "wine_quality", "jm1",
+]
+
+
+def _norm(s):
+    return re.sub(r"[^a-z0-9]", "", str(s).lower())
+
+
+def _name_hit(name, pool):
+    """(kind, matched) if `name` exact- or substring-matches any pool name
+    (shorter side >= 6 chars to avoid generic-token false hits), else None."""
+    n = _norm(name)
+    for other in pool:
+        o = _norm(other)
+        if n == o:
+            return ("exact", other)
+        short, long_ = (n, o) if len(n) <= len(o) else (o, n)
+        if len(short) >= 6 and short in long_:
+            return ("contains", other)
+    return None
+
+
+# --------------------------------------------------------------------------
+# registration
+# --------------------------------------------------------------------------
+def test_registration_idempotent_and_tasks():
+    rb._add_highcard_datasets()
+    keys = [k for k in rb.DATASETS if k.startswith("hc:")]
+    rb._add_highcard_datasets()  # second call must not duplicate
+    keys2 = [k for k in rb.DATASETS if k.startswith("hc:")]
+    assert keys == keys2
+    assert len(keys) == len(rb.HC_DATASETS) >= 12
+    for name, spec in rb.HC_DATASETS.items():
+        key = f"hc:{name}"
+        assert key in rb.DATASETS
+        assert rb._task_of(key) == spec["task"] == rb.HC_TASKS[key]
+        assert spec["task"] in ("binary", "multiclass", "regression")
+
+
+def test_composition_meets_plan_targets():
+    tasks = [s["task"] for s in rb.HC_DATASETS.values()]
+    assert tasks.count("regression") >= 2          # >= 2 reg-with-cats
+    assert tasks.count("multiclass") >= 3          # multiclass columns land
+    assert len(rb.HC_DATASETS) >= 12
+
+
+# --------------------------------------------------------------------------
+# frozen list <-> doc agreement
+# --------------------------------------------------------------------------
+def _parse_frozen_doc():
+    """Rows of the form `| hc:<name> | <id> | <task> | ...` in HIGHCARD_PLAN.md."""
+    out = {}
+    with open(PLAN_MD, encoding="utf-8") as f:
+        for line in f:
+            m = re.match(r"\|\s*hc:([\w.\-]+)\s*\|\s*(\d+)\s*\|\s*(\w+)\s*\|", line)
+            if m:
+                out[m.group(1)] = (int(m.group(2)), m.group(3))
+    return out
+
+
+def test_frozen_matches_doc():
+    doc = _parse_frozen_doc()
+    code = {name: (spec["data_id"], spec["task"])
+            for name, spec in rb.HC_DATASETS.items()}
+    assert doc, "no frozen `| hc:... |` table rows found in HIGHCARD_PLAN.md"
+    assert doc == code, (
+        "HC_DATASETS and the HIGHCARD_PLAN.md frozen table disagree — "
+        f"only in doc: {set(doc) - set(code)}; only in code: {set(code) - set(doc)}; "
+        f"mismatched: {{k: (doc[k], code[k]) for k in set(doc)&set(code) if doc[k]!=code[k]}}")
+
+
+# --------------------------------------------------------------------------
+# sealed-holdout overlap regression test (the hard gate)
+# --------------------------------------------------------------------------
+def test_no_suite_overlap():
+    grinsztajn = [n for names in rb.GRINSZTAJN_DATASETS.values() for n in names]
+    gate_names = list(rb.OPENML_SUITE)
+    gate_ids = {spec["data_id"] for spec in rb.OPENML_SUITE.values()}
+    pmlb = [n for items in rb.PMLB_DATASETS.values() for n, _ in items]
+
+    failures = []
+    for name, spec in rb.HC_DATASETS.items():
+        did = spec["data_id"]
+        if did in gate_ids:
+            failures.append(f"{name}: OpenML id {did} is in the gate suite")
+        for tag, pool in (("TabArena", TABARENA_51), ("Grinsztajn", grinsztajn),
+                          ("gate", gate_names), ("PMLB", pmlb)):
+            hit = _name_hit(name, pool)
+            if hit:
+                failures.append(f"{name}: {tag} {hit[0]} match '{hit[1]}'")
+    assert not failures, "HC suite overlaps a sealed/decision suite:\n" + "\n".join(failures)
+
+
+# --------------------------------------------------------------------------
+# loader smoke (2 smallest sets); skips if OpenML/cache is unavailable
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("name", ["eucalyptus", "Moneyball"])
+def test_loader_smoke_smallest(name):
+    import numpy as np
+    spec = rb.HC_DATASETS[name]
+    try:
+        X, y, cat, task = rb.DATASETS[f"hc:{name}"](1.0, np.random.default_rng(0))
+    except Exception as e:  # no network / no A: cache -> not a code failure
+        pytest.skip(f"OpenML fetch unavailable for {name}: {e}")
+    assert X.shape[0] == len(y) > 0
+    assert task == spec["task"]
+    assert cat, f"{name} should expose categorical columns"
+    assert X.dtype == object
+    for j in cat[:3]:
+        assert all(isinstance(v, str) for v in X[:20, j])
+
+
+def test_id_columns_dropped():
+    # employee_salaries carries a `full_name` column (99.9% unique). The HC
+    # builder must drop near-unique categoricals, so no surviving cat column has
+    # cardinality > _HIGHCARD_ID_FRAC * n.
+    import numpy as np
+    try:
+        X, y, cat, task = rb.DATASETS["hc:employee_salaries"](
+            1.0, np.random.default_rng(0))
+    except Exception as e:
+        pytest.skip(f"OpenML fetch unavailable: {e}")
+    n = X.shape[0]
+    for j in cat:
+        card = len({v for v in X[:, j] if v == v})
+        assert card <= rb._HIGHCARD_ID_FRAC * n, (
+            f"cat col {j} card {card} exceeds id-drop threshold "
+            f"{rb._HIGHCARD_ID_FRAC} * {n}")
+
+
+# --------------------------------------------------------------------------
+# summarize: multiclass columns render only when multiclass records exist
+# --------------------------------------------------------------------------
+def _mini(with_mc):
+    def rec(ds, model, **mt):
+        return {"dataset": ds, "model": model, "seed": 0,
+                "metrics": {"primary": 0.0, **mt}, "fit_time": mt.get("_ft", 1.0)}
+    datasets = {"gr:bin1": {"task": "binary"}}
+    records = [rec("gr:bin1", "ChimeraBoost", f1_macro=.9, brier=.2, calibration_mcb=.01),
+               rec("gr:bin1", "CatBoost", f1_macro=.88, brier=.22, calibration_mcb=.02, _ft=2.0)]
+    if with_mc:
+        datasets["hc:mc1"] = {"task": "multiclass"}
+        records += [rec("hc:mc1", "ChimeraBoost", f1_macro=.7, brier=.5, calibration_mcb=.03),
+                    rec("hc:mc1", "CatBoost", f1_macro=.75, brier=.45, calibration_mcb=.02, _ft=2.0)]
+    return {"config": {"seeds": 1}, "datasets": datasets, "records": records}
+
+
+def test_summarize_multiclass_columns_conditional():
+    no_mc = summarize.format_table(_mini(False))
+    assert "Multi F1%" not in no_mc and "Multi Brier%" not in no_mc
+
+    with_mc = summarize.format_table(_mini(True))
+    assert "Multi F1%" in with_mc and "Multi Brier%" in with_mc
+    # every table row is the same width (alignment holds with the extra columns)
+    rows = [l for l in with_mc.splitlines()
+            if l.startswith(("Model", "ChimeraBoost", "CatBoost"))]
+    assert len({len(r) for r in rows}) == 1
+
+    # aggregate exposes the multiclass columns; make_pareto blend ignores them
+    cols, _ = summarize.aggregate(_mini(True))
+    assert "Multi F1%" in cols and "Multi Brier%" in cols


### PR DESCRIPTION
Adds a frozen 14-dataset real high-cardinality-categorical suite (`--highcard`) to the decision tier alongside Grinsztajn, per `benchmarks/HIGHCARD_PLAN.md`. This gives the decision stack a real-data view of the entity-cat / high-card / multiclass regime where CatBoost's Brier edge lives — the regime Grinsztajn curates out entirely.

**Freeze + audit (the hard gate):**
- 14 datasets: 4 binary + 4 multiclass + 6 regression; 10 with max cardinality ≥ 50 (up to ~32k levels).
- Zero overlap with TabArena-51 (sealed holdout), Grinsztajn-59, the OpenML gate-29, or PMLB-25 — matched by OpenML id and normalized name. Audit matrix, property table, and per-candidate verdicts committed in `HIGHCARD_PLAN.md`; a self-contained regression test (`tests/test_highcard.py::test_no_suite_overlap`) re-checks the frozen list on every run.
- Selection by data properties only (no model result). Cut highlights: the KDDCup09 trio (share TabArena appetency's identical feature matrix), airlines (Grinsztajn domain overlap), KDDCup99 (zero-support classes), SpeedDating (structural target leak).

**Harness:**
- `HC_DATASETS` + `_add_highcard_datasets()` + `--highcard`, mirroring the Grinsztajn/PMLB conventions; deterministic 100k subsample; sklearn cache on A:.
- summarize gains `Multi F1%` / `Multi Brier%` columns, rendered only when multiclass records exist. The blended north star is unchanged (make_pareto ignores them).
- `benchmarks/hc_gap.py`: first-read analysis (Brier gap by cardinality slice vs the synth entity-cat prediction).
- Three robustness fixes the high-card regime forced: a runner that raises is recorded as skipped instead of aborting the run (sklearn HGB's 255-category cap); pandas-3.0 `str` dtype now detected as categorical (free-text columns previously crashed the loader); near-unique id/free-text categorical columns dropped in the HC loader.

**Baseline verdict (hc-baseline.json, 3 seeds):** CatBoost reclaims the Brier crown on real high-card data — 86–88% Brier winrate, 100% on multiclass — confirming the SynthGen v2 entity-cat prior (predicted 91%) and reversing the Grinsztajn read, at ~111× slowdown vs ChimeraBoost's 2.9×. Logged in `synthgen/PAYOFF.md` v3 watch items. `/experiment` tier 2 now runs both suites, sign-tested separately; ship-rule weighting between them stays a human call.

Also fixes a duplicated "Generator v3 watch items" header that the #18 merge left in `PAYOFF.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
