### PR TITLE
H1/H2: honest leaf_estimation_iterations default (3 → None auto)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to ChimeraBoost are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- **Classifier `leaf_estimation_iterations` default is now `None` (auto)
+  instead of a concrete `3`; it resolves to 3 and fits bit-identically.** The
+  effective value is unchanged — an A/B across the synthetic, Grinsztajn,
+  highcard and OpenML suites confirmed `3` is correct: it helps small and
+  categorical-heavy binary fits (e.g. `credit-g`, `kc2` on the independent
+  gate) and is provably inert everywhere linear leaves take over (Grinsztajn
+  came out 59/59 bit-identical) or for multiclass. `None` simply stops the API
+  from advertising a refinement count that is dead for multiclass and shadowed
+  for large binary. The regressor's honest `1` is unchanged.
+### Fixed
+- The inert-knob warnings for `leaf_estimation_iterations` now fire for any
+  **explicitly-set** value `> 1` that will be ignored on the path about to run
+  (linear leaves active, or multiclass), while the auto default stays quiet —
+  previously the former default `3` was silently exempted, so an explicit `3`
+  meant to request refinement was never flagged.
 
 ## [0.18.1] - 2026-07-20
 ### Fixed

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -57,8 +57,10 @@ def _validate_hyperparams(estimator):
     """
     p = estimator.get_params()
 
-    def _pos_int(name, lo=1):
+    def _pos_int(name, lo=1, allow_none=False):
         v = p[name]
+        if v is None and allow_none:
+            return
         if not (isinstance(v, (int, np.integer)) and not isinstance(v, bool)
                 and v >= lo):
             raise ValueError(f"{name} must be an integer >= {lo}; got {v!r}.")
@@ -79,7 +81,9 @@ def _validate_hyperparams(estimator):
 
     _pos_int("n_estimators")
     _pos_int("cat_n_permutations")
-    _pos_int("leaf_estimation_iterations")
+    # None = the classifier's auto default (resolved to 3 at fit); the regressor
+    # passes a concrete int.
+    _pos_int("leaf_estimation_iterations", allow_none=True)
     # depth: a depth-d tree allocates 2**d leaves in the histogram buffer, so an
     # unbounded depth OOMs. 16 matches CatBoost's documented maximum. None is the
     # regressor's loss-adaptive default, resolved at fit.
@@ -1196,6 +1200,10 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         # always holds >=1 sample = hess >= 1); resolve an explicit None to 1.0.
         if kw.get("min_child_weight") is None:
             kw["min_child_weight"] = 1.0
+        # The regressor default is a concrete 1, but the shared validator accepts
+        # None (the classifier's auto default); resolve an explicit None to 1.
+        if kw.get("leaf_estimation_iterations") is None:
+            kw["leaf_estimation_iterations"] = 1
         # colsample None = auto: full columns for a single model (the bagged
         # path resolves members to 0.85 before this runs; see _fit_bagged).
         if kw.get("colsample") is None:
@@ -1468,8 +1476,14 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         them automatically only when the data is entirely categorical (where the
         interaction columns help without crowding out numeric splits); set
         ``True``/``False`` to force it on/off.
-    leaf_estimation_iterations : int, default 3
-        Newton refinement steps per leaf.
+    leaf_estimation_iterations : int or None, default None
+        Extra Newton refinement steps per leaf. ``None`` is the auto default and
+        resolves to 3, which helps small and categorical-heavy binary fits.
+        Refinement only applies to the plain constant-leaf path: it is inert
+        while ``linear_leaves`` is active (default-on for binary ≥ ~1000 rows,
+        where the per-leaf ridge already fits the second-order-optimal leaf) and
+        is not implemented for multiclass. An explicitly-set value that will be
+        ignored on the path about to run warns.
     linear_leaves : bool or None, default None
         Fit a ridge linear model per leaf over the numeric split features instead
         of a constant. ``None`` enables it for binary classification and disables
@@ -1558,7 +1572,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                  early_stopping_rounds=None,
                  min_child_weight=None, thread_count=None, random_state=None,
                  verbose=False, ordered_boosting=False,
-                 cat_combinations=None, leaf_estimation_iterations=3,
+                 cat_combinations=None, leaf_estimation_iterations=None,
                  linear_leaves=None, linear_lambda=1.0, cross_features=None,
                  selection_rounds=100,
                  early_stopping=True, validation_fraction=0.2,
@@ -1723,6 +1737,13 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         # (the regressor resolves it per loss); the booster requires an int.
         if kw.get("depth") is None:
             kw["depth"] = 6
+        # leaf_estimation_iterations None = auto -> 3. This is the classifier's
+        # long-standing effective value (it helps small/categorical binary and
+        # is inert where linear leaves take over or for multiclass); None just
+        # keeps the API from advertising a concrete count that is dead in those
+        # regimes. The booster requires an int.
+        if kw.get("leaf_estimation_iterations") is None:
+            kw["leaf_estimation_iterations"] = 3
         # colsample None = auto: full columns for a single model (the bagged
         # path resolves members to 0.85 before this runs; see _fit_bagged).
         if kw.get("colsample") is None:
@@ -1745,24 +1766,27 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                 "linear_leaves is not supported for multiclass classification "
                 "yet; use it on regression or binary classification.")
         # Warn when an explicitly non-default setting will be silently inert on
-        # the path about to run (defaults stay quiet -- the precedence is
-        # documented). The linear-leaf update owns the training step, so it
+        # the path about to run (the auto defaults stay quiet -- the precedence
+        # is documented). The linear-leaf update owns the training step, so it
         # shadows both ordered boosting and leaf refinement; multiclass never
-        # refines leaves. leaf_estimation_iterations=1 means "no refinement"
-        # and is trivially satisfied, so it never warns.
+        # refines leaves. leaf_estimation_iterations is checked against the raw
+        # attribute (None = auto, no user intent) rather than the resolved kw,
+        # and a refinement count of 1 asks for nothing, so neither warns.
         ll_shadows = (not self._multiclass and kw.get("linear_leaves")
                       and len(X) >= LINEAR_LEAVES_MIN_SAMPLES)
+        lei_set = self.leaf_estimation_iterations
+        lei_wanted = lei_set is not None and lei_set > 1
         if ll_shadows and self.ordered_boosting:
             warnings.warn(
                 "ordered_boosting is ignored while linear leaves are active "
                 "(the per-leaf linear model owns the training step); set "
                 "linear_leaves=False to use it.", UserWarning, stacklevel=2)
-        if ll_shadows and self.leaf_estimation_iterations not in (1, 3):
+        if ll_shadows and lei_wanted:
             warnings.warn(
                 "leaf_estimation_iterations is ignored while linear leaves "
                 "are active; set linear_leaves=False to use it.",
                 UserWarning, stacklevel=2)
-        if self._multiclass and self.leaf_estimation_iterations not in (1, 3):
+        if self._multiclass and lei_wanted:
             warnings.warn(
                 "leaf_estimation_iterations is not implemented for multiclass "
                 "and will be ignored.", UserWarning, stacklevel=2)

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -43,7 +43,7 @@ Core design choices (all deliberate, all validated):
 | `l2_leaf_reg` | 1.0 | 1.0 |
 | `max_bins` | 128 | 128 |
 | `ordered_boosting` (LOO) | False | False |
-| `leaf_estimation_iterations` | 1 | 3 |
+| `leaf_estimation_iterations` | 1 | None → 3 |
 | `min_child_weight` | 1.0 | None → size-adaptive `_auto_min_child_weight(n)` |
 | `n_estimators` / patience | 2000 max, patience 50 | same |
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -11,7 +11,7 @@ For more detail, see [API reference](api.md).
 | `depth` | `None`→auto (reg) / `6` (clf) | Tree depth (a depth-d tree is d splits). The regressor's `None` resolves to 6 for `"RMSE"`/`"MAE"` and 4 for `loss="Quantile"` (deep leaves overfit the tail quantile). Conservative by default; raise to 8–10 for large, interaction-heavy regression. |
 | `l2_leaf_reg` | `1.0` | L2 penalty on leaf values. Higher is smoother. |
 | `min_child_weight` | `1.0` (reg) / `None`→auto (clf) | Minimum hessian mass on each side of a split. The classifier's `None` is size-adaptive: the full veto (1.0) below ~500 training rows, fading linearly to 0 above ~2000 — oblivious trees underfit large data under a fixed veto, while small data still needs one. |
-| `leaf_estimation_iterations` | `1` (reg) / `3` (clf) | Extra Newton refinement steps per leaf. Applies to the plain constant-leaf path only: inactive while linear leaves are active, and not implemented for multiclass or `loss="MAE"`/`"Quantile"` (an explicitly non-default value warns there). |
+| `leaf_estimation_iterations` | `1` (reg) / `None`→`3` (clf) | Extra Newton refinement steps per leaf. The classifier's `None` is an auto default resolving to 3 (it helps small/categorical-heavy binary fits). Applies to the plain constant-leaf path only: inert while linear leaves are active (default-on for binary ≥ ~1000 rows — the per-leaf ridge already fits the second-order-optimal leaf), and not implemented for multiclass or `loss="MAE"`/`"Quantile"`. An explicitly-set value that will be ignored on the path warns. |
 
 ## Binning
 

--- a/tests/test_audit_fixes.py
+++ b/tests/test_audit_fixes.py
@@ -171,14 +171,69 @@ def test_ordered_boosting_warns_when_linear_leaves_shadow_it():
         clf.fit(Xc, yc)
 
 
-def test_leaf_estimation_iterations_warns_on_multiclass():
+def test_leaf_estimation_iterations_default_is_none_auto():
+    # H1/H2: the classifier's default is None (auto), not a concrete 3, so the
+    # API stops advertising a refinement count that is inert for multiclass and
+    # shadowed by linear leaves. None resolves to 3 for the constant-leaf path.
+    assert ChimeraBoostClassifier().leaf_estimation_iterations is None
+
+
+def test_leaf_estimation_iterations_auto_resolves_to_three():
+    # The auto default must reproduce the historical effective value (3) exactly
+    # -- i.e. be bit-identical to explicitly passing 3 -- on a constant-leaf
+    # binary fit where refinement is live (linear leaves off).
+    Xc, yc = _toy_binary(n=1500, seed=2)
+    common = dict(n_estimators=40, random_state=0, linear_leaves=False)
+    p_auto = ChimeraBoostClassifier(**common).fit(Xc, yc).predict_proba(Xc)
+    p_three = ChimeraBoostClassifier(leaf_estimation_iterations=3,
+                                     **common).fit(Xc, yc).predict_proba(Xc)
+    np.testing.assert_array_equal(p_auto, p_three)
+
+
+def test_leaf_estimation_iterations_auto_is_quiet_on_multiclass():
+    # The auto default (None) must NOT warn on multiclass -- only an explicitly
+    # set, ignored value should.
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(300, 4))
+    y = rng.choice([0, 1, 2], size=300)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")   # any warning becomes a failure
+        ChimeraBoostClassifier(n_estimators=10, random_state=0).fit(X, y)
+
+
+def test_regressor_accepts_none_leaf_estimation_iterations():
+    # The shared validator now accepts None (the classifier's auto default);
+    # the regressor resolves an explicit None to its concrete default 1.
+    X, y = _toy_regression(n=300)
+    common = dict(n_estimators=20, random_state=0)
+    p_none = ChimeraBoostRegressor(leaf_estimation_iterations=None,
+                                   **common).fit(X, y).predict(X)
+    p_one = ChimeraBoostRegressor(leaf_estimation_iterations=1,
+                                  **common).fit(X, y).predict(X)
+    np.testing.assert_array_equal(p_none, p_one)
+
+
+@pytest.mark.parametrize("lei", [2, 3, 8])
+def test_leaf_estimation_iterations_warns_on_multiclass(lei):
+    # Any explicitly-set lei>1 that is ignored on multiclass warns honestly
+    # (the former default 3 no longer gets a silent exemption).
     rng = np.random.default_rng(0)
     X = rng.normal(size=(300, 4))
     y = rng.choice([0, 1, 2], size=300)
     clf = ChimeraBoostClassifier(n_estimators=10, random_state=0,
-                                 leaf_estimation_iterations=8)
+                                 leaf_estimation_iterations=lei)
     with pytest.warns(UserWarning, match="not implemented for multiclass"):
         clf.fit(X, y)
+
+
+@pytest.mark.parametrize("lei", [2, 3])
+def test_leaf_estimation_iterations_warns_when_linear_leaves_shadow_it(lei):
+    Xc, yc = _toy_binary(n=1600)               # >= 1000 rows -> linear leaves on
+    clf = ChimeraBoostClassifier(n_estimators=10, random_state=0,
+                                 leaf_estimation_iterations=lei)
+    with pytest.warns(UserWarning,
+                      match="leaf_estimation_iterations is ignored"):
+        clf.fit(Xc, yc)
 
 
 def test_ordered_boosting_warns_on_mae():


### PR DESCRIPTION
## Phase-2 audit follow-up: H1/H2

**The experiment reversed the premise.** The audit flagged the classifier's `leaf_estimation_iterations=3` (lei) default as stale — shadowed by linear leaves for binary ≥1000 rows (H1) and dead for multiclass (H2). I A/B-tested reverting it to `lei=1` across all four tiers of the `/experiment` protocol, and the gate **killed the revert**:

| Tier | `lei=1` vs `lei=3` | Read |
|---|---|---|
| Synth | 9W–13L–114T (p=0.52) | reg **0-0-48** & multiclass **0-0-34** bit-identical; binary a coin-flip |
| Grinsztajn | **0-0-59** (all ties) | linear leaves fully shadow lei here — reverting is invisible |
| Highcard | 2W–1L–11T (−0.007%) | flat |
| OpenML gate | 3W–6L–27T (−0.196%) | `lei=1` **loses** on small-data `credit-g` (−4.6%), `kc2` (−1.8%) |

So `lei=3`'s *effect* is correct: it earns its keep on small/categorical-heavy binary (the constant-leaf regime linear leaves hand off to it) and is provably inert everywhere else. The real defect was **API honesty** — the classifier advertised a concrete `3` that's dead for multiclass and shadowed for large binary.

## Change (bit-identical — goldens green, no re-gate)
- **Classifier default `3` → `None` (auto)**, resolved to `3` at fit on the constant-leaf path. Mirrors the existing `min_child_weight=None` auto-default pattern. Regressor keeps its honest concrete `1`.
- **Warnings** now fire for an *explicitly-set* `lei>1` that will be ignored (linear-shadow / multiclass); the auto default stays quiet (previously the value `3` was silently exempted, so an explicit `3` was never flagged).
- Docstring, `docs/parameters.md`, `docs/PROJECT_STATUS.md`, `CHANGELOG` updated.
- Tests: default-is-`None`, auto-resolves-to-`3` (bit-identity), auto-quiet-on-multiclass, explicit-`lei` warns (incl. `3`), regressor accepts `None`. **493 pass.**

## Deferred
A backtracking line search for `lei>1` was prototyped and pulled back out: it changes the vindicated default and would need its own gate for marginal upside (raw `lei=3` already tests net-positive). Recorded as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)