### PR TITLE
H3: make sample_weight weight-aware (encoder, binner, early-stopping metric)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to ChimeraBoost are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- **`sample_weight` is now honored everywhere, not just in the gradient
+  step.** Rows are weighted in the ordered-target categorical encoder (prior
+  and per-category statistics), in the quantile bin borders, and in the
+  early-stopping validation metric on an automatically split (or bagged
+  out-of-bag) holdout. Previously a `sample_weight=0` row still shaped the
+  categorical encodings and bin edges, and — worst — still scored the
+  early-stopping metric with full weight: in an adversarial repro (zeroed-out
+  rows carrying garbage targets) the reported validation RMSE was ~2000
+  instead of ~0.1, which stopped training at the wrong iteration and could
+  degrade the model by an order of magnitude. Uniform weights collapse to the
+  unweighted path, so `sample_weight=None` and any constant weight vector stay
+  bitwise-identical to before. An explicitly passed `eval_set` is still scored
+  unweighted (it carries no weights); a third `(X, y, sample_weight)` element
+  is now accepted for callers that want to supply them.
 
 ## [0.18.1] - 2026-07-20
 ### Fixed

--- a/chimeraboost/binning.py
+++ b/chimeraboost/binning.py
@@ -53,17 +53,50 @@ def _bin_matrix(X, borders_flat, offsets, out):
                 out[i, f] = a - lo
 
 
-def _feature_borders(col, max_bins):
-    """Quantile borders for one numeric column, ignoring NaNs."""
-    finite = col[np.isfinite(col)]
+def _weighted_quantiles(values, weights, qs):
+    """Weighted quantiles at levels ``qs`` (sorted values, midpoint plotting
+    position). Reduces to the ordinary midpoint quantile when weights are
+    equal; used only on the sample-weighted binning path."""
+    order = np.argsort(values, kind="stable")
+    v = values[order]
+    w = weights[order]
+    cumw = np.cumsum(w)
+    total = cumw[-1]
+    # Position of each value on [0, 1]: cumulative weight up to its midpoint.
+    pos = (cumw - 0.5 * w) / total
+    return np.interp(qs, pos, v)
+
+
+def _feature_borders(col, max_bins, weights=None):
+    """Quantile borders for one numeric column, ignoring NaNs.
+
+    ``weights`` (per row, aligned with ``col``) makes the borders sample-weight
+    aware: zero-weight rows are dropped outright and fractional weights steer the
+    quantiles, so a row the caller zeroed out cannot place a bin edge. ``None``
+    is the unweighted fast path, unchanged from before this argument existed."""
+    finite_mask = np.isfinite(col)
+    finite = col[finite_mask]
+    if weights is None:
+        if finite.size == 0:
+            return np.array([], dtype=np.float64)
+        uniq = np.unique(finite)
+        if uniq.size <= max_bins:
+            # Few distinct values: put a border between each pair.
+            return ((uniq[:-1] + uniq[1:]) / 2.0).astype(np.float64)
+        qs = np.linspace(0.0, 1.0, max_bins + 1)[1:-1]
+        borders = np.quantile(finite, qs)
+        return np.unique(borders).astype(np.float64)
+    # Weighted path: a zero-weight row does not exist for border purposes.
+    fw = weights[finite_mask]
+    pos = fw > 0.0
+    finite, fw = finite[pos], fw[pos]
     if finite.size == 0:
         return np.array([], dtype=np.float64)
     uniq = np.unique(finite)
     if uniq.size <= max_bins:
-        # Few distinct values: put a border between each pair.
         return ((uniq[:-1] + uniq[1:]) / 2.0).astype(np.float64)
     qs = np.linspace(0.0, 1.0, max_bins + 1)[1:-1]
-    borders = np.quantile(finite, qs)
+    borders = _weighted_quantiles(finite, fw, qs)
     return np.unique(borders).astype(np.float64)
 
 
@@ -124,12 +157,17 @@ class Binner:
         centers[m + 1] = np.nan                     # NaN bin
         return centers
 
-    def fit(self, X):
-        """Learn quantile borders for each column from training data."""
+    def fit(self, X, sample_weight=None):
+        """Learn quantile borders for each column from training data.
+
+        ``sample_weight`` (per row, ``None`` == uniform) makes the borders
+        weight-aware; ``None`` is bit-identical to the pre-weight behavior."""
         X = np.asarray(X, dtype=np.float64)
         n_features = X.shape[1]
