### PR TITLE
Drop pandas dependency; share categorical transform across bagged members at predict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to ChimeraBoost are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- **pandas is no longer a dependency.** The categorical machinery
+  (factorize, predict-time code mapping, gdiff group means) is now
+  numpy/numba only, bit-identical to the pandas implementation (the gdiff
+  group sums replicate pandas' Kahan-compensated groupby exactly).
+  DataFrames still work as input — they are consumed through their own
+  `to_numpy`/`columns` attributes, so users who pass frames already have
+  pandas (or polars) installed. Installs pull four packages instead of five.
+- **Bagged predict no longer redoes the categorical transform per member.**
+  Members factorize each categorical (and combo) column once per call
+  through a shared cache and remap only the unique values through their own
+  fit-time maps; the input conversion and validation also run once instead
+  of once per member. Predictions are bit-identical. 50k rows,
+  `n_ensembles=8`, 4 string categoricals: binary predict 1.21 s → 0.40 s,
+  multiclass 1.78 s → 0.74 s; single-model predict is unchanged at big
+  batches and ~9× faster at 1-row calls (0.19 ms vs 1.7 ms — the per-call
+  pandas overhead dominated small batches).
 ### Fixed
 - **Bagged members no longer keep their fit-time thread cap at predict.** A
   parallel `n_ensembles` fit divides the thread budget across workers

--- a/chimeraboost/booster.py
+++ b/chimeraboost/booster.py
@@ -248,10 +248,12 @@ class _BaseBooster:
             self.n_threads_ = n
             return self._fit_impl(X, y, *args, **kwargs)
 
-    def predict_raw(self, X):
-        """Predict under this model's thread limit (restored on exit)."""
+    def predict_raw(self, X, cat_ctx=None):
+        """Predict under this model's thread limit (restored on exit).
+        ``cat_ctx`` (internal) shares categorical factorizations across the
+        members of a bagged ensemble -- see CatTransformCache."""
         with _thread_limit(self.thread_count):
-            return self._predict_raw_impl(X)
+            return self._predict_raw_impl(X, cat_ctx)
 
     def __getstate__(self):
         """Pickle without the lazily-built packed-forest caches: they are
@@ -616,14 +618,14 @@ class GradientBoosting(_BaseBooster):
             w = w_sorted[lo:hi] if w_sorted is not None else None
             tree.values[l] = self.lr_ * self.loss_.leaf_value(r_sorted[lo:hi], w)
 
-    def _predict_raw_impl(self, X):
+    def _predict_raw_impl(self, X, cat_ctx=None):
         """Return raw additive scores (pre-link): the regression prediction, or
         the log-odds for binary classification."""
         X = as_model_array(X, bool(self.prep_.cat_features_))
         # The fused predict kernels consume the binner's row-major output
         # directly (no feature-major transpose; each sample's bins stay in
         # one or two cache lines for the whole forest walk).
-        Xb = self.prep_.transform(X)
+        Xb = self.prep_.transform(X, cat_ctx)
         if not self.trees_:
             return np.full(Xb.shape[0], self.init_, dtype=np.float64)
         if getattr(self, "_centers_std_", None) is not None:
@@ -812,13 +814,13 @@ class MulticlassBoosting(_BaseBooster):
         self.best_iteration_ = len(self.trees_)
         return self
 
-    def _predict_raw_impl(self, X):
+    def _predict_raw_impl(self, X, cat_ctx=None):
         """Return the (n_samples, n_classes) matrix of raw per-class scores
         (pre-softmax)."""
         X = as_model_array(X, bool(self.prep_.cat_features_))
         # Row-major binned matrix straight from the binner (see the scalar
         # predict_raw); the K per-class walks reuse the same hot rows.
-        Xb = self.prep_.transform(X)
+        Xb = self.prep_.transform(X, cat_ctx)
         F = np.tile(self.init_, (Xb.shape[0], 1))
         if not self.trees_:
             return F

--- a/chimeraboost/preprocessing.py
+++ b/chimeraboost/preprocessing.py
@@ -16,6 +16,7 @@ column index, so importances can be aggregated in the user's feature space.
 """
 
 import numpy as np
+from numba import njit
 
 from .binning import Binner
 from .target_encoding import OrderedTargetEncoder, factorize
@@ -43,6 +44,70 @@ def as_model_array(X, want_object):
         except TypeError:
             pass  # older pandas / polars: no na_value kwarg -> plain cast below
     return np.asarray(X, dtype=dtype)
+
+
+@njit(cache=True)
+def _grouped_kahan_sum(codes, vals, n_groups):
+    """Per-group Kahan-compensated sums (row order, sequential).
+
+    Kahan matters for reproducibility, not just accuracy: the gdiff group
+    means were historically computed by pandas' groupby, whose kernel is
+    Kahan-compensated, and existing fitted models / identity goldens embed
+    those exact floats. A naive accumulation drifts in the last ulp on large
+    groups, so a bit-identical replacement has to compensate the same way.
+    """
+    out = np.zeros(n_groups)
+    comp = np.zeros(n_groups)
+    for i in range(codes.shape[0]):
+        c = codes[i]
+        y = vals[i] - comp[c]
+        t = out[c] + y
+        comp[c] = (t - out[c]) - y
+        out[c] = t
+    return out
+
+
+class CatTransformCache:
+    """Canonical factorizations of one input matrix's categorical columns
+    (and combo string columns), computed once per fit/predict call.
+
+    Bagged members each learned their own category->code map on their own
+    bootstrap, so fit-time codes can't be shared across the bag -- but
+    hashing every row of the batch is member-independent. The bagged parent
+    passes one cache into every member's transform; the first member pays the
+    per-row factorize and each further member maps only the ~n_unique
+    canonical categories through its own dict and gathers. Callers must pass
+    one cache only across transforms of the *same* matrix ``X`` (entries are
+    keyed by column index alone).
+    """
+
+    def __init__(self):
+        self._columns = {}
+        self._combos = {}
+
+    def column(self, X, f):
+        """(codes, categories) of raw column ``f``, first-appearance order."""
+        out = self._columns.get(f)
+        if out is None:
+            out = self._columns[f] = factorize(X[:, f])
+        return out
+
+    def combo(self, X, f_a, f_b):
+        """(codes, categories) of the synthetic combo column for a pair."""
+        out = self._combos.get((f_a, f_b))
+        if out is None:
+            out = self._combos[(f_a, f_b)] = factorize(
+                FeaturePreprocessor._combo_values(X, f_a, f_b))
+        return out
+
+
+def _remap_codes(categories, mapping, default):
+    """Vectorize a fit-time {category value -> code/float} dict over canonical
+    categories: the returned array, gathered by canonical codes, equals the
+    row-wise dict lookup with ``default`` for unseen categories."""
+    dtype = np.int64 if isinstance(default, int) else np.float64
+    return np.fromiter((mapping.get(u, default) for u in categories.tolist()),
+                       dtype=dtype, count=len(categories))
 
 
 class FeaturePreprocessor:
@@ -104,7 +169,7 @@ class FeaturePreprocessor:
         col_b = np.asarray(X[:, f_b], dtype=str)
         return np.char.add(np.char.add(col_a, "_x_"), col_b)
 
-    def _split_columns_fit(self, X, cat_features):
+    def _split_columns_fit(self, X, cat_features, cat_ctx=None):
         """Split input into a numeric matrix and an integer-code matrix for the
         categorical columns, learning the category->code maps on the way.
         When cat_combinations is True, appends combo codes after the base codes."""
@@ -112,6 +177,8 @@ class FeaturePreprocessor:
         cat_set = set(cat_features or [])
         self.cat_features_ = sorted(cat_set)
         self.num_features_ = [f for f in range(n_features) if f not in cat_set]
+        if cat_ctx is None:
+            cat_ctx = CatTransformCache()
 
         num = self._numeric_block(X)
 
@@ -119,7 +186,7 @@ class FeaturePreprocessor:
             codes = np.empty((X.shape[0], len(self.cat_features_)), dtype=np.int64)
             self.cat_maps_ = []
             for j, f in enumerate(self.cat_features_):
-                c, cats = factorize(X[:, f])
+                c, cats = cat_ctx.column(X, f)
                 codes[:, j] = c
                 self.cat_maps_.append({v: i for i, v in enumerate(cats)})
         else:
@@ -137,7 +204,7 @@ class FeaturePreprocessor:
             for a in range(n_cat):
                 for b in range(a + 1, n_cat):
                     f_a, f_b = self.cat_features_[a], self.cat_features_[b]
-                    c, cats = factorize(self._combo_values(X, f_a, f_b))
+                    c, cats = cat_ctx.combo(X, f_a, f_b)
                     self.combo_pairs_.append((f_a, f_b))
                     self.combo_maps_.append({v: i for i, v in enumerate(cats)})
                     combo_cols.append(c)
@@ -146,7 +213,7 @@ class FeaturePreprocessor:
                     [codes, np.column_stack(combo_cols).astype(np.int64)])
         return num, codes
 
