### PR TITLE
Predict/fit semi-bug fixes: cross-block cast reuse, single predict conversion, MAE lei guard, depth-0 truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,44 @@
 All notable changes to ChimeraBoost are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+### Changed
+- **Cross-feature columns no longer re-cast their parent columns per pair.**
+  `_cross_block` reads numeric parents from the float64 numeric block the
+  transform already builds (one cast per input column instead of one per
+  cross pair). On object-dtype input (categoricals present) those per-pair
+  element-wise casts dominated cross-feature predict cost: 4k-row predict
+  on a cross-selected model with 2 categoricals 13.6 ms → 8.6 ms, 1-row
+  predict 0.35 ms → 0.27 ms; fit improves too (same code path). Bit-identical.
+- **Predict converts the input once, not twice.** The predict-time inf
+  check's model-array conversion is now reused for the prediction itself
+  instead of being discarded and redone; on DataFrame input this removes a
+  full second `to_numpy` materialization per predict call. Bit-identical.
+- **Bagged predict switches the numba thread count once per call, not once
+  per member** (only observable with an explicit `thread_count`; each
+  switch charges an ~1 ms OpenMP re-team on the next parallel region).
+- **Multiclass predict skips a dead full-matrix init**, and `shap_values`
+  on linear-leaf models reuses the packed forest predict already caches
+  instead of repacking on every call.
+- **`warmup()` now covers the weighted ordered-TS kernel and the gdiff
+  group-sum kernel** (a weighted categorical regression fit plus a direct
+  kernel call). Both sit on default paths — `sample_weight` fits, and
+  ≥2000-row categorical fits (auto cross features) — but were not compiled
+  by warmup, so short-lived workers still hit a JIT stall there.
+### Fixed
+- **`leaf_estimation_iterations > 1` no longer corrupts MAE/Quantile
+  models.** These losses set each leaf to the exact minimizer (median /
+  alpha-quantile); the extra Newton refinement steps then ran anyway,
+  adding sign-gradient steps on top and degrading the model — while the
+  sklearn layer warned the parameter "will have no effect". The warning is
+  now true: refinement is skipped when leaves are loss-corrected. Defaults
+  (`leaf_estimation_iterations=1`) are unaffected.
+- **A depth-0 early exit now keeps the best validation prefix.** When
+  boosting stopped because a round produced no legal split, the
+  "truncate to the best validation iteration" step was skipped, silently
+  keeping trees grown after the validation optimum. That exit now truncates
+  exactly like patience and budget exhaustion do (scalar and multiclass).
+
 ## [0.21.0] - 2026-07-22
 ### Changed
 - **pandas is no longer a dependency.** The categorical machinery

--- a/chimeraboost/booster.py
+++ b/chimeraboost/booster.py
@@ -536,8 +536,12 @@ class GradientBoosting(_BaseBooster):
                                               quantize=self.quantize_gradients,
                                               qbuf=qbuf, qseed=qseed)
             # A depth-0 tree found no legal split; the next round on the same
-            # gradients would too, so stop rather than bank empty trees.
+            # gradients would too, so stop rather than bank empty trees. Keep
+            # the best prefix exactly as the other exits do -- without this,
+            # trees grown after the validation optimum survived on this path.
             if tree.depth == 0:
+                if Fv is not None and stopper.patience:
+                    self.trees_ = self.trees_[: stopper.best_iter + 1]
                 break
             if adjusts_leaves:
                 self._correct_leaves(tree, leaf, y - F, w)
@@ -557,8 +561,13 @@ class GradientBoosting(_BaseBooster):
                 # Additional Newton steps refine the leaf values using the updated
                 # residuals after each step. For constant-hessian losses (RMSE)
                 # this converges in a few steps; for Logloss it reaches a better
-                # per-leaf approximation than the single first-order step.
-                self._refine_leaf_values(tree, leaf, F, y, w)
+                # per-leaf approximation than the single first-order step. Not
+                # for MAE/Quantile: _correct_leaves already set the exact
+                # minimizer (median/quantile), and a sign-gradient Newton step
+                # on top would corrupt it -- the sklearn layer's "no effect"
+                # warning for those losses is honest only with this guard.
+                if not adjusts_leaves:
+                    self._refine_leaf_values(tree, leaf, F, y, w)
                 F += tree.values[leaf]
             if self.verbose:
                 self.train_history_.append(self.loss_.eval(y, F, w))