+        w = None if sample_weight is None else np.asarray(
+            sample_weight, dtype=np.float64)
         self.borders_ = [
-            _feature_borders(X[:, f], self._max_bins_for(f))
+            _feature_borders(X[:, f], self._max_bins_for(f), w)
             for f in range(n_features)
         ]
         # +1 for the searchsorted upper bucket, +1 for the NaN bucket.
@@ -164,5 +202,5 @@ class Binner:
             _bin_matrix(X, self._borders_flat, self._offsets, out)
         return out
 
-    def fit_transform(self, X):
-        return self.fit(X).transform(X)
+    def fit_transform(self, X, sample_weight=None):
+        return self.fit(X, sample_weight).transform(X)

--- a/chimeraboost/booster.py
+++ b/chimeraboost/booster.py
@@ -19,6 +19,19 @@ from .tree import (build_oblivious_tree, _loo_leaf_step, _leaf_values,
                    pack_forest_linear, _shap_forest_linear)
 
 
+def _uniform_to_none(w):
+    """Collapse uniform (all-equal) weights to None: they are the unweighted
+    case, and routing them through None keeps every weight-aware path (grad/hess,
+    loss init, target encoder, binner, validation metric) bit-identical to
+    sample_weight=None. None passes through unchanged."""
+    if w is None:
+        return None
+    w = np.asarray(w, dtype=np.float64)
+    if w.size and np.all(w == w[0]):
+        return None
+    return w
+
+
 def _run_callbacks(callbacks, iteration, train_loss, val_loss, model):
     """Invoke each fit callback for one boosting round. A callback is
     ``cb(iteration, train_loss, val_loss, model)``; returning True requests an
@@ -238,9 +251,11 @@ class _BaseBooster:
         return state
 
     def _prep_matrices(self, X, encode_targets, cat_features, eval_set,
-                       prep_cache):
+                       prep_cache, sample_weight=None):
         """Fit ``self.prep_`` and return the feature-major binned train/eval
         matrices ``(Xb, Xvb)`` (``Xvb`` is None without an eval set).
+        ``sample_weight`` (mean-1 normalized train weights, ``None`` == uniform)
+        is forwarded to the encoder/binner so zero-weight rows shape neither.
         ``encode_targets`` is the list of TS-encoding targets: ``[y]`` for the
         scalar booster, the K one-hot columns for multiclass.
 
@@ -268,7 +283,7 @@ class _BaseBooster:
             base_prep, base_Xb, base_Xvb = base
             self.prep_, cross_binner, crossb = \
                 FeaturePreprocessor.from_base_with_cross(
-                    base_prep, list(self.cross_pairs), X)
+                    base_prep, list(self.cross_pairs), X, sample_weight)
             nb = len(self.prep_.num_features_)
             # Stacked column order is [numeric | cross | TS]; splice the new
             # cross rows into the feature-major base matrix (concatenate
@@ -288,7 +303,8 @@ class _BaseBooster:
             self.prep_ = self._new_preprocessor()
             # Tree kernels consume a feature-major matrix; transpose once here.
             Xb = np.ascontiguousarray(
-                self.prep_.fit_transform(X, encode_targets, cat_features).T)
+                self.prep_.fit_transform(
+                    X, encode_targets, cat_features, sample_weight).T)
             Xvb = None
             if eval_set is not None:
                 Xv = as_model_array(eval_set[0], bool(cat_features))