-    def _fit_gdiff(self, X, sample_weight=None):
+    def _fit_gdiff(self, X, sample_weight=None, cat_ctx=None):
         """Learn the per-category means backing the gdiff cross columns:
         for each (i, j, "gdiff") pair a {category value -> mean of X[:, i]}
         map plus the global-mean fallback for categories unseen at fit.
@@ -158,70 +225,78 @@ class FeaturePreprocessor:
         pairs = [(i, j) for i, j, op in self.cross_pairs if op == "gdiff"]
         if not pairs:
             return
-        import pandas as pd
+        if cat_ctx is None:
+            cat_ctx = CatTransformCache()
         for i, j in pairs:
             a = np.asarray(X[:, i], dtype=np.float64)
-            keys = pd.Series(np.asarray(X[:, j], dtype=object))
-            keys = keys.where(~pd.isna(keys), "__nan__")
             ok = np.isfinite(a)
-            w = (np.ones(ok.sum()) if sample_weight is None
+            if ok.all():
+                codes, cats = cat_ctx.column(X, j)
+                v = a
+            else:
+                # Factorize the finite rows only: category (= summation)
+                # order is first appearance among the contributing rows.
+                codes, cats = factorize(np.asarray(X[:, j], dtype=object)[ok])
+                v = a[ok]
+            w = (np.ones(v.shape[0]) if sample_weight is None
                  else np.asarray(sample_weight, dtype=np.float64)[ok])
-            df = pd.DataFrame({"v": a[ok] * w, "w": w, "k": keys[ok].values})
-            agg = df.groupby("k", sort=False).sum()
-            tot_w = float(agg["w"].sum())
-            global_mean = (float(agg["v"].sum() / tot_w) if tot_w > 0 else 0.0)
+            vsum = _grouped_kahan_sum(codes, v * w, len(cats))
+            wsum = _grouped_kahan_sum(codes, w, len(cats))
+            tot_w = float(np.sum(wsum))
+            global_mean = (float(np.sum(vsum) / tot_w) if tot_w > 0 else 0.0)
             with np.errstate(invalid="ignore", divide="ignore"):
-                means = agg["v"] / agg["w"]
-            means = means.where(np.isfinite(means), global_mean)
-            self.gdiff_maps_.append((means.to_dict(), global_mean))
+                means = vsum / wsum
+            means = np.where(np.isfinite(means), means, global_mean)
+            self.gdiff_maps_.append(
+                (dict(zip(cats.tolist(), means.tolist())), global_mean))
 
-    def _cross_block(self, X):
+    def _cross_block(self, X, cat_ctx=None):
         """Compute the cross-feature columns (float64) from raw input. NaN in
         a numeric parent propagates to the cross (binned to the missing bucket
         like any numeric NaN); gdiff maps a NaN category to its own "__nan__"
         group and an unseen category to the global mean."""
         if not self.cross_pairs:
             return np.empty((X.shape[0], 0))
+        if cat_ctx is None:
+            cat_ctx = CatTransformCache()
         cols = []
         g = 0
         for i, j, op in self.cross_pairs:
             a = np.asarray(X[:, i], dtype=np.float64)
             if op == "gdiff":
-                import pandas as pd
                 means, global_mean = self.gdiff_maps_[g]
                 g += 1
-                keys = pd.Series(np.asarray(X[:, j], dtype=object))
-                keys = keys.where(~pd.isna(keys), "__nan__")
-                centered = (keys.map(means).astype(np.float64)
-                            .fillna(global_mean).to_numpy())
-                cols.append(a - centered)
+                codes, cats = cat_ctx.column(X, j)
+                cols.append(a - _remap_codes(cats, means, global_mean)[codes])
                 continue
             b = np.asarray(X[:, j], dtype=np.float64)
             cols.append(a - b if op == "diff" else a * b)
         return np.column_stack(cols)
 
-    def _codes_for_transform(self, X):
+    def _codes_for_transform(self, X, cat_ctx=None):
         """Map categorical columns to the codes learned at fit time; unseen
