### PR TITLE
A1 + 0.19.0 release prep: verbose notice for the silent early-stopping holdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 All notable changes to ChimeraBoost are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [0.19.0] - 2026-07-20
+### Added
+- With `verbose=True`, fit now prints a notice when `early_stopping=True`
+  silently holds out `validation_fraction` of the training rows as the
+  validation set (the default path when no `eval_set` is passed), so the
+  effective training size is visible. Default `verbose=False` is unchanged.
 ### Changed
 - **Classifier `leaf_estimation_iterations` default is now `None` (auto)
   instead of a concrete `3`; it resolves to 3 and fits bit-identically.** The

--- a/chimeraboost/__init__.py
+++ b/chimeraboost/__init__.py
@@ -29,4 +29,4 @@ __all__ = [
     "ChimeraBoostClassifier",
     "warmup",
 ]
-__version__ = "0.18.1"
+__version__ = "0.19.0"

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -1176,6 +1176,11 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                 es_active = False  # data too small to hold out a val set
             else:
                 train_idx, val_idx = split
+                if self.verbose and not getattr(self, "_is_bag_member", False):
+                    print(f"early_stopping=True: holding out {len(val_idx)} "
+                          f"of {len(X)} rows as a validation set (pass "
+                          "eval_set to choose it, or early_stopping=False "
+                          "to train on all rows)")
                 # Carry the val rows' weights so zero-weight rows split off into
                 # the auto holdout don't score the early-stopping metric (H3).
                 sw_val = (sample_weight[val_idx]
@@ -1730,6 +1735,11 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                 es_active = False  # data too small to hold out a val set
             else:
                 train_idx, val_idx = split
+                if self.verbose and not getattr(self, "_is_bag_member", False):
+                    print(f"early_stopping=True: holding out {len(val_idx)} "
+                          f"of {len(X)} rows as a validation set (pass "
+                          "eval_set to choose it, or early_stopping=False "
+                          "to train on all rows)")
                 # Carry val-row weights so zero-weight holdout rows don't score
                 # the early-stopping metric (H3).
                 sw_val = (sample_weight[val_idx]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chimeraboost"
-version = "0.18.1"
+version = "0.19.0"
 description = "CatBoost-inspired gradient boosting in pure Python with a numba backend"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_audit_fixes.py
+++ b/tests/test_audit_fixes.py
@@ -384,3 +384,39 @@ def test_h3_uniform_weight_bit_identical_with_cats_and_es():
     m_ones = ChimeraBoostRegressor(**kw).fit(
         X, y, cat_features=[0], sample_weight=np.ones(n))
     np.testing.assert_array_equal(m_none.predict(Xte), m_ones.predict(Xte))
+
+
+def _small_reg_data(n=300, seed=0):
+    rng = np.random.default_rng(seed)
+    X = rng.normal(size=(n, 4))
+    y = X[:, 0] - X[:, 1] + 0.1 * rng.normal(size=n)
+    return X, y
+
+
+def test_a1_auto_split_notice_verbose_regressor(capsys):
+    """verbose=True announces the silent 20% early-stopping holdout (A1)."""
+    X, y = _small_reg_data()
+    ChimeraBoostRegressor(n_estimators=5, verbose=True,
+                          random_state=0).fit(X, y)
+    out = capsys.readouterr().out
+    assert "holding out 60 of 300 rows" in out
+    assert "early_stopping=False" in out
+
+
+def test_a1_auto_split_notice_verbose_classifier(capsys):
+    X, y = _small_reg_data()
+    y = (y > 0).astype(int)
+    ChimeraBoostClassifier(n_estimators=5, verbose=True,
+                           random_state=0).fit(X, y)
+    out = capsys.readouterr().out
+    assert "holding out 60 of 300 rows" in out
+
+
+def test_a1_auto_split_notice_silent_by_default(capsys):
+    """Default verbose=False stays quiet; so does an explicit eval_set."""
+    X, y = _small_reg_data()
+    ChimeraBoostRegressor(n_estimators=5, random_state=0).fit(X, y)
+    assert "holding out" not in capsys.readouterr().out
+    ChimeraBoostRegressor(n_estimators=5, verbose=True, random_state=0).fit(
+        X[:240], y[:240], eval_set=(X[240:], y[240:]))
+    assert "holding out" not in capsys.readouterr().out


### PR DESCRIPTION
The last decided Phase 2 audit item (A1), bundled with the 0.19.0 release prep so one merge readies main for `twine upload` + tag.

- With `verbose=True`, fit prints how many rows `early_stopping=True` held out as the automatic validation set (both estimators; bagged members stay quiet, explicit `eval_set` stays quiet). Default `verbose=False` is unchanged.
- Version 0.18.1 → 0.19.0 in both `pyproject.toml` and `__init__.py`; CHANGELOG `[Unreleased]` → `[0.19.0] - 2026-07-20` (H1/H2 lei auto default + H3 weight-aware fixes + this notice).
- Full suite green locally: 501 passed (3 new A1 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3G7QxkKLXfh3DinQiMqqk