@@ -300,11 +316,13 @@ class _BaseBooster:
     @staticmethod
     def _normalize_weights(sample_weight, n_samples):
         """Scale weights to mean 1 so the gradient magnitude matches the
-        unweighted case. None passes through unchanged."""
+        unweighted case. None passes through unchanged. Uniform weights collapse
+        to None so the whole fit takes the exact unweighted path (see
+        ``_uniform_to_none``)."""
         if sample_weight is None:
             return None
         w = np.asarray(sample_weight, dtype=np.float64)
-        return w * (n_samples / w.sum())
+        return _uniform_to_none(w * (n_samples / w.sum()))
 
     def _resolve_lr(self, n_samples, eval_set):
         if self.learning_rate is not None:
@@ -435,7 +453,7 @@ class GradientBoosting(_BaseBooster):
         self.lr_ = self._resolve_lr(n_samples, eval_set)
 
         Xb, Xvb = self._prep_matrices(X, [y], cat_features, eval_set,
-                                      prep_cache)
+                                      prep_cache, w)
         n_bins = self.prep_.n_bins_
         hist_buffers = self._alloc_hist_buffers(Xb.shape[0], n_bins)
         # Packed quantized grad/hess scratch, reused across trees (see
@@ -450,9 +468,13 @@ class GradientBoosting(_BaseBooster):
             n_samples, bg_n, replace=False)
         self._shap_background_ = np.ascontiguousarray(Xb[:, bg_idx])
 
-        yv = Fv = None
+        yv = Fv = wv = None
         if eval_set is not None:
             yv = np.asarray(eval_set[1], dtype=np.float64)
+            # eval_set may carry per-row validation weights as a 3rd element
+            # (auto-split / OOB folds); uniform or absent -> unweighted metric.
+            if len(eval_set) > 2:
+                wv = _uniform_to_none(eval_set[2])
 
         self.init_ = self.loss_.init(y, w)
         F = np.full(n_samples, self.init_, dtype=np.float64)
@@ -527,7 +549,7 @@ class GradientBoosting(_BaseBooster):
 
             if Fv is not None:
                 Fv += tree.predict(Xvb)
-                val = self.loss_.eval(yv, Fv)   # validation is always unweighted
+                val = self.loss_.eval(yv, Fv, wv)   # wv=None -> unweighted
                 self.valid_history_.append(val)
                 if stopper.step(val, m):
                     if self.verbose:
@@ -680,17 +702,19 @@ class MulticlassBoosting(_BaseBooster):
 
         # One ordered-TS target per class (CatBoost-style per-class statistics).
         Xb, Xvb = self._prep_matrices(X, [Y[:, k] for k in range(K)],
-                                      cat_features, eval_set, prep_cache)
+                                      cat_features, eval_set, prep_cache, w)
         n_bins = self.prep_.n_bins_
         hist_buffers = self._alloc_hist_buffers(Xb.shape[0], n_bins)
         # Packed quantized grad/hess scratch, reused across every class tree.
         qbuf = (np.empty(n_samples, dtype=np.int64)
                 if self.quantize_gradients else None)
 
-        Yv = Fv = yv_idx = None
+        Yv = Fv = yv_idx = wv = None
         if eval_set is not None:
             yv_idx = np.searchsorted(self.classes_, np.asarray(eval_set[1]))
             Yv = np.eye(K)[yv_idx]
+            if len(eval_set) > 2:
+                wv = _uniform_to_none(eval_set[2])
 
         self.init_ = self.loss_.init(Y, w)         # (K,)
         F = np.tile(self.init_, (n_samples, 1))    # (n, K)
@@ -741,7 +765,7 @@ class MulticlassBoosting(_BaseBooster):
             if Fv is not None:
                 for k in range(K):
                     Fv[:, k] += round_trees[k].predict(Xvb)
-                val = self.loss_.eval(Yv, Fv)   # validation is always unweighted
+                val = self.loss_.eval(Yv, Fv, wv)   # wv=None -> unweighted
                 self.valid_history_.append(val)
                 if stopper.step(val, m):
                     if self.verbose:

--- a/chimeraboost/preprocessing.py
+++ b/chimeraboost/preprocessing.py
@@ -179,8 +179,13 @@ class FeaturePreprocessor:
         return combo_codes
 
     # ---- fit / transform -----------------------------------------------------
-    def fit_transform(self, X, encode_targets, cat_features):
-        """encode_targets: list of 1D arrays used for ordered TS (len T)."""
+    def fit_transform(self, X, encode_targets, cat_features, sample_weight=None):
+        """encode_targets: list of 1D arrays used for ordered TS (len T).
+
+        ``sample_weight`` (mean-1 normalized, ``None`` == uniform) is forwarded to
+        the ordered-target encoder and the binner so zero-weight rows shape
+        neither the categorical statistics nor the bin borders. ``None`` is the
+        unweighted path, bit-identical to before this argument existed."""
         num, codes = self._split_columns_fit(X, cat_features)
         cross = self._cross_block(X)
         if cross.shape[1]:
@@ -195,7 +200,8 @@ class FeaturePreprocessor:
                     None if self.random_state is None else self.random_state + t,
                     self.cat_n_permutations,
                 )
-                encoded_blocks.append(enc.fit_transform(codes, target))
+                encoded_blocks.append(
+                    enc.fit_transform(codes, target, sample_weight))
                 self.encoders_.append(enc)
 
         feat = self._stack(num, encoded_blocks)
@@ -207,7 +213,7 @@ class FeaturePreprocessor:
         self.is_numeric_binned_[:num.shape[1]] = True
 
         self.binner_ = Binner(self.max_bins)
-        X_binned = self.binner_.fit_transform(feat)
+        X_binned = self.binner_.fit_transform(feat, sample_weight)
         self.n_bins_ = self.binner_.n_bins_
         return X_binned
 
@@ -229,7 +235,7 @@ class FeaturePreprocessor:
         return self.binner_.transform(feat)
 
     @classmethod
-    def from_base_with_cross(cls, base, cross_pairs, X):
+    def from_base_with_cross(cls, base, cross_pairs, X, sample_weight=None):
         """A fitted preprocessor equal to refitting ``base``'s configuration
         with ``cross_pairs`` added, built by reusing ``base``'s fitted state.
 