-        categories get -1 (the encoder then falls back to the prior).
-        Vectorized via pandas."""
+        categories get -1 (the encoder then falls back to the prior). Each
+        column is factorized once and only its unique values pass through the
+        fit-time dict; with a shared ``cat_ctx`` the factorization is also
+        reused across bagged members."""
         if not self.cat_features_:
             return np.empty((X.shape[0], 0), dtype=np.int64)
-        import pandas as pd
+        if cat_ctx is None:
+            cat_ctx = CatTransformCache()
         codes = np.empty((X.shape[0], len(self.cat_features_)), dtype=np.int64)
         for j, f in enumerate(self.cat_features_):
-            s = pd.Series(X[:, f], dtype=object)
-            s = s.where(~pd.isna(s), "__nan__")
-            mapped = s.map(self.cat_maps_[j])          # unseen -> NaN
-            codes[:, j] = mapped.fillna(-1).astype(np.int64).to_numpy()
+            c, cats = cat_ctx.column(X, f)
+            codes[:, j] = _remap_codes(cats, self.cat_maps_[j], -1)[c]
         return codes
 
-    def _combo_codes_for_transform(self, X):
+    def _combo_codes_for_transform(self, X, cat_ctx=None):
         """Reconstruct combination codes for transform using stored combo maps."""