@@ -680,10 +689,17 @@ class GradientBoosting(_BaseBooster):
             sel = np.random.default_rng(random_state).choice(
                 Rb.shape[1], max_background, replace=False)
             Rb = np.ascontiguousarray(Rb[:, sel])
-        feats, thrs, depths, lin_k, foff, lidx, coff, coef = \
-            pack_forest_linear(self.trees_, self.depth)
         cs = getattr(self, "_centers_std_", None)
-        if cs is None:
+        if cs is not None:
+            # Linear-leaf model: predict caches the same linear-packed forest
+            # in _forest_; build it once and share (constant-leaf models cache
+            # the non-linear pack there instead, so those repack here).
+            if self._forest_ is None:
+                self._forest_ = pack_forest_linear(self.trees_, self.depth)
+            feats, thrs, depths, lin_k, foff, lidx, coff, coef = self._forest_
+        else:
+            feats, thrs, depths, lin_k, foff, lidx, coff, coef = \
+                pack_forest_linear(self.trees_, self.depth)
             cs = np.zeros((1, 1))   # unused: every tree is constant (k=0)
         fact = _factorials(self.depth)
         phi = _shap_forest_linear(Xb, Rb, feats, thrs, depths, lin_k, foff, lidx,
@@ -772,8 +788,11 @@ class MulticlassBoosting(_BaseBooster):
                     F[:, k] += tree.values[leaf]
                 # depth-0 trees contribute nothing (predict would be zeros).
             # Stop only once EVERY class has exhausted its splits; a single class
-            # still learning makes the round productive.
+            # still learning makes the round productive. Keep the best prefix
+            # exactly as the other exits do (see the scalar loop).
             if all(t.depth == 0 for t in round_trees):
+                if Fv is not None and stopper.patience:
+                    self.trees_ = self.trees_[: stopper.best_iter + 1]
                 break
             self.trees_.append(round_trees)
             if self.verbose:
@@ -821,9 +840,10 @@ class MulticlassBoosting(_BaseBooster):
         # Row-major binned matrix straight from the binner (see the scalar
         # predict_raw); the K per-class walks reuse the same hot rows.
         Xb = self.prep_.transform(X, cat_ctx)
-        F = np.tile(self.init_, (Xb.shape[0], 1))
         if not self.trees_:
-            return F
+            return np.tile(self.init_, (Xb.shape[0], 1))
+        # Every column is fully overwritten below; no need to tile the init.
+        F = np.empty((Xb.shape[0], self.n_classes_), dtype=np.float64)
         if self._forests_ is None:
             # One packed forest per class: class k's trees are round_trees[k]
             # across every round.

--- a/chimeraboost/preprocessing.py
+++ b/chimeraboost/preprocessing.py
@@ -250,26 +250,35 @@ class FeaturePreprocessor:
             self.gdiff_maps_.append(
                 (dict(zip(cats.tolist(), means.tolist())), global_mean))
 
-    def _cross_block(self, X, cat_ctx=None):
+    def _cross_block(self, X, cat_ctx=None, num=None):
         """Compute the cross-feature columns (float64) from raw input. NaN in
         a numeric parent propagates to the cross (binned to the missing bucket
         like any numeric NaN); gdiff maps a NaN category to its own "__nan__"
-        group and an unseen category to the global mean."""
+        group and an unseen category to the global mean.
+
+        Numeric parents are read from ``num`` (the float64 numeric block;
+        pass the one already built for this matrix, else it is computed
+        here): one cast per input column instead of one per pair. On object
+        arrays (categoricals present) the per-pair element-wise casts were
+        the dominant predict-time cost of cross features."""
         if not self.cross_pairs:
             return np.empty((X.shape[0], 0))
         if cat_ctx is None:
             cat_ctx = CatTransformCache()
+        if num is None:
+            num = self._numeric_block(X)
+        pos = {f: k for k, f in enumerate(self.num_features_)}
         cols = []
         g = 0
         for i, j, op in self.cross_pairs:
-            a = np.asarray(X[:, i], dtype=np.float64)
+            a = num[:, pos[i]]
             if op == "gdiff":
                 means, global_mean = self.gdiff_maps_[g]
                 g += 1
                 codes, cats = cat_ctx.column(X, j)
                 cols.append(a - _remap_codes(cats, means, global_mean)[codes])
                 continue
-            b = np.asarray(X[:, j], dtype=np.float64)
+            b = num[:, pos[j]]
             cols.append(a - b if op == "diff" else a * b)
         return np.column_stack(cols)
 
@@ -310,7 +319,7 @@ class FeaturePreprocessor:
         cat_ctx = CatTransformCache()
         num, codes = self._split_columns_fit(X, cat_features, cat_ctx)
         self._fit_gdiff(X, sample_weight, cat_ctx)
-        cross = self._cross_block(X, cat_ctx)
+        cross = self._cross_block(X, cat_ctx, num=num)
         if cross.shape[1]:
             num = np.hstack([num, cross]) if num.shape[1] else cross
 
@@ -347,7 +356,7 @@ class FeaturePreprocessor:
         if cat_ctx is None:
             cat_ctx = CatTransformCache()
         num = self._numeric_block(X)
-        cross = self._cross_block(X, cat_ctx)
+        cross = self._cross_block(X, cat_ctx, num=num)
         if cross.shape[1]:
             num = np.hstack([num, cross]) if num.shape[1] else cross
         encoded_blocks = []

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -4,7 +4,7 @@ import warnings
 
 import numpy as np
 from .booster import (GradientBoosting, LINEAR_LEAVES_MIN_SAMPLES,
-                      MulticlassBoosting)
+                      MulticlassBoosting, _thread_limit)
 from .preprocessing import CatTransformCache, as_model_array
 from sklearn.base import BaseEstimator, RegressorMixin, ClassifierMixin
 
@@ -759,22 +759,36 @@ def _check_predict_input(estimator, X):
     # bin and returns the "missing" prediction with no error. This is the only
     # O(n) check on the hot predict path, so it is skippable via sklearn's
     # ``assume_finite`` config for latency-critical serving.
-    if not _assume_finite():
-        if not _was_fit_with_cats(estimator):
-            try:
-                Xf = as_model_array(X, want_object=False)
-            except (ValueError, TypeError):
-                Xf = None
-        else:
-            # Categorical fit: only the numeric columns need to be finite (the
-            # cat columns are strings). Pull their positions from the fitted
-            # preprocessor and check just those, mirroring the fit-time check.
-            num_idx = getattr(_fitted_prep(estimator), "num_features_", None)
-            Xf = _numeric_block(X, num_idx)
+    #
+    # The model-array conversion the check needs is the same one the booster
+    # would redo immediately after; return it so callers thread it through
+    # (one full DataFrame materialization per predict instead of two).
+    # Returns None when no full conversion happened (assume_finite, or a
+    # conversion failure whose descriptive error the booster raises).
+    if _assume_finite():
+        return None
+    if not _was_fit_with_cats(estimator):
+        try:
+            Xc = as_model_array(X, want_object=False)
+        except (ValueError, TypeError):
+            return None
+    else:
+        # Categorical fit: convert to the object array the booster consumes,
+        # then check finiteness of the numeric columns only (the cat columns
+        # are strings), mirroring the fit-time check.
+        Xc = as_model_array(X, want_object=True)
+        num_idx = getattr(_fitted_prep(estimator), "num_features_", None)
+        Xf = _numeric_block(Xc, num_idx)
         if Xf is not None and np.isinf(Xf).any():
             raise ValueError(
                 "X contains infinity. NaN is accepted (treated as missing), but "
                 "inf is not -- clip or clean it first.")
+        return Xc
+    if np.isinf(Xc).any():
+        raise ValueError(
+            "X contains infinity. NaN is accepted (treated as missing), but "
+            "inf is not -- clip or clean it first.")
+    return Xc
 
 
 def _auto_min_child_weight(n_train):
@@ -1421,20 +1435,25 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         return self
 
     def predict(self, X):
-        _check_predict_input(self, X)
+        Xv = _check_predict_input(self, X)
+        X = X if Xv is None else Xv
         if self.estimators_ is not None:
             # One shared conversion + factorization cache for the whole bag;
-            # each member applies its own conformal offset.
-            Xc, ctx = _bag_predict_context(self, X)
-            return np.mean([m.model_.predict_raw(Xc, ctx) + m.quantile_offset_
-                            for m in self.estimators_], axis=0)
+            # each member applies its own conformal offset. One thread-limit
+            # switch for the whole bag (members' re-entries are no-ops).
+            with _thread_limit(self.thread_count):
+                Xc, ctx = _bag_predict_context(self, X)
+                return np.mean(
+                    [m.model_.predict_raw(Xc, ctx) + m.quantile_offset_
+                     for m in self.estimators_], axis=0)
         return self.model_.predict_raw(X) + self.quantile_offset_
 
     def staged_predict(self, X):
         """Yield the prediction after each successive tree (the conformal
         quantile offset, a post-fit constant, is included in every stage so the
         final stage equals ``predict``)."""
-        _check_predict_input(self, X)
+        Xv = _check_predict_input(self, X)
+        X = X if Xv is None else Xv
         if self.estimators_ is not None:
             raise NotImplementedError("staged_predict is not defined for a "
                                       "bagged ensemble (n_ensembles > 1).")
@@ -1475,7 +1494,8 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         ``n_ensembles > 1`` (the bag prediction is the members' mean, so the
         averaged attribution stays exact). ``X_background`` overrides the
         reference distribution (default: a sample of the training data)."""
-        _check_predict_input(self, X)
+        Xv = _check_predict_input(self, X)
+        X = X if Xv is None else Xv
         if self.estimators_ is not None:
             out = [m.model_.shap_values(X, background=X_background)
                    for m in self.estimators_]
@@ -1976,14 +1996,17 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         return self
 
     def predict_proba(self, X):
-        _check_predict_input(self, X)
+        Xv = _check_predict_input(self, X)
+        X = X if Xv is None else Xv
         if self.estimators_ is not None:
             # Soft-vote: average members' calibrated probabilities, aligning each
             # member's class columns to the global class set (a member whose
             # bootstrap missed a class simply contributes 0 to that column).
-            # One shared conversion + factorization cache for the whole bag.
-            Xc, ctx = _bag_predict_context(self, X)
-            probas = [m._proba_impl(Xc, ctx) for m in self.estimators_]
+            # One shared conversion + factorization cache for the whole bag,
+            # and one thread-limit switch (members' re-entries are no-ops).
+            with _thread_limit(self.thread_count):
+                Xc, ctx = _bag_predict_context(self, X)
+                probas = [m._proba_impl(Xc, ctx) for m in self.estimators_]
             acc = np.zeros((probas[0].shape[0], self.n_classes_))
             for m, p in zip(self.estimators_, probas):
                 cols = np.searchsorted(self.classes_, m.classes_)
@@ -2037,7 +2060,8 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         included exactly. Averaged across the bag when ``n_ensembles > 1`` (an
         additive surrogate for the soft-voted probability). Multiclass is not
         supported yet. ``X_background`` overrides the reference distribution."""
-        _check_predict_input(self, X)
+        Xv = _check_predict_input(self, X)
+        X = X if Xv is None else Xv
         members = self.estimators_ if self.estimators_ is not None else None
         if (members is not None and getattr(members[0], "_multiclass", False)) \
                 or (members is None and self._multiclass):

--- a/chimeraboost/warmup.py
+++ b/chimeraboost/warmup.py
@@ -26,9 +26,11 @@ def warmup(verbose=False, background=False):
     """Compile (or load from the on-disk cache) all default-path kernels.
 
     Covers binary classification with linear leaves, a categorical feature
-    and a validation set; multiclass; and regression with ordered boosting —
-    together these touch every fit- and predict-path numba kernel except the
-    SHAP kernels (compiled on the first ``shap_values`` call).
+    and a validation set; multiclass; regression with ordered boosting and
+    non-uniform sample weights (the weighted ordered-TS kernel); and the
+    gdiff cross-feature group-sum kernel — together these touch every fit-
+    and predict-path numba kernel except the SHAP kernels (compiled on the
+    first ``shap_values`` call).
 
     Instead of calling this yourself, you can set the environment variable
     ``CHIMERABOOST_WARMUP=1`` to run it automatically when ``chimeraboost``
@@ -81,13 +83,25 @@ def warmup(verbose=False, background=False):
     mc.predict_proba(X[:8, :3])
     _log("multiclass")
 
-    # Regression, ordered boosting on (the LOO leaf-step kernel).
+    # Regression, ordered boosting on (the LOO leaf-step kernel), with a
+    # categorical column and NON-uniform sample weights: the weighted
+    # ordered-TS kernel (`_ordered_ts_weighted`) and the weighted binner
+    # borders only compile on a weighted fit (uniform weights collapse to the
+    # unweighted path), which the other stages deliberately keep.
     yr = X[:320, 0] + 0.1 * rng.standard_normal(320)
+    sw = rng.uniform(0.5, 1.5, size=320)
     reg = ChimeraBoostRegressor(n_estimators=2, random_state=0,
                                 ordered_boosting=True)
-    reg.fit(X[:320, :3], yr)
-    reg.predict(X[:8, :3])
-    _log("regression + ordered boosting")
+    reg.fit(X[:320], yr, cat_features=[3], sample_weight=sw)
+    reg.predict(X[:8])
+    _log("regression + ordered boosting + weighted categoricals")
+
+    # The gdiff (group-centered cross feature) kernel sits on the default
+    # path only for fits >= CROSS_MIN_SAMPLES rows -- too big for a warmup
+    # fit, so compile it directly with the dtypes the real call uses.
+    from .preprocessing import _grouped_kahan_sum
+    _grouped_kahan_sum(np.zeros(4, dtype=np.int64), np.ones(4), 2)
+    _log("gdiff group-sum kernel")
 
     # The fused level kernel (`_build_split_descend`) has one signature for
     # both its small-n and large-n branches, so the small fits above compile

--- a/tests/test_audit_fixes.py
+++ b/tests/test_audit_fixes.py
@@ -420,3 +420,69 @@ def test_a1_auto_split_notice_silent_by_default(capsys):
     ChimeraBoostRegressor(n_estimators=5, verbose=True, random_state=0).fit(
         X[:240], y[:240], eval_set=(X[240:], y[240:]))
     assert "holding out" not in capsys.readouterr().out
+
+
+# ------------------------------------------- 2026-07-23 semi-bug hunt fixes
+
+
+def test_mae_quantile_leaf_estimation_iterations_is_truly_inert():
+    """For MAE/Quantile, _correct_leaves sets the exact minimizer (median /
+    alpha-quantile); leaf_estimation_iterations > 1 must not run sign-gradient
+    Newton steps on top of it. The sklearn layer has always *warned* the
+    parameter has no effect for these losses -- this pins that the warning is
+    honest: predictions are identical whatever the value."""
+    X, y = _toy_regression(n=600, seed=3)
+    for loss in ("MAE", "Quantile"):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            base = ChimeraBoostRegressor(
+                loss=loss, n_estimators=40, leaf_estimation_iterations=1,
+                random_state=0).fit(X, y)
+            lei3 = ChimeraBoostRegressor(
+                loss=loss, n_estimators=40, leaf_estimation_iterations=3,
+                random_state=0).fit(X, y)
+        np.testing.assert_array_equal(base.predict(X), lei3.predict(X))
+
+
+def test_depth0_stop_keeps_best_validation_prefix(monkeypatch):
+    """A depth-0 tree ends boosting early; that exit must keep the best
+    validation prefix exactly like patience and budget exhaustion do. Scripted
+    trees: round 0 improves validation, rounds 1-2 worsen it, round 3 returns
+    depth-0 -- the fitted model must keep only the one good tree."""
+    import chimeraboost.booster as bst
+
+    class _FakeTree:
+        def __init__(self, depth, step):
+            self.depth = depth
+            self.values = np.full(2, step)
+            self.gains = np.zeros(max(depth, 1))
+            self.splits_feat = np.zeros(depth, dtype=np.int64)
+            self.splits_thr = np.zeros(depth, dtype=np.int64)
+            self.lin_feats = None
+            self.lin_coef = None
+            self.centers_std = None
+
+        def predict(self, Xb):
+            return np.full(Xb.shape[1], self.values[0])
+
+    steps = iter([0.5, -0.5, -0.5])
+
+    def fake_build(Xb, g, h, *args, **kw):
+        step = next(steps, None)
+        if step is None:
+            return _FakeTree(0, 0.0), np.zeros(Xb.shape[1], dtype=np.int64)
+        return _FakeTree(1, step), np.zeros(Xb.shape[1], dtype=np.int64)
+
+    monkeypatch.setattr(bst, "build_oblivious_tree", fake_build)
+    rng = np.random.default_rng(0)
+    Xtr = rng.normal(size=(64, 2))
+    ytr = np.zeros(64)                    # init_ = 0
+    Xv = rng.normal(size=(16, 2))
+    yv = np.ones(16)                      # val RMSE: 1.0 -> 0.5 -> 1.0 -> 1.5
+    b = bst.GradientBoosting(loss="RMSE", n_estimators=10,
+                             early_stopping_rounds=50, linear_leaves=False,
+                             learning_rate=0.1, random_state=0)
+    b.fit(Xtr, ytr, eval_set=(Xv, yv))
+    assert len(b.trees_) == 1, (
+        f"depth-0 exit kept {len(b.trees_)} trees; the best validation "
+        "prefix is 1 tree")


### PR DESCRIPTION
Audit follow-up to the 0.21.0 categorical-predict slowdown findings: a systematic sweep of the predict path, fit path, and API/preprocessing layer for more slowdown/quality semi-bugs.

## Perf fixes (bit-identical; 519 tests incl. identity goldens green)
- **Cross-feature block reuses the numeric block's float64 casts.** Each cross pair re-extracted and re-cast its parent columns from the raw (object-dtype, when cats are present) matrix — the top features got re-cast ~10x per call, and this dominated cross-feature predict cost. Measured on a cross-selected model with 2 cats: 4k-row predict 13.6 ms → 8.6 ms (−37%), 1-row 0.35 → 0.27 ms, fit 2.2 s → 1.3 s. Likely recovers a chunk of the TabArena predict-time regression (0.109 → 0.162 s/1K after 0.20.0 cat crosses).
- **Predict converts the input once.** The inf-check's model-array conversion was discarded and immediately redone by the booster (DataFrame input paid two full `to_numpy` materializations; bagged three).
- **Bagged predict enters `_thread_limit` once per call** instead of once per member (K OpenMP re-teams with explicit `thread_count`).
- **Multiclass predict drops a dead `np.tile` init; `shap_values` reuses the cached linear forest pack.**
- **`warmup()` now compiles `_ordered_ts_weighted` and `_grouped_kahan_sum`** — both on default paths (weighted fits; ≥2000-row categorical fits with auto cross features) but previously missed, so the fleets warmup targets still hit JIT stalls there.

## Correctness fixes (edge-triggered, non-default paths)
- **MAE/Quantile + `leaf_estimation_iterations>1` corrupted leaf values**: `_correct_leaves` sets the exact median/quantile minimizer, then unguarded Newton refinement added sign-gradient steps on top — while the sklearn layer warned the parameter "will have no effect". The guard makes the warning honest. Defaults unaffected (lei=1 refinement is a no-op).
- **Depth-0 early exit skipped best-prefix truncation**: a round with no legal split broke out of the loop without truncating to the best validation iteration, keeping trees grown after the val optimum. Now truncates like the patience and budget-exhaustion exits (scalar + multiclass).

Both correctness fixes have regression tests (`tests/test_audit_fixes.py`).

## Verified
- Full suite: 519 passed (includes numerical-identity goldens — default-path outputs are bit-identical).
- Micro-benchmark A/B (PYTHONPATH-pinned, `chimeraboost.__file__` checked both runs).

## Audit findings NOT in this PR (behavior-changing, need /experiment or a call)
- Combo-cat encoding: `"_x_"` string-concat can alias distinct pairs and conflates NaN with the string "nan" (silent quality-only; fix changes encodings).
- Grouped-classification auto-split ignores `random_state` (StratifiedGroupKFold, always fold 0).
- Predict kernels have no small-n serial twins (1-row predict pays 2 OpenMP fork/joins); fit path has them.
- "Prune unused cross columns at predict" was measured and killed: trees used all 38 candidate columns on a real fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSMP6TRSv1WzFBjcRnvTJs