@@ -259,7 +265,7 @@ class FeaturePreprocessor:
         prep.encoders_ = base.encoders_
 
         cross = prep._cross_block(X)
-        cross_binner = Binner(base.max_bins).fit(cross)
+        cross_binner = Binner(base.max_bins).fit(cross, sample_weight)
         nb = len(base.num_features_)
         bb = base.binner_
         binner = Binner(base.max_bins)

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -167,9 +167,14 @@ def _resolve_cat_feature_names(cat_features, X):
 def _check_eval_set(eval_set, n_features):
     """Validate a user-passed ``eval_set`` up front with a named error instead of
     a cryptic IndexError/broadcast failure deep in the booster."""
-    if not (isinstance(eval_set, (tuple, list)) and len(eval_set) == 2):
-        raise ValueError("eval_set must be a (X_val, y_val) tuple.")
-    Xv, yv = eval_set
+    # 2-tuple is the documented form; a 3rd element is optional per-row
+    # validation weights (used internally for weight-aware auto-split / bagged
+    # OOB early stopping, so zero-weight rows don't score the metric).
+    if not (isinstance(eval_set, (tuple, list)) and len(eval_set) in (2, 3)):
+        raise ValueError(
+            "eval_set must be a (X_val, y_val) tuple "
+            "(optionally (X_val, y_val, sample_weight_val)).")
+    Xv, yv = eval_set[0], eval_set[1]
     shape = getattr(Xv, "shape", None)
     if shape is None or len(shape) != 2:
         shape = np.asarray(Xv, dtype=object).shape
@@ -182,6 +187,11 @@ def _check_eval_set(eval_set, n_features):
         raise ValueError(
             f"eval_set X and y have inconsistent lengths: {shape[0]} vs "
             f"{len(yv)}.")
+    if len(eval_set) == 3 and eval_set[2] is not None \
+            and len(eval_set[2]) != shape[0]:
+        raise ValueError(
+            f"eval_set sample_weight has length {len(eval_set[2])}, but "
+            f"eval_set X has {shape[0]} rows; they must match.")
 
 
 def _check_eval_labels(eval_set, y):
@@ -342,7 +352,12 @@ def _fit_bagged(estimator, X, y, cat_features, eval_set, groups, sample_weight):
             oob_idx = np.where(oob_mask)[0]
             # Degenerate case: every row drawn (possible for tiny n). Fall back
             # to letting the member auto-split rather than training with no eval.