-        combo_codes = np.full((X.shape[0], len(self.combo_pairs_)), -1, dtype=np.int64)
+        if cat_ctx is None:
+            cat_ctx = CatTransformCache()
+        combo_codes = np.empty((X.shape[0], len(self.combo_pairs_)), dtype=np.int64)
         for k, (f_a, f_b) in enumerate(self.combo_pairs_):
-            m = self.combo_maps_[k]
-            vals = self._combo_values(X, f_a, f_b)
-            combo_codes[:, k] = [m.get(v, -1) for v in vals.tolist()]
+            c, cats = cat_ctx.combo(X, f_a, f_b)
+            combo_codes[:, k] = _remap_codes(cats, self.combo_maps_[k], -1)[c]
         return combo_codes
 
     # ---- fit / transform -----------------------------------------------------
@@ -232,9 +307,10 @@ class FeaturePreprocessor:
         the ordered-target encoder and the binner so zero-weight rows shape
         neither the categorical statistics nor the bin borders. ``None`` is the
         unweighted path, bit-identical to before this argument existed."""
-        num, codes = self._split_columns_fit(X, cat_features)
-        self._fit_gdiff(X, sample_weight)
-        cross = self._cross_block(X)
+        cat_ctx = CatTransformCache()
+        num, codes = self._split_columns_fit(X, cat_features, cat_ctx)
+        self._fit_gdiff(X, sample_weight, cat_ctx)
+        cross = self._cross_block(X, cat_ctx)
         if cross.shape[1]:
             num = np.hstack([num, cross]) if num.shape[1] else cross
 
@@ -264,17 +340,21 @@ class FeaturePreprocessor:
         self.n_bins_ = self.binner_.n_bins_
         return X_binned
 
-    def transform(self, X):
-        """Apply the fitted binning + categorical encoding to new data."""
+    def transform(self, X, cat_ctx=None):
+        """Apply the fitted binning + categorical encoding to new data.
+        ``cat_ctx`` (internal) shares the per-column canonical factorizations
+        across the members of a bagged ensemble -- see CatTransformCache."""
+        if cat_ctx is None:
+            cat_ctx = CatTransformCache()
         num = self._numeric_block(X)
-        cross = self._cross_block(X)
+        cross = self._cross_block(X, cat_ctx)
         if cross.shape[1]:
             num = np.hstack([num, cross]) if num.shape[1] else cross
         encoded_blocks = []
         if self.cat_features_:
-            codes = self._codes_for_transform(X)
+            codes = self._codes_for_transform(X, cat_ctx)
             if self.combo_pairs_:
-                combo_codes = self._combo_codes_for_transform(X)
+                combo_codes = self._combo_codes_for_transform(X, cat_ctx)
                 codes = np.hstack([codes, combo_codes])
             for enc in self.encoders_:
                 encoded_blocks.append(enc.transform(codes))
@@ -311,8 +391,9 @@ class FeaturePreprocessor:
         prep.combo_maps_ = base.combo_maps_
         prep.encoders_ = base.encoders_
 
-        prep._fit_gdiff(X, sample_weight)
-        cross = prep._cross_block(X)
+        cat_ctx = CatTransformCache()
+        prep._fit_gdiff(X, sample_weight, cat_ctx)
+        cross = prep._cross_block(X, cat_ctx)
         cross_binner = Binner(base.max_bins).fit(cross, sample_weight)
         nb = len(base.num_features_)
         bb = base.binner_

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -5,7 +5,7 @@ import warnings
 import numpy as np
 from .booster import (GradientBoosting, LINEAR_LEAVES_MIN_SAMPLES,
                       MulticlassBoosting)
-from .preprocessing import as_model_array
+from .preprocessing import CatTransformCache, as_model_array
 from sklearn.base import BaseEstimator, RegressorMixin, ClassifierMixin
 
 
@@ -716,6 +716,17 @@ def _was_fit_with_cats(estimator):
     return bool(getattr(_fitted_prep(estimator), "cat_features_", None))
 
 
+def _bag_predict_context(estimator, X):
+    """Per-call predict state shared across the members of a bagged ensemble:
+    the raw-matrix conversion and a categorical-factorization cache, computed
+    once instead of once per member. The caller has already validated ``X``
+    (``_check_predict_input``), so members skip re-validation entirely -- each
+    member's prediction is unchanged, only the redundant per-member conversion,
+    hashing, and input checks are gone."""
+    Xc = as_model_array(X, _was_fit_with_cats(estimator))
+    return Xc, CatTransformCache()
+
+
 def _check_predict_input(estimator, X):
     """Raise NotFittedError if unfitted, then validate X is 2D with the same
     number of features as training -- preventing silently-wrong predictions on
@@ -1412,8 +1423,11 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
     def predict(self, X):
         _check_predict_input(self, X)
         if self.estimators_ is not None:
-            # Members apply their own conformal offsets inside m.predict.
-            return np.mean([m.predict(X) for m in self.estimators_], axis=0)
+            # One shared conversion + factorization cache for the whole bag;
+            # each member applies its own conformal offset.
+            Xc, ctx = _bag_predict_context(self, X)
+            return np.mean([m.model_.predict_raw(Xc, ctx) + m.quantile_offset_
+                            for m in self.estimators_], axis=0)
         return self.model_.predict_raw(X) + self.quantile_offset_
 
     def staged_predict(self, X):
@@ -1967,13 +1981,20 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
             # Soft-vote: average members' calibrated probabilities, aligning each
             # member's class columns to the global class set (a member whose
             # bootstrap missed a class simply contributes 0 to that column).
-            probas = [m.predict_proba(X) for m in self.estimators_]
+            # One shared conversion + factorization cache for the whole bag.
+            Xc, ctx = _bag_predict_context(self, X)
+            probas = [m._proba_impl(Xc, ctx) for m in self.estimators_]
             acc = np.zeros((probas[0].shape[0], self.n_classes_))
             for m, p in zip(self.estimators_, probas):
                 cols = np.searchsorted(self.classes_, m.classes_)
                 acc[:, cols] += p
             return acc / len(self.estimators_)