-            member_eval = (X[oob_idx], y[oob_idx]) if len(oob_idx) > 0 else None
+            # Carry OOB-row weights so zero-weight rows don't score the member's
+            # early-stopping metric (H3).
+            sw_oob = (np.asarray(sample_weight)[oob_idx]
+                      if sample_weight is not None else None)
+            member_eval = ((X[oob_idx], y[oob_idx], sw_oob)
+                           if len(oob_idx) > 0 else None)
         else:
             member_eval = eval_set
         member.fit(X[idx], y[idx], cat_features=cat_features, eval_set=member_eval,
@@ -1079,8 +1094,12 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
             are kept intact across the train/validation boundary using
             ``GroupShuffleSplit``.
         sample_weight : array-like of shape (n_samples,) or None
-            Per-sample weights.  Normalized to mean 1 internally.  Only applied
-            to the training set; the validation eval metric is always unweighted.
+            Per-sample weights.  Normalized to mean 1 internally.  Applied
+            throughout: the gradient/leaf fit, the categorical target encoder,
+            the quantile bin borders, and the early-stopping metric on an
+            automatically split (or bagged out-of-bag) validation set, so a
+            zero-weight row never influences the model.  An explicitly passed
+            ``eval_set`` carries no weights and is scored unweighted.
         callbacks : callable or list of callable, or None
             Per-round fit hooks ``cb(iteration, train_loss, val_loss, model)``;
             a callback returning True requests an early stop. Used for live
@@ -1153,7 +1172,11 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                 es_active = False  # data too small to hold out a val set
             else:
                 train_idx, val_idx = split
-                eval_set = (X[val_idx], y[val_idx])
+                # Carry the val rows' weights so zero-weight rows split off into
+                # the auto holdout don't score the early-stopping metric (H3).
+                sw_val = (sample_weight[val_idx]
+                          if sample_weight is not None else None)
+                eval_set = (X[val_idx], y[val_idx], sw_val)
                 X, y = X[train_idx], y[train_idx]
                 if sample_weight is not None:
                     sample_weight = sample_weight[train_idx]
@@ -1615,8 +1638,12 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
             stopping triggers an automatic split, ``StratifiedGroupKFold`` keeps
             groups intact and class proportions balanced across the split.
         sample_weight : array-like of shape (n_samples,) or None
-            Per-sample weights.  Normalized to mean 1 internally.  Only applied
-            to the training set; the validation eval metric is always unweighted.
+            Per-sample weights.  Normalized to mean 1 internally.  Applied
+            throughout: the gradient/leaf fit, the categorical target encoder,
+            the quantile bin borders, and the early-stopping metric on an
+            automatically split (or bagged out-of-bag) validation set, so a
+            zero-weight row never influences the model.  An explicitly passed
+            ``eval_set`` carries no weights and is scored unweighted.
         callbacks : callable or list of callable, or None
             Per-round fit hooks ``cb(iteration, train_loss, val_loss, model)``;
             a callback returning True requests an early stop. Used for live
@@ -1689,7 +1716,11 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                 es_active = False  # data too small to hold out a val set
             else:
                 train_idx, val_idx = split
-                eval_set = (X[val_idx], y[val_idx])
+                # Carry val-row weights so zero-weight holdout rows don't score
+                # the early-stopping metric (H3).
+                sw_val = (sample_weight[val_idx]
+                          if sample_weight is not None else None)
+                eval_set = (X[val_idx], y[val_idx], sw_val)
                 X, y = X[train_idx], y[train_idx]
                 if sample_weight is not None:
                     sample_weight = sample_weight[train_idx]
@@ -1798,7 +1829,9 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
             if eval_set is not None:
                 cal_Xv = eval_set[0]
                 cal_y = (np.asarray(eval_set[1]) == self.classes_[1]).astype(np.float64)
-                eval_set = (cal_Xv, cal_y)
+                # Preserve any val-row weights through the 0/1 relabeling.
+                sw_v = eval_set[2] if len(eval_set) > 2 else None
+                eval_set = (cal_Xv, cal_y, sw_v)
         self.model_ = _make()
         self.model_.fit(X, y_fit, cat_features=cat_features, eval_set=eval_set,
                         sample_weight=sample_weight,

--- a/chimeraboost/target_encoding.py
+++ b/chimeraboost/target_encoding.py
@@ -41,6 +41,28 @@ def _ordered_ts(codes, y, perm, n_cat, prior, a):
     return out, sums, counts
 
 
+@njit(cache=True)
+def _ordered_ts_weighted(codes, y, w, perm, n_cat, prior, a):
+    """Sample-weighted ordered target statistic.
+
+    Each row contributes its weight ``w[i]`` to the running per-category sum and
+    count, so a zero-weight row is a ghost: it neither shifts the statistic used
+    by later rows nor (via the returned totals) the predict-time encoding. With
+    ``w`` all ones this is bit-identical to ``_ordered_ts``; the unweighted
+    kernel is kept as the fast path for that case.
+    """
+    sums = np.zeros(n_cat)
+    counts = np.zeros(n_cat)
+    out = np.empty(codes.shape[0], dtype=np.float64)
+    for pos in range(perm.shape[0]):
+        i = perm[pos]
+        c = codes[i]
+        out[i] = (sums[c] + prior * a) / (counts[c] + a)
+        sums[c] += w[i] * y[i]
+        counts[c] += w[i]
+    return out, sums, counts
+
+
 class OrderedTargetEncoder:
     """Encodes one or more categorical columns into numeric ctr columns.
 
@@ -63,14 +85,22 @@ class OrderedTargetEncoder:
         self.counts_ = None     # list per column
         self.n_cat_ = None      # list per column
 
-    def fit_transform(self, codes_matrix, y):
-        """codes_matrix: (n_samples, n_cat_features) int array of codes."""
+    def fit_transform(self, codes_matrix, y, sample_weight=None):
+        """codes_matrix: (n_samples, n_cat_features) int array of codes.
+
+        ``sample_weight`` (mean-1 normalized, ``None`` == uniform) weights each
+        row's contribution to the prior and the per-category statistics, so a
+        zero-weight row never shapes another row's encoding. ``None`` takes the
+        unweighted fast path, bit-identical to before this argument existed."""
         codes_matrix = np.asarray(codes_matrix, dtype=np.int64)
         y = np.asarray(y, dtype=np.float64)
+        w = None if sample_weight is None else np.ascontiguousarray(
+            sample_weight, dtype=np.float64)
         n_samples, n_cols = codes_matrix.shape
         rng = np.random.default_rng(self.random_state)
 
-        self.prior_ = float(np.mean(y))
+        self.prior_ = (float(np.mean(y)) if w is None
+                       else float(np.average(y, weights=w)))
         self.sums_, self.counts_, self.n_cat_ = [], [], []
         out = np.zeros((n_samples, n_cols), dtype=np.float64)
 
@@ -81,9 +111,12 @@ class OrderedTargetEncoder:
             sums = counts = None
             for _ in range(self.n_permutations):
                 perm = rng.permutation(n_samples)
-                enc, sums, counts = _ordered_ts(
-                    codes, y, perm, n_cat, self.prior_, self.smoothing
-                )
+                if w is None:
+                    enc, sums, counts = _ordered_ts(
+                        codes, y, perm, n_cat, self.prior_, self.smoothing)
+                else:
+                    enc, sums, counts = _ordered_ts_weighted(
+                        codes, y, w, perm, n_cat, self.prior_, self.smoothing)
                 acc += enc
             out[:, j] = acc / self.n_permutations
             # sums/counts are full-data totals: identical across permutations.

--- a/tests/test_audit_fixes.py
+++ b/tests/test_audit_fixes.py
@@ -208,3 +208,124 @@ def test_bagged_members_carry_feature_names():
     # The member-level column-order guard now applies too.
     with pytest.raises(ValueError, match="feature names"):
         bag.predict(df[list(df.columns[::-1])])
+
+
+# ---------------------------------------------------------------- H3: weights
+# sample_weight=0 rows must not shape the target encoder, the bin borders, or
+# the early-stopping metric. See the audit note H3 / project-audit-2026-07-19.
+
+
+def _garbage_weight_data(seed=0, n=4000, n_garbage=800):
+    """Clean signal plus zero-weight 'garbage' rows with wild targets and
+    extreme feature values. A correct fit treats the garbage as ghosts."""
+    rng = np.random.default_rng(seed)
+    Xc = rng.normal(size=(n, 6))
+    yc = Xc[:, 0] * 2.0 + Xc[:, 1] - 0.5 * Xc[:, 2] + 0.1 * rng.normal(size=n)
+    Xg = rng.normal(size=(n_garbage, 6)) * 50.0
+    yg = rng.normal(size=n_garbage) * 1000.0 + 5000.0
+    X = np.vstack([Xc, Xg])
+    y = np.concatenate([yc, yg])
+    w = np.concatenate([np.ones(n), np.zeros(n_garbage)])
+    perm = rng.permutation(len(y))
+    return X[perm], y[perm], w[perm]
+
+
+def test_h3_encoder_totals_are_weighted():
+    """The ordered-target encoder's prior and per-category totals weight each
+    row by sample_weight, so a zero-weight row contributes nothing."""
+    from chimeraboost.target_encoding import OrderedTargetEncoder
+    rng = np.random.default_rng(0)
+    n, g = 2000, 400
+    codes = np.concatenate([rng.integers(0, 5, n), rng.integers(0, 5, g)])
+    y = np.concatenate([rng.normal(size=n), np.full(g, 9999.0)])
+    w = np.concatenate([np.ones(n), np.zeros(g)])
+    enc = OrderedTargetEncoder(smoothing=1.0, random_state=0, n_permutations=4)
+    enc.fit_transform(codes.reshape(-1, 1), y, w)
+    # Prior is the weighted mean -> the 9999 garbage rows drop out entirely.
+    assert np.isclose(enc.prior_, np.average(y, weights=w))
+    assert enc.prior_ < 10.0            # not dragged toward 9999
+    # Per-category totals equal the weighted sums/counts over positive rows.
+    for c in range(5):
+        m = codes == c
+        assert np.isclose(enc.sums_[0][c], np.sum(w[m] * y[m]))
+        assert np.isclose(enc.counts_[0][c], np.sum(w[m]))
+
+
+def test_h3_bin_borders_drop_zero_weight_rows():
+    """Zero-weight rows must not place a bin edge: extreme values carried only
+    by weight-0 rows never appear in the learned borders."""
+    from chimeraboost.binning import _feature_borders
+    col = np.array([0.0, 1.0, 2.0, 100.0, 100.0])
+    w = np.array([1.0, 1.0, 1.0, 0.0, 0.0])
+    borders = _feature_borders(col, max_bins=128, weights=w)
+    # Only {0,1,2} survive -> midpoints, and nothing near the weight-0 value 100.
+    np.testing.assert_allclose(borders, [0.5, 1.5])
+    assert borders.max() < 3.0
+    # The unweighted path still sees the 100s (regression guard on the default).
+    plain = _feature_borders(col, max_bins=128, weights=None)
+    assert plain.max() > 3.0
+
+
+def test_h3_early_stopping_metric_ignores_zero_weight_rows():
+    """The headline leak: zero-weight rows landing in the auto-split validation
+    fold must not corrupt the early-stopping metric or wreck the fit."""
+    X, y, w = _garbage_weight_data(seed=2)
+    keep = w > 0
+    m_zero = ChimeraBoostRegressor(
+        n_estimators=500, early_stopping=True, validation_fraction=0.2,
+        early_stopping_rounds=20, random_state=0).fit(X, y, sample_weight=w)
+    m_drop = ChimeraBoostRegressor(
+        n_estimators=500, early_stopping=True, validation_fraction=0.2,
+        early_stopping_rounds=20, random_state=0).fit(X[keep], y[keep])
+    # Validation loss is on the signal scale (~0.1), not the garbage scale (~2e3).
+    assert min(m_zero.model_.valid_history_) < 1.0
+    # And the model is not truncated to near-nothing by a corrupted metric.
+    assert m_zero.best_iteration_ > 20
+    rng = np.random.default_rng(99)
+    Xte = rng.normal(size=(2000, 6))
+    yte = Xte[:, 0] * 2.0 + Xte[:, 1] - 0.5 * Xte[:, 2]
+    rmse = lambda a, b: float(np.sqrt(np.mean((a - b) ** 2)))
+    # Predictions track the rows-removed model closely (not off by an order
+    # of magnitude, as the corrupted-metric fit was).
+    assert rmse(m_zero.predict(Xte), m_drop.predict(Xte)) < 0.1
+
+
+def test_h3_classifier_early_stopping_ignores_zero_weight_rows():
+    """Same guard for the binary classifier (eval_set is relabeled 0/1 and must
+    carry the val weights through)."""
+    rng = np.random.default_rng(0)
+    n, g = 3000, 600
+    Xc = rng.normal(size=(n, 6))
+    yc = (Xc[:, 0] + Xc[:, 1] + 0.3 * rng.normal(size=n) > 0).astype(int)
+    Xg = rng.normal(size=(g, 6)) * 50.0
+    yg = (rng.normal(size=g) > 0).astype(int)   # noise labels on extreme X
+    X = np.vstack([Xc, Xg]); y = np.concatenate([yc, yg])
+    w = np.concatenate([np.ones(n), np.zeros(g)])
+    perm = rng.permutation(len(y))
+    X, y, w = X[perm], y[perm], w[perm]
+    m = ChimeraBoostClassifier(
+        n_estimators=300, early_stopping=True, validation_fraction=0.2,
+        early_stopping_rounds=20, random_state=0).fit(X, y, sample_weight=w)
+    # Logloss on the clean signal is well under a random-guess ~0.69, which a
+    # garbage-corrupted validation metric would never allow.
+    assert min(m.model_.valid_history_) < 0.5
+
+
+def test_h3_uniform_weight_bit_identical_with_cats_and_es():
+    """Uniform weights collapse to the unweighted path everywhere, including the
+    new weighted encoder/binner/val-metric code, so predictions stay bitwise
+    identical to sample_weight=None even with categoricals + early stopping."""
+    rng = np.random.default_rng(0)
+    n = 2500
+    cats = rng.integers(0, 6, size=n).astype(float)
+    Xnum = rng.normal(size=(n, 4))
+    X = np.column_stack([cats, Xnum])
+    y = cats * 0.5 + Xnum[:, 0] - Xnum[:, 1] + 0.1 * rng.normal(size=n)
+    Xte = np.column_stack([rng.integers(0, 6, 500).astype(float),
+                           rng.normal(size=(500, 4))])
+    kw = dict(n_estimators=120, early_stopping=True, early_stopping_rounds=20,
+              random_state=0)
+    m_none = ChimeraBoostRegressor(**kw).fit(X, y, cat_features=[0])
+    m_ones = ChimeraBoostRegressor(**kw).fit(
+        X, y, cat_features=[0], sample_weight=np.ones(n))
+    np.testing.assert_array_equal(m_none.predict(Xte), m_ones.predict(Xte))


### PR DESCRIPTION
## What

`sample_weight` was only ever applied to the gradient/leaf step. Rows with `sample_weight=0` still shaped three things they shouldn't (audit item **H3**):

1. **Ordered-target categorical encodings** — the prior and per-category statistics counted zeroed-out rows.
2. **Quantile bin borders** — extreme values carried only by weight-0 rows could place bin edges.
3. **The early-stopping validation metric** — computed *unweighted* on the auto-split holdout, so zeroed-out rows scored the model at full weight.

### The damage (repro)

Zero-weight "garbage" rows (wild targets, extreme features) scattered into the auto-split validation fold:

| seed | best val RMSE (weight 0 present) | best val RMSE (rows removed) | test RMSE zero / removed |
|---|---|---|---|
| 0 | **2082** → `0.13` | 0.13 | 0.15 / 0.13 |
| 2 | **2160** → `0.13` | 0.13 | **1.35** → `0.14` / 0.15 |

On seed 2 the corrupted metric stopped training at iteration 6 instead of ~52, degrading the model by ~10×. After the fix the validation metric reads the signal scale and the model tracks the rows-removed baseline.

## How

- **Encoder**: weighted prior + a weighted ordered-TS numba kernel (per-category sums/counts weighted). Unweighted kernel kept as the fast path.
- **Binner**: weighted quantile borders; zero-weight rows dropped before border computation.
- **ES metric**: validation weights threaded via an optional 3rd `eval_set` element (auto-split + bagged OOB folds) into `loss.eval`.
- **Uniform collapse**: `_normalize_weights` collapses any constant weight vector to `None`, so `sample_weight=None` and uniform weights stay **bitwise-identical** to before.

## Validation

- **Numerical-identity goldens green** — the decision suites (Grinsztajn / HC / synth) use no weights, so they run the `None` path and are bit-identical by construction. No `/experiment` sign test needed; the goldens are the stronger exact-identity gate for this class of change.
- **Full suite: 490 passed** (5 new H3 regression tests: weighted encoder totals, border drop, regressor + classifier ES metric, uniform-weight bit-identity with cats + early stopping).

## Scope note

The classifier's temperature-scaling calibration still runs unweighted on the val set — a separate calibration knob, outside the audit's stated encoder/binner/val-metric scope. Flagged as a follow-up, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