-        raw = self.model_.predict_raw(X) / self.temperature_
+        return self._proba_impl(X)
+
+    def _proba_impl(self, X, cat_ctx=None):
+        """Calibrated probabilities of this single (non-bagged) model, without
+        input validation -- the public entry points handle that."""
+        raw = self.model_.predict_raw(X, cat_ctx) / self.temperature_
         if self._multiclass:
             return self.model_.loss_.transform(raw)            # (n, K)
         p1 = self.model_.loss_.transform(raw)

--- a/chimeraboost/target_encoding.py
+++ b/chimeraboost/target_encoding.py
@@ -147,13 +147,26 @@ def factorize(column):
     (codes, categories).
 
     Codes are internal labels; the ordered target encoder is invariant to their
-    particular values.
+    particular values. Missing values are anything None, NaN-like (compares
+    unequal to itself), or refusing self-comparison (pandas' NA scalar raises on
+    ``bool``) -- the same set ``pd.isna`` recognizes, without needing pandas.
     """
-    import pandas as pd
     col = np.asarray(column, dtype=object)
-    na = pd.isna(col)
-    if na.any():
-        col = col.copy()
-        col[na] = "__nan__"
-    codes, categories = pd.factorize(col, sort=False)   # first-appearance order
-    return codes.astype(np.int64), np.asarray(categories, dtype=object)
+    codes = np.empty(col.shape[0], dtype=np.int64)
+    mapping = {}
+    cats = []
+    for i, v in enumerate(col.tolist()):
+        if v is None:
+            v = "__nan__"
+        else:
+            try:
+                if v != v:
+                    v = "__nan__"
+            except (TypeError, ValueError):
+                v = "__nan__"
+        code = mapping.get(v)
+        if code is None:
+            code = mapping[v] = len(cats)
+            cats.append(v)
+        codes[i] = code
+    return codes, np.asarray(cats, dtype=object)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -65,10 +65,10 @@ validation, dtype conversion, binning), not the forest walk:
 - If your serving data is already validated, skip the finiteness scan with
   sklearn's `assume_finite` (see [FAQ](faq.md#how-can-i-make-inference-faster))
   — worth ~10% at this scale.
-- Models fit with `cat_features` decode categorical columns through pandas
-  on every call: ≈ 1.7 ms per call regardless of batch size. Sub-2 ms is
-  fine for most serving, but it is the one predict path with no
-  microsecond option.
+- Models fit with `cat_features` re-map categorical strings to codes on
+  every call: ≈ 0.2 ms for a one-row ndarray call — about 2× the numeric
+  classifier path, no longer the ~1.7 ms pandas-powered outlier it was
+  before 0.21.0.
 
 ## Big batches
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -61,7 +61,9 @@ model = joblib.load("model.joblib")
 
 ## What exactly does it depend on?
 
-NumPy, numba, scikit-learn, SciPy, and pandas.
+NumPy, numba, scikit-learn, and SciPy. pandas is not required — DataFrames
+are consumed through their own conversion methods, so passing them works
+whenever you have pandas (or polars) installed yourself.
 
 ## How do I tune it?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,14 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
+# pandas is intentionally NOT a dependency: the library consumes DataFrames
+# through their own to_numpy/columns attributes, so pandas (or polars) is only
+# needed by users who pass frames -- and they already have it.
 dependencies = [
     "numpy>=1.22",
     "numba>=0.57",
     "scikit-learn>=1.0",
     "scipy>=1.7",
-    "pandas>=1.3",
 ]
 
 [project.urls]
@@ -29,7 +31,7 @@ Homepage = "https://github.com/bbstats/chimeraboost"
 Repository = "https://github.com/bbstats/chimeraboost"
 
 [project.optional-dependencies]
-dev = ["pytest"]
+dev = ["pytest", "pandas>=1.3"]
 docs = ["mkdocs-material>=9.5", "mkdocstrings[python]>=0.24", "black>=24.0"]
 
 [tool.setuptools.packages.find]

--- a/tests/test_pandas_free.py
+++ b/tests/test_pandas_free.py
@@ -1,0 +1,110 @@
+"""The library must run without pandas, and the shared-factorization bagged
+predict must be bit-identical to per-member prediction.
+
+pandas was dropped as a dependency (sklearn does not pull it in): frames are
+consumed through their own to_numpy/columns attributes, and the categorical
+machinery (factorize, code mapping, gdiff group means) is numpy/numba only.
+"""
+
+import sys
+
+import numpy as np
+import pytest
+
+from chimeraboost import ChimeraBoostClassifier, ChimeraBoostRegressor
+from chimeraboost.preprocessing import CatTransformCache, FeaturePreprocessor
+from chimeraboost.target_encoding import factorize
+
+
+def _cat_data(n=600, seed=0):
+    rng = np.random.default_rng(seed)
+    X = np.empty((n, 3), dtype=object)
+    X[:, 0] = rng.choice(["a", "b", "c", "d"], n)
+    X[:, 1] = rng.normal(size=n)
+    X[:, 2] = rng.choice(["x", "y", "z"], n)
+    X[rng.random(n) < 0.05, 0] = np.nan
+    y = ((X[:, 0] == "a").astype(int) ^ (X[:, 2] == "x").astype(int))
+    return X, y
+
+
+def test_factorize_first_appearance_and_missing():
+    codes, cats = factorize(np.array(["b", None, "a", np.nan, "b", "a"],
+                                     dtype=object))
+    assert cats.tolist() == ["b", "__nan__", "a"]
+    assert codes.tolist() == [0, 1, 2, 1, 0, 2]
+
+
+class _BlockPandas:
+    """Meta-path finder that makes `import pandas` fail as if not installed."""
+
+    def find_spec(self, name, path=None, target=None):
+        if name == "pandas" or name.startswith("pandas."):
+            raise ImportError("pandas is blocked for this test")
+        return None
+
+
+def test_library_runs_without_pandas(monkeypatch):
+    """Categorical fit + predict (incl. bagging, combos, and gdiff crosses)
+    in a simulated pandas-less environment: the module is absent from
+    sys.modules and any fresh import raises ImportError."""
+    for mod in [m for m in sys.modules
+                if m == "pandas" or m.startswith("pandas.")]:
+        monkeypatch.delitem(sys.modules, mod)
+    monkeypatch.setattr(sys, "meta_path", [_BlockPandas()] + sys.meta_path)
+    X, y = _cat_data()
+
+    clf = ChimeraBoostClassifier(n_estimators=40, random_state=0,
+                                 cat_combinations=True)
+    clf.fit(X, y, cat_features=[0, 2])
+    assert clf.predict_proba(X).shape == (len(y), 2)
+
+    with pytest.warns(UserWarning, match="member defaults"):
+        bag = ChimeraBoostRegressor(n_estimators=30, random_state=0,
+                                    n_ensembles=3)
+        bag.fit(X, y.astype(float), cat_features=[0, 2])
+    assert bag.predict(X).shape == (len(y),)
+
+    prep = FeaturePreprocessor(max_bins=32, random_state=0,
+                               cross_pairs=[(1, 0, "gdiff")])
+    Xb = prep.fit_transform(X, [y.astype(np.float64)], [0, 2])
+    assert prep.transform(X).shape == Xb.shape
+
+
+def test_bagged_predict_matches_member_average_bitwise():
+    """The shared conversion + CatTransformCache path must reproduce the
+    per-member public predictions exactly, DataFrame input included."""
+    pd = pytest.importorskip("pandas")
+    X, y = _cat_data()
+    df = pd.DataFrame({"c1": X[:, 0], "n1": X[:, 1].astype(float),
+                       "c2": X[:, 2]})
+
+    reg = ChimeraBoostRegressor(n_estimators=40, random_state=0, n_ensembles=3)
+    with pytest.warns(UserWarning, match="member defaults"):
+        reg.fit(df, y.astype(float), cat_features=["c1", "c2"])
+    manual = np.mean([m.predict(df) for m in reg.estimators_], axis=0)
+    assert np.array_equal(reg.predict(df), manual)
+
+    clf = ChimeraBoostClassifier(n_estimators=40, random_state=0, n_ensembles=3)
+    with pytest.warns(UserWarning, match="member defaults"):
+        clf.fit(df, y, cat_features=["c1", "c2"])
+    acc = np.zeros((len(y), clf.n_classes_))
+    for m in clf.estimators_:
+        acc[:, np.searchsorted(clf.classes_, m.classes_)] += m.predict_proba(df)
+    assert np.array_equal(clf.predict_proba(df), acc / len(clf.estimators_))
+
+
+def test_cat_transform_cache_shares_factorizations():
+    """A shared cache factorizes each column once; repeated transforms through
+    it produce codes identical to uncached transforms."""
+    X, y = _cat_data()
+    prep = FeaturePreprocessor(max_bins=32, random_state=0)
+    prep.fit_transform(X, [y.astype(np.float64)], [0, 2])
+
+    ctx = CatTransformCache()
+    first = prep.transform(X, ctx)
+    assert set(ctx._columns) == {0, 2}
+    codes_obj = [id(v) for v in ctx._columns.values()]
+    again = prep.transform(X, ctx)
+    assert [id(v) for v in ctx._columns.values()] == codes_obj  # reused, not rebuilt
+    assert np.array_equal(first, again)
+    assert np.array_equal(first, prep.transform(X))


### PR DESCRIPTION
## What

Fix 2 of the bagged-predict slowdown (fix 1, the thread-cap restoration, shipped in 852481b): each bagged member independently redid the DataFrame conversion, input validation, and per-row string-to-code hashing at predict. Members' category maps differ per bootstrap so *codes* can't be shared -- but hashing the batch's rows is member-independent. A per-call `CatTransformCache` now factorizes each categorical (and combo) column once; each member remaps only the ~n_unique canonical values through its own fit-time dict and gathers.

Doing that rewrite made pandas unnecessary everywhere else too, so it is no longer a dependency (sklearn does not pull it in; installs drop from five packages to four). `factorize`, predict-time code mapping, and the gdiff group means are numpy/numba only. DataFrames still work as input -- they're consumed through their own `to_numpy`/`columns` attributes.

## Bit-identity

- gdiff group sums replicate pandas' Kahan-compensated groupby kernel exactly (probed on this box: bincount's naive summation does NOT match; the Kahan kernel matches bitwise).
- A/B harness (old=main vs new=worktree, `PYTHONPATH`-pinned): 13 arrays -- prep fit/transform matrices, gdiff maps, predictions for regression/binary/multiclass x single/bag3 x weighted/unweighted x DataFrame/ndarray -- all bitwise identical.
- 513 existing tests green (numerical-identity goldens included) + 4 new: factorize semantics, pandas-import-blocked end-to-end fit/predict (bagging, combos, gdiff), bagged-vs-member-average bitwise equality, cache-reuse identity.

## Speed (50k rows, K=8, 4 string cats, this box)

| path | before | after |
|---|---|---|
| binary bagged predict | 1.21 s | 0.40 s |
| multiclass bagged predict | 1.78 s | 0.74 s |
| single big-batch predict | 0.109 s | 0.106 s |
| single 1-row cat predict | ~1.7 ms | 0.19 ms |

Numeric bagged predict unchanged (0.09 s). Parallelizing member predicts was considered and skipped: the remaining gap over the numeric bag is legitimate per-member work (TS encode, binning, forest walk), and members already use the full thread budget since 852481b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018V1LjsaDPtHhjvMCbAKkKw