### PR TITLE
Custom objectives + eval_metric hook; built-in Huber/Poisson/Gamma/Tweedie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to ChimeraBoost are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+### Added
+- **Custom objectives.** The regressor's ``loss`` accepts a user objective
+  instance: subclass ``chimeraboost.CustomObjective``, implement
+  ``grad_hess(y, raw)`` and ``eval(y, raw, sample_weight=None)``, optionally
+  override ``init`` / ``transform``. Flows through the full stack —
+  quantized histograms, subsampling, bagging, pickling.
+- **Four new built-in regression losses on that hook:** ``"Huber"``
+  (``delta``), and the log-link family ``"Poisson"``, ``"Gamma"``,
+  ``"Tweedie"`` (``tweedie_variance_power``), whose predictions are
+  ``exp(raw) > 0``. y-domain violations raise clear errors at fit.
+- **``eval_metric``** on both estimators: a callable
+  ``metric(y_true, y_pred[, sample_weight])`` scored on the validation set
+  each round, driving early stopping and the internal model selections
+  instead of the training loss; ``greater_is_better = True`` attribute
+  supported (``validation_history_`` records negated values).
+  All defaults are bit-identical: string losses take the exact old path and
+  ``eval_metric=None`` changes nothing (numerical-identity goldens green).
+
 ## [0.23.0] - 2026-07-23
 ### Changed
 - **Categorical combinations are pairs, not concatenated strings.** A combo

--- a/chimeraboost/__init__.py
+++ b/chimeraboost/__init__.py
@@ -17,6 +17,7 @@ from .sklearn_api import (
     ChimeraBoostRegressor,
     ChimeraBoostClassifier,
 )
+from .losses import CustomObjective
 from .warmup import warmup, _warmup_from_env
 
 # CHIMERABOOST_WARMUP=1 -> compile the numba kernels at import ("background"
@@ -27,6 +28,7 @@ _warmup_from_env(_os.environ.get("CHIMERABOOST_WARMUP"))
 __all__ = [
     "ChimeraBoostRegressor",
     "ChimeraBoostClassifier",
+    "CustomObjective",
     "warmup",
 ]
 __version__ = "0.23.0"

--- a/chimeraboost/booster.py
+++ b/chimeraboost/booster.py
@@ -162,7 +162,7 @@ class _BaseBooster:
                  ordered_boosting=False, cat_combinations=False,
                  leaf_estimation_iterations=1,
                  linear_leaves=False, linear_lambda=1.0, cross_pairs=None,
-                 quantize_gradients=True):
+                 quantize_gradients=True, eval_metric=None):
         self.n_estimators = int(n_estimators)
         self.learning_rate = learning_rate
         self.depth = int(depth)
@@ -184,6 +184,7 @@ class _BaseBooster:
         self.linear_lambda = float(linear_lambda)
         self.cross_pairs = list(cross_pairs) if cross_pairs else []
         self.quantize_gradients = bool(quantize_gradients)
+        self.eval_metric = eval_metric
 
     def _alloc_hist_buffers(self, n_features, n_bins):
         """Allocate the reusable histogram buffer once per fit.
@@ -249,6 +250,23 @@ class _BaseBooster:
         with _thread_limit(self.thread_count) as n:
             self.n_threads_ = n
             return self._fit_impl(X, y, *args, **kwargs)
+
+    def _val_score(self, yv, Fv, wv):
+        """One entry of the validation series (early stopping and the sklearn
+        layer's selections take the min of this). Default: the training loss
+        on raw scores. With a custom ``eval_metric``, the metric on transformed
+        predictions instead — negated when the metric declares
+        ``greater_is_better = True`` so the lower-is-better machinery is
+        untouched (``valid_history_`` then holds the negated values)."""
+        if self.eval_metric is None:
+            return self.loss_.eval(yv, Fv, wv)
+        pred = self.loss_.transform(Fv)
+        # Two-arg call when there are no validation weights, so plain
+        # ``lambda y, p: ...`` metrics work.
+        val = float(self.eval_metric(yv, pred) if wv is None
+                    else self.eval_metric(yv, pred, wv))
+        return -val if getattr(self.eval_metric, "greater_is_better", False) \
+            else val
 
     def predict_raw(self, X, cat_ctx=None):
         """Predict under this model's thread limit (restored on exit).
@@ -466,7 +484,10 @@ class GradientBoosting(_BaseBooster):
         n_samples = X.shape[0]
         w = self._normalize_weights(sample_weight, n_samples)
 
-        self.loss_ = LOSSES[self.loss_name](**self.loss_kwargs)
+        # A non-string loss is a user objective instance implementing the
+        # losses.py protocol (see losses.CustomObjective); used as-is.
+        self.loss_ = (LOSSES[self.loss_name](**self.loss_kwargs)
+                      if isinstance(self.loss_name, str) else self.loss_name)
         self.lr_ = self._resolve_lr(n_samples, eval_set)
 
         Xb, Xvb = self._prep_matrices(X, [y], cat_features, eval_set,
@@ -576,7 +597,7 @@ class GradientBoosting(_BaseBooster):
 
             if Fv is not None:
                 Fv += tree.predict(Xvb)
-                val = self.loss_.eval(yv, Fv, wv)   # wv=None -> unweighted
+                val = self._val_score(yv, Fv, wv)   # wv=None -> unweighted
                 self.valid_history_.append(val)
                 if stopper.step(val, m):
                     if self.verbose:
@@ -807,7 +828,7 @@ class MulticlassBoosting(_BaseBooster):
             if Fv is not None:
                 for k in range(K):
                     Fv[:, k] += round_trees[k].predict(Xvb)
-                val = self.loss_.eval(Yv, Fv, wv)   # wv=None -> unweighted
+                val = self._val_score(Yv, Fv, wv)   # wv=None -> unweighted
                 self.valid_history_.append(val)
                 if stopper.step(val, m):
                     if self.verbose:

--- a/chimeraboost/losses.py
+++ b/chimeraboost/losses.py
@@ -149,6 +149,181 @@ class Quantile:
         return raw
 
 
+# Cap on exponent arguments in the log-link losses: exp(80) ~ 5.5e34 keeps
+# every downstream product finite in float64 while leaving the cap far outside
+# any raw score a sane fit produces (raw = log(mean prediction)).
+_EXP_CLIP = 80.0
+
+
+def _exp(z):
+    return np.exp(np.clip(z, -_EXP_CLIP, _EXP_CLIP))
+
+
+class Huber:
+    """Huber regression: quadratic within `delta` of the target, linear
+    beyond. `delta` is in y units (fixed, not quantile-adaptive), so scale it
+    to the data. hess = 1 in both regions (the standard GBDT treatment)."""
+
+    name = "Huber"
+    is_classification = False
+    adjusts_leaves = False
+
+    def __init__(self, delta=1.0):
+        self.delta = float(delta)
+
+    def init(self, y, sample_weight=None):
+        return _weighted_quantile(y, sample_weight, 0.5)
+
+    def grad_hess(self, y, raw):
+        r = raw - y
+        grad = np.clip(r, -self.delta, self.delta)
+        hess = np.ones_like(raw)
+        return grad, hess
+
+    def eval(self, y, raw, sample_weight=None):
+        r = np.abs(raw - y)
+        d = self.delta
+        loss = np.where(r <= d, 0.5 * r * r, d * (r - 0.5 * d))
+        return float(np.average(loss, weights=sample_weight))
+
+    def transform(self, raw):
+        return raw
+
+
+class Poisson:
+    """Poisson regression for counts with a log link: raw = log(mu).
+    grad = mu - y, hess = mu. Predictions (`transform`) are exp(raw) > 0."""
+
+    name = "Poisson"
+    is_classification = False
+    adjusts_leaves = False
+
+    def init(self, y, sample_weight=None):
+        if np.any(y < 0):
+            raise ValueError("loss='Poisson' requires non-negative y.")
+        mean = np.average(y, weights=sample_weight)
+        if mean <= 0:
+            raise ValueError("loss='Poisson' requires y with a positive mean.")
+        return float(np.log(mean))
+
+    def grad_hess(self, y, raw):
+        mu = _exp(raw)
+        return mu - y, np.maximum(mu, 1e-6)
+
+    def eval(self, y, raw, sample_weight=None):
+        """Mean Poisson deviance (2 * (y log(y/mu) - (y - mu)); y log y := 0 at 0)."""
+        mu = _exp(raw)
+        ylog = np.zeros_like(mu)
+        nz = y > 0
+        ylog[nz] = y[nz] * np.log(y[nz] / mu[nz])
+        return float(np.average(2.0 * (ylog - (y - mu)),
+                                weights=sample_weight))
+
+    def transform(self, raw):
+        return _exp(raw)
+
+
+class Gamma:
+    """Gamma regression for positive, right-skewed targets with a log link:
+    raw = log(mu). grad = 1 - y/mu, hess = y/mu (the gamma NLL curvature)."""
+
+    name = "Gamma"
+    is_classification = False
+    adjusts_leaves = False
+
+    def init(self, y, sample_weight=None):
+        if np.any(y <= 0):
+            raise ValueError("loss='Gamma' requires strictly positive y.")
+        return float(np.log(np.average(y, weights=sample_weight)))
+
+    def grad_hess(self, y, raw):
+        y_over_mu = y * _exp(-raw)
+        return 1.0 - y_over_mu, np.maximum(y_over_mu, 1e-6)
+
+    def eval(self, y, raw, sample_weight=None):
+        """Mean gamma deviance: 2 * (log(mu/y) + y/mu - 1)."""
+        y_over_mu = y * _exp(-raw)
+        dev = 2.0 * (-np.log(y_over_mu) + y_over_mu - 1.0)
+        return float(np.average(dev, weights=sample_weight))
+
+    def transform(self, raw):
+        return _exp(raw)
+
+
+class Tweedie:
+    """Tweedie regression (compound Poisson-gamma) with a log link, for
+    non-negative targets with exact zeros plus a long right tail (insurance
+    claims, rainfall). `power` in (1, 2) interpolates Poisson -> Gamma."""
+
+    name = "Tweedie"
+    is_classification = False
+    adjusts_leaves = False
+
+    def __init__(self, power=1.5):
+        power = float(power)
+        if not 1.0 < power < 2.0:
+            raise ValueError(
+                f"Tweedie variance power must be in (1, 2); got {power!r}.")
+        self.power = power
+
+    def init(self, y, sample_weight=None):
+        if np.any(y < 0):
+            raise ValueError("loss='Tweedie' requires non-negative y.")
+        mean = np.average(y, weights=sample_weight)
+        if mean <= 0:
+            raise ValueError("loss='Tweedie' requires y with a positive mean.")
+        return float(np.log(mean))
+
+    def grad_hess(self, y, raw):
+        p = self.power
+        e1 = _exp((1.0 - p) * raw)   # mu^(1-p)
+        e2 = _exp((2.0 - p) * raw)   # mu^(2-p)
+        grad = e2 - y * e1
+        hess = (2.0 - p) * e2 - (1.0 - p) * y * e1
+        return grad, np.maximum(hess, 1e-6)
+
+    def eval(self, y, raw, sample_weight=None):
+        """Mean Tweedie deviance at `power` (y = 0 contributes only the mu term)."""
+        p = self.power
+        mu1p = _exp((1.0 - p) * raw)
+        mu2p = _exp((2.0 - p) * raw)
+        dev = 2.0 * (np.power(y, 2.0 - p) / ((1.0 - p) * (2.0 - p))
+                     - y * mu1p / (1.0 - p) + mu2p / (2.0 - p))
+        return float(np.average(dev, weights=sample_weight))
+
+    def transform(self, raw):
+        return _exp(raw)
+
+
+class CustomObjective:
+    """Base class for user-defined regression objectives.
+
+    Subclass and implement ``grad_hess(y, raw)`` -> (gradient, hessian) and
+    ``eval(y, raw, sample_weight=None)`` -> scalar (lower is better; drives
+    early stopping). Optionally override ``init(y, sample_weight=None)`` (the
+    starting raw score, default 0.0) and ``transform(raw)`` (raw scores ->
+    predictions, default identity). Pass an *instance* as the regressor's
+    ``loss``. Instances must be stateless across fits and picklable (define
+    the subclass at module level) — bagged members fit in worker processes.
+    """
+
+    name = "Custom"
+    is_classification = False
+    adjusts_leaves = False
+
+    def init(self, y, sample_weight=None):
+        return 0.0
+
+    def grad_hess(self, y, raw):
+        raise NotImplementedError
+
+    def eval(self, y, raw, sample_weight=None):
+        raise NotImplementedError
+
+    def transform(self, raw):
+        return raw
+
+
 def _softmax(F):
     z = F - F.max(axis=1, keepdims=True)
     ez = np.exp(z)
@@ -183,5 +358,7 @@ class MultiSoftmax:
         return _softmax(F)
 
 
-LOSSES = {"RMSE": RMSE, "Logloss": Logloss, "MAE": MAE, "Quantile": Quantile}
+LOSSES = {"RMSE": RMSE, "Logloss": Logloss, "MAE": MAE, "Quantile": Quantile,
+          "Huber": Huber, "Poisson": Poisson, "Gamma": Gamma,
+          "Tweedie": Tweedie}
 

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -109,11 +109,38 @@ def _validate_hyperparams(estimator):
     _in_range("max_samples", 0.0, 1.0, lo_incl=False)
     # Regressor-only loss / alpha (the classifier picks its loss automatically).
     if "loss" in p:
-        if p["loss"] not in ("RMSE", "MAE", "Quantile"):
-            raise ValueError(
-                f"loss must be one of 'RMSE', 'MAE', 'Quantile'; got {p['loss']!r}.")
-        if p["loss"] == "Quantile":
-            _in_range("alpha", 0.0, 1.0, lo_incl=False, hi_incl=False)
+        loss = p["loss"]
+        if isinstance(loss, str):
+            known = ("RMSE", "MAE", "Quantile", "Huber", "Poisson", "Gamma",
+                     "Tweedie")
+            if loss not in known:
+                raise ValueError(
+                    f"loss must be one of {known} or a custom objective "
+                    f"instance; got {loss!r}.")
+            if loss == "Quantile":
+                _in_range("alpha", 0.0, 1.0, lo_incl=False, hi_incl=False)
+            if loss == "Huber":
+                _in_range("delta", 0.0, np.inf, lo_incl=False)
+            if loss == "Tweedie":
+                _in_range("tweedie_variance_power", 1.0, 2.0,
+                          lo_incl=False, hi_incl=False)
+        else:
+            # Custom objective: an instance implementing the losses.py
+            # protocol (subclass chimeraboost.CustomObjective for the
+            # optional-method defaults).
+            missing = [a for a in ("init", "grad_hess", "eval")
+                       if not callable(getattr(loss, a, None))]
+            if missing:
+                raise ValueError(
+                    "A custom loss must be an instance with callable "
+                    f"init/grad_hess/eval (missing: {missing}); subclass "
+                    "chimeraboost.CustomObjective. Got "
+                    f"{loss!r}.")
+    if p.get("eval_metric") is not None and not callable(p["eval_metric"]):
+        raise ValueError(
+            "eval_metric must be a callable metric(y_true, y_pred"
+            "[, sample_weight]) -> float, or None; got "
+            f"{p['eval_metric']!r}.")
 
 
 def _resolve_cat_features(estimator, cat_features):
@@ -975,10 +1002,33 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
     early_stopping_rounds : int or None, default None
         Rounds without validation improvement before stopping. ``None`` becomes 50
         when early stopping is active.
-    loss : {"RMSE", "MAE", "Quantile"}, default "RMSE"
-        Training objective. Set the level with ``alpha`` for ``"Quantile"``.
+    loss : str or object, default "RMSE"
+        Training objective. Built in: ``"RMSE"``, ``"MAE"``, ``"Quantile"``
+        (level set by ``alpha``), ``"Huber"`` (transition set by ``delta``),
+        and the log-link losses ``"Poisson"``, ``"Gamma"``, ``"Tweedie"``
+        (power set by ``tweedie_variance_power``), whose predictions are
+        ``exp(raw score) > 0``. Alternatively a custom objective *instance*:
+        subclass ``chimeraboost.CustomObjective`` and implement
+        ``grad_hess(y, raw)`` and ``eval(y, raw, sample_weight=None)``.
     alpha : float, default 0.5
         Quantile level for ``loss="Quantile"`` (e.g. 0.9 for the 90th percentile).
+    delta : float, default 1.0
+        Huber transition point for ``loss="Huber"``, in y units: quadratic
+        within ``delta`` of the target, linear beyond. Fixed, not
+        quantile-adaptive -- scale it to the data.
+    tweedie_variance_power : float, default 1.5
+        Variance power for ``loss="Tweedie"``, strictly between 1 (Poisson)
+        and 2 (Gamma).
+    eval_metric : callable or None, default None
+        Custom validation metric ``metric(y_true, y_pred[, sample_weight]) ->
+        float`` scored on the validation set each round and used for early
+        stopping and the internal model selections instead of the training
+        loss. ``y_pred`` is the prediction (after the loss link). Lower is
+        better, unless the callable carries a ``greater_is_better = True``
+        attribute -- ``validation_history_`` then records negated values so
+        the internal lower-is-better machinery is unchanged. The training
+        loss still drives the gradients; the verbose per-round "train" column
+        stays in training-loss units.
     min_child_weight : float, default 1.0
         Minimum total hessian required on each side of a split.
     thread_count : int or None, default None
@@ -1101,7 +1151,8 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                  selection_rounds=100,
                  early_stopping=True, validation_fraction=0.2,
                  n_ensembles=None, ensemble_n_jobs=-1, max_samples=0.8,
-                 cat_features=None, quantize_gradients=True):
+                 cat_features=None, quantize_gradients=True,
+                 eval_metric=None, delta=1.0, tweedie_variance_power=1.5):
         self.n_estimators = n_estimators
         self.learning_rate = learning_rate
         self.depth = depth
@@ -1115,6 +1166,9 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         self.cat_features = cat_features
         self.loss = loss
         self.alpha = alpha
+        self.delta = delta
+        self.tweedie_variance_power = tweedie_variance_power
+        self.eval_metric = eval_metric
         self.min_child_weight = min_child_weight
         self.thread_count = thread_count
         self.random_state = random_state
@@ -1273,9 +1327,16 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         if es_active and es_rounds is None:
             es_rounds = 50
 
-        loss_kwargs = {"alpha": self.alpha} if self.loss == "Quantile" else {}
+        loss_kwargs = {}
+        if self.loss == "Quantile":
+            loss_kwargs["alpha"] = self.alpha
+        elif self.loss == "Huber":
+            loss_kwargs["delta"] = self.delta
+        elif self.loss == "Tweedie":
+            loss_kwargs["power"] = self.tweedie_variance_power
         kw = {k: v for k, v in self.get_params().items()
-              if k not in {"loss", "alpha"} | _SKLEARN_ONLY}
+              if k not in {"loss", "alpha", "delta",
+                           "tweedie_variance_power"} | _SKLEARN_ONLY}
         kw["early_stopping_rounds"] = es_rounds
         # Resolve the loss-adaptive depth default (see the `depth` docstring):
         # 6 for RMSE/MAE (unchanged), 4 for Quantile, where deep leaves overfit
@@ -1445,19 +1506,30 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                 self.quantile_offset_ = float(resid[k - 1])
         return self
 
+    def _transform_raw(self, raw):
+        """Map raw additive scores to predictions through the loss link --
+        identity for RMSE/MAE/Quantile/Huber (returns ``raw`` unchanged, so
+        those paths stay bit-identical), ``exp`` for Poisson/Gamma/Tweedie,
+        the custom loss's ``transform`` when it defines one."""
+        tf = getattr(self.model_.loss_, "transform", None)
+        return raw if tf is None else tf(raw)
+
     def predict(self, X):
         Xv = _check_predict_input(self, X)
         X = X if Xv is None else Xv
         if self.estimators_ is not None:
             # One shared conversion + factorization cache for the whole bag;
-            # each member applies its own conformal offset. One thread-limit
+            # each member applies its own link + conformal offset (the bag
+            # prediction is the mean of member predictions). One thread-limit
             # switch for the whole bag (members' re-entries are no-ops).
             with _thread_limit(self.thread_count):
                 Xc, ctx = _bag_predict_context(self, X)
                 return np.mean(
-                    [m.model_.predict_raw(Xc, ctx) + m.quantile_offset_
+                    [m._transform_raw(m.model_.predict_raw(Xc, ctx))
+                     + m.quantile_offset_
                      for m in self.estimators_], axis=0)
-        return self.model_.predict_raw(X) + self.quantile_offset_
+        return self._transform_raw(self.model_.predict_raw(X)) \
+            + self.quantile_offset_
 
     def staged_predict(self, X):
         """Yield the prediction after each successive tree (the conformal
@@ -1469,7 +1541,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
             raise NotImplementedError("staged_predict is not defined for a "
                                       "bagged ensemble (n_ensembles > 1).")
         for staged in self.model_.staged_predict_raw(X):
-            yield staged + self.quantile_offset_
+            yield self._transform_raw(staged) + self.quantile_offset_
 
     @property
     def best_iteration_(self):
@@ -1479,10 +1551,13 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
 
     @property
     def validation_history_(self):
-        """Per-round validation loss recorded during ``fit`` (RMSE-space loss for
-        regression), as a list whose length is the number of rounds run. Empty
-        when no ``eval_set`` / early-stopping split was available; for a bagged
-        model (``n_ensembles > 1``) a list of the members' histories."""
+        """Per-round validation score recorded during ``fit`` -- the training
+        loss (RMSE-space for regression), or the custom ``eval_metric`` when
+        one was set (negated when the metric declares
+        ``greater_is_better = True``, so lower is always better here). A list
+        whose length is the number of rounds run; empty when no ``eval_set`` /
+        early-stopping split was available; for a bagged model
+        (``n_ensembles > 1``) a list of the members' histories."""
         if self.estimators_ is not None:
             return [m.model_.valid_history_ for m in self.estimators_]
         return self.model_.valid_history_
@@ -1504,7 +1579,11 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         linear-leaf slopes are included exactly. Averaged across the bag when
         ``n_ensembles > 1`` (the bag prediction is the members' mean, so the
         averaged attribution stays exact). ``X_background`` overrides the
-        reference distribution (default: a sample of the training data)."""
+        reference distribution (default: a sample of the training data).
+        For the log-link losses (Poisson/Gamma/Tweedie) and custom losses
+        with a non-identity ``transform``, attributions are in raw (link)
+        space -- rows sum to the log of the prediction, the usual GBDT
+        margin-space convention."""
         Xv = _check_predict_input(self, X)
         X = X if Xv is None else Xv
         if self.estimators_ is not None:
@@ -1595,6 +1674,17 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         use the exact float gradients; the rounding noise touches only
         split selection and is deterministic for a fixed ``random_state``.
         ``False`` restores exact float64 histograms.
+    eval_metric : callable or None, default None
+        Custom validation metric ``metric(y_true, y_pred[, sample_weight]) ->
+        float`` scored on the validation set each round and used for early
+        stopping and the internal model selections instead of log loss.
+        Binary: ``y_true`` is the 0/1-encoded target and ``y_pred`` the
+        positive-class probability; multiclass: ``y_true`` is one-hot
+        ``(n, K)`` and ``y_pred`` the probability matrix. Lower is better,
+        unless the callable carries a ``greater_is_better = True`` attribute
+        -- ``validation_history_`` then records negated values so the
+        internal lower-is-better machinery is unchanged. Temperature scaling
+        still calibrates on log loss.
     cross_features : bool or None, default None
         Numeric interaction columns. ``None`` (the default) refits the model
         with difference and product columns for the pairs of the top numeric
@@ -1674,7 +1764,8 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                  selection_rounds=100,
                  early_stopping=True, validation_fraction=0.2,
                  n_ensembles=None, ensemble_n_jobs=-1, max_samples=0.8,
-                 cat_features=None, quantize_gradients=True):
+                 cat_features=None, quantize_gradients=True,
+                 eval_metric=None):
         self.n_estimators = n_estimators
         self.learning_rate = learning_rate
         self.depth = depth
@@ -1687,6 +1778,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         self.early_stopping_rounds = early_stopping_rounds
         self.cat_features = cat_features
         self.min_child_weight = min_child_weight
+        self.eval_metric = eval_metric
         self.thread_count = thread_count
         self.random_state = random_state
         self.verbose = verbose

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -44,10 +44,18 @@ mix — e.g. `cat_features=["city", "brand"]` or `cat_features=[0, 3]`.
 
 | Parameter | Default | Effect |
 |---|---|---|
-| `loss` | `"RMSE"` | `"RMSE"`, `"MAE"` (median), or `"Quantile"`. |
+| `loss` | `"RMSE"` | `"RMSE"`, `"MAE"` (median), `"Quantile"`, `"Huber"`, or the log-link losses `"Poisson"` (counts), `"Gamma"` (positive, right-skewed), `"Tweedie"` (non-negative with exact zeros) — predictions are `exp(raw) > 0`. Or a custom objective instance: subclass `chimeraboost.CustomObjective`, implement `grad_hess(y, raw)` and `eval(y, raw, sample_weight=None)`, optionally override `init`/`transform`. |
 | `alpha` | `0.5` | Quantile level for `loss="Quantile"`. |
+| `delta` | `1.0` | Huber transition point, in y units (quadratic within, linear beyond; fixed, so scale it to the data). |
+| `tweedie_variance_power` | `1.5` | Tweedie variance power, strictly between 1 (Poisson) and 2 (Gamma). |
 
 The classifier picks its loss automatically: binary logloss for 2 classes, softmax for 3+.
+
+## Validation metric (both estimators)
+
+| Parameter | Default | Effect |
+|---|---|---|
+| `eval_metric` | `None` | Callable `metric(y_true, y_pred[, sample_weight]) -> float` scored on the validation set each round; drives early stopping and the internal selections instead of the training loss. `y_pred` is the prediction (probabilities for the classifier; multiclass metrics get one-hot `y_true` and the probability matrix). Lower is better unless the callable has a `greater_is_better = True` attribute (`validation_history_` then records negated values). Gradients still come from the training loss. |
 
 ## Leaf models
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -76,6 +76,50 @@ validation split, which restores near-nominal marginal coverage at the tails.
 With `early_stopping=False` and no `eval_set` there is no split to calibrate on,
 and the raw (typically under-dispersed) quantiles are returned.
 
+## Counts, positive targets, zero-inflated targets
+
+The log-link losses keep predictions positive and match the noise model:
+
+```python
+counts = ChimeraBoostRegressor(loss="Poisson").fit(X, y_counts)        # y >= 0
+costs = ChimeraBoostRegressor(loss="Gamma").fit(X, y_positive)         # y > 0
+claims = ChimeraBoostRegressor(loss="Tweedie",
+                               tweedie_variance_power=1.5).fit(X, y)   # y >= 0, exact zeros
+```
+
+`loss="Huber"` (transition `delta`, in y units) is squared error that tolerates
+outliers.
+
+## Custom objectives and metrics
+
+Subclass `CustomObjective` with the gradient/hessian of your loss on the raw
+score; pass an instance as `loss`. `eval_metric` swaps the early-stopping
+metric on either estimator:
+
+```python
+from chimeraboost import ChimeraBoostRegressor, CustomObjective
+
+class LogCosh(CustomObjective):          # smooth MAE
+    def grad_hess(self, y, raw):
+        t = np.tanh(raw - y)
+        return t, 1.0 - t**2 + 1e-6
+    def eval(self, y, raw, sample_weight=None):
+        return float(np.average(np.logaddexp(raw - y, y - raw) - np.log(2),
+                                weights=sample_weight))
+
+model = ChimeraBoostRegressor(loss=LogCosh()).fit(X_train, y_train)
+
+def mae(y_true, y_pred):                 # early-stop on MAE instead of RMSE
+    return float(np.mean(np.abs(y_true - y_pred)))
+
+model = ChimeraBoostRegressor(eval_metric=mae).fit(X_train, y_train)
+```
+
+A metric where larger is better declares it: `mae.greater_is_better = True`-style
+attribute (then `validation_history_` records negated values). Define custom
+objectives at module level — bagged members fit in worker processes and must
+pickle the loss.
+
 ## Multiclass classification
 
 No configuration needed — the classifier switches to softmax when it sees 3 or more

--- a/tests/test_custom_objectives.py
+++ b/tests/test_custom_objectives.py
@@ -1,0 +1,369 @@
+"""Custom objective hook + the extra built-in losses (Huber/Poisson/Gamma/
+Tweedie) + the eval_metric hook."""
+
+import pickle
+
+import numpy as np
+import pytest
+
+from chimeraboost import (ChimeraBoostClassifier, ChimeraBoostRegressor,
+                          CustomObjective)
+from chimeraboost.losses import Gamma, Huber, Poisson, Tweedie
+
+
+def _reg_data(seed=0, n=2000, link=None):
+    rng = np.random.default_rng(seed)
+    X = rng.normal(size=(n, 5))
+    f = 0.8 * X[:, 0] - 0.5 * X[:, 1] + 0.3 * X[:, 2] * X[:, 3]
+    if link == "exp":
+        return X, f  # caller samples counts / positives from exp(f)
+    y = f + rng.normal(scale=0.3, size=n)
+    return X, y
+
+
+def _split(X, y, n_train=1500):
+    return X[:n_train], y[:n_train], X[n_train:], y[n_train:]
+
+
+# ---------------------------------------------------------------------------
+# Built-in losses
+# ---------------------------------------------------------------------------
+
+def test_huber_close_to_rmse_on_clean_data():
+    X, y = _reg_data(seed=1)
+    Xtr, ytr, Xte, yte = _split(X, y)
+    kw = dict(n_estimators=300, random_state=0, cross_features=False,
+              linear_leaves=False)
+    rmse_pred = ChimeraBoostRegressor(**kw).fit(Xtr, ytr).predict(Xte)
+    hub_pred = ChimeraBoostRegressor(loss="Huber", delta=2.0, **kw) \
+        .fit(Xtr, ytr).predict(Xte)
+    # With delta at ~6 sigma of the residuals, Huber is essentially squared
+    # error; the two models should land very close on clean data.
+    assert np.sqrt(np.mean((rmse_pred - hub_pred) ** 2)) < 0.15
+
+
+def test_huber_robust_to_outliers():
+    X, y = _reg_data(seed=2)
+    Xtr, ytr, Xte, yte = _split(X, y)
+    rng = np.random.default_rng(3)
+    bad = rng.random(len(ytr)) < 0.08
+    ytr_out = ytr.copy()
+    ytr_out[bad] += rng.choice([-50.0, 50.0], size=bad.sum())
+    kw = dict(n_estimators=300, random_state=0, cross_features=False,
+              linear_leaves=False)
+    rmse_err = np.mean(np.abs(
+        ChimeraBoostRegressor(**kw).fit(Xtr, ytr_out).predict(Xte) - yte))
+    hub_err = np.mean(np.abs(
+        ChimeraBoostRegressor(loss="Huber", delta=1.0, **kw)
+        .fit(Xtr, ytr_out).predict(Xte) - yte))
+    assert hub_err < rmse_err
+
+
+def test_poisson_fits_counts():
+    X, f = _reg_data(seed=4, link="exp")
+    rng = np.random.default_rng(5)
+    y = rng.poisson(np.exp(f)).astype(np.float64)
+    Xtr, ytr, Xte, yte = _split(X, y)
+    m = ChimeraBoostRegressor(loss="Poisson", n_estimators=300,
+                              random_state=0).fit(Xtr, ytr)
+    pred = m.predict(Xte)
+    assert np.all(pred > 0)  # log link: predictions are exp(raw)
+
+    def poisson_dev(y_, mu):
+        ylog = np.where(y_ > 0, y_ * np.log(np.where(y_ > 0, y_, 1.0) / mu), 0.0)
+        return np.mean(2.0 * (ylog - (y_ - mu)))
+
+    baseline = poisson_dev(yte, np.full_like(yte, ytr.mean()))
+    assert poisson_dev(yte, pred) < 0.8 * baseline
+
+
+def test_gamma_fits_positive_targets():
+    X, f = _reg_data(seed=6, link="exp")
+    rng = np.random.default_rng(7)
+    shape = 2.0
+    y = rng.gamma(shape, np.exp(f) / shape)
+    y = np.maximum(y, 1e-8)
+    Xtr, ytr, Xte, yte = _split(X, y)
+    m = ChimeraBoostRegressor(loss="Gamma", n_estimators=300,
+                              random_state=0).fit(Xtr, ytr)
+    pred = m.predict(Xte)
+    assert np.all(pred > 0)
+
+    def gamma_dev(y_, mu):
+        return np.mean(2.0 * (np.log(mu / y_) + y_ / mu - 1.0))
+
+    baseline = gamma_dev(yte, np.full_like(yte, ytr.mean()))
+    assert gamma_dev(yte, pred) < 0.8 * baseline
+
+
+def test_tweedie_fits_zero_inflated():
+    X, f = _reg_data(seed=8, link="exp")
+    rng = np.random.default_rng(9)
+    # Compound Poisson-gamma: zeros where the Poisson count is 0.
+    counts = rng.poisson(0.7 * np.exp(f))
+    y = np.array([rng.gamma(2.0, 1.0, size=c).sum() for c in counts])
+    Xtr, ytr, Xte, yte = _split(X, y)
+    assert (ytr == 0).any()  # the regime Tweedie exists for
+    m = ChimeraBoostRegressor(loss="Tweedie", tweedie_variance_power=1.5,
+                              n_estimators=300, random_state=0).fit(Xtr, ytr)
+    pred = m.predict(Xte)
+    assert np.all(pred > 0)
+
+    def tweedie_dev(y_, mu, p=1.5):
+        return np.mean(2.0 * (np.power(y_, 2 - p) / ((1 - p) * (2 - p))
+                              - y_ * np.power(mu, 1 - p) / (1 - p)
+                              + np.power(mu, 2 - p) / (2 - p)))
+
+    baseline = tweedie_dev(yte, np.full_like(yte, ytr.mean()))
+    assert tweedie_dev(yte, pred) < baseline
+
+
+def test_log_link_staged_predict_matches_predict():
+    X, f = _reg_data(seed=10, link="exp")
+    rng = np.random.default_rng(11)
+    y = rng.poisson(np.exp(f)).astype(np.float64)
+    m = ChimeraBoostRegressor(loss="Poisson", n_estimators=100,
+                              random_state=0).fit(X, y)
+    *_, last = m.staged_predict(X[:20])
+    np.testing.assert_allclose(last, m.predict(X[:20]))
+
+
+def test_log_link_pickle_roundtrip():
+    X, f = _reg_data(seed=12, link="exp")
+    rng = np.random.default_rng(13)
+    y = rng.poisson(np.exp(f)).astype(np.float64)
+    m = ChimeraBoostRegressor(loss="Poisson", n_estimators=100,
+                              random_state=0).fit(X, y)
+    m2 = pickle.loads(pickle.dumps(m))
+    np.testing.assert_array_equal(m.predict(X[:50]), m2.predict(X[:50]))
+
+
+def test_y_domain_errors():
+    X = np.random.default_rng(0).normal(size=(200, 3))
+    y_neg = np.linspace(-1, 5, 200)
+    with pytest.raises(ValueError, match="non-negative"):
+        ChimeraBoostRegressor(loss="Poisson").fit(X, y_neg)
+    with pytest.raises(ValueError, match="positive"):
+        ChimeraBoostRegressor(loss="Gamma").fit(X, np.zeros(200))
+    with pytest.raises(ValueError, match="non-negative"):
+        ChimeraBoostRegressor(loss="Tweedie").fit(X, y_neg)
+
+
+def test_loss_param_validation():
+    X = np.random.default_rng(0).normal(size=(100, 3))
+    y = X[:, 0]
+    with pytest.raises(ValueError, match="loss must be one of"):
+        ChimeraBoostRegressor(loss="bogus").fit(X, y)
+    with pytest.raises(ValueError, match="delta"):
+        ChimeraBoostRegressor(loss="Huber", delta=0.0).fit(X, y)
+    with pytest.raises(ValueError, match="tweedie_variance_power"):
+        ChimeraBoostRegressor(loss="Tweedie",
+                              tweedie_variance_power=2.5).fit(X, y)
+    with pytest.raises(ValueError, match="tweedie_variance_power"):
+        ChimeraBoostRegressor(loss="Tweedie",
+                              tweedie_variance_power=1.0).fit(X, y)
+
+
+def test_loss_classes_reject_bad_construction():
+    with pytest.raises(ValueError):
+        Tweedie(power=2.0)
+    # Sanity: direct loss objects agree with their sklearn-string twins.
+    y = np.array([0.0, 1.0, 2.0, 3.0])
+    raw = np.log(np.maximum(y, 0.5))
+    for loss in (Huber(1.0), Poisson(), Gamma(), Tweedie(1.5)):
+        if isinstance(loss, Gamma):
+            g, h = loss.grad_hess(y + 0.5, raw)
+        else:
+            g, h = loss.grad_hess(y, raw)
+        assert np.all(np.isfinite(g)) and np.all(h > 0)
+
+
+# ---------------------------------------------------------------------------
+# Custom objective hook
+# ---------------------------------------------------------------------------
+
+class _SquaredError(CustomObjective):
+    """RMSE re-implemented through the public hook (used to prove the custom
+    path is numerically identical to the built-in when the math matches)."""
+
+    def init(self, y, sample_weight=None):
+        return float(np.average(y, weights=sample_weight))
+
+    def grad_hess(self, y, raw):
+        return raw - y, np.ones_like(raw)
+
+    def eval(self, y, raw, sample_weight=None):
+        return float(np.sqrt(np.average((raw - y) ** 2,
+                                        weights=sample_weight)))
+
+
+class _LogCosh(CustomObjective):
+    """A genuinely non-built-in objective (smooth MAE)."""
+
+    def grad_hess(self, y, raw):
+        r = raw - y
+        return np.tanh(r), 1.0 - np.tanh(r) ** 2 + 1e-6
+
+    def eval(self, y, raw, sample_weight=None):
+        return float(np.average(np.logaddexp(raw - y, y - raw) - np.log(2.0),
+                                weights=sample_weight))
+
+
+def test_custom_objective_matches_builtin_rmse():
+    X, y = _reg_data(seed=14)
+    # Custom losses skip the RMSE-only linear-leaf/cross-feature auditions,
+    # so pin both variants off on the built-in side for an apples-to-apples
+    # comparison; everything else runs the identical code path.
+    kw = dict(n_estimators=200, random_state=0, cross_features=False,
+              linear_leaves=False)
+    builtin = ChimeraBoostRegressor(loss="RMSE", **kw).fit(X, y)
+    custom = ChimeraBoostRegressor(loss=_SquaredError(), **kw).fit(X, y)
+    np.testing.assert_array_equal(builtin.predict(X[:100]),
+                                  custom.predict(X[:100]))
+
+
+def test_custom_objective_logcosh_learns():
+    X, y = _reg_data(seed=15)
+    Xtr, ytr, Xte, yte = _split(X, y)
+    m = ChimeraBoostRegressor(loss=_LogCosh(), n_estimators=300,
+                              random_state=0).fit(Xtr, ytr)
+    err = np.mean(np.abs(m.predict(Xte) - yte))
+    assert err < 0.5 * np.mean(np.abs(yte - ytr.mean()))
+
+
+def test_custom_objective_bagged_and_pickled():
+    X, y = _reg_data(seed=16, n=1200)
+    m = ChimeraBoostRegressor(loss=_LogCosh(), n_estimators=100,
+                              n_ensembles=2, random_state=0).fit(X, y)
+    pred = m.predict(X[:50])
+    m2 = pickle.loads(pickle.dumps(m))
+    np.testing.assert_array_equal(pred, m2.predict(X[:50]))
+
+
+def test_custom_objective_protocol_validation():
+    X = np.random.default_rng(0).normal(size=(100, 3))
+    y = X[:, 0]
+    with pytest.raises(ValueError, match="CustomObjective"):
+        ChimeraBoostRegressor(loss=object()).fit(X, y)
+
+
+# ---------------------------------------------------------------------------
+# eval_metric hook
+# ---------------------------------------------------------------------------
+
+def _mae_metric(y_true, y_pred):
+    return float(np.mean(np.abs(y_true - y_pred)))
+
+
+def _neg_mae_metric(y_true, y_pred):
+    return -float(np.mean(np.abs(y_true - y_pred)))
+
+
+_neg_mae_metric.greater_is_better = True
+
+
+def test_eval_metric_drives_validation_history():
+    X, y = _reg_data(seed=17)
+    m = ChimeraBoostRegressor(n_estimators=150, random_state=0,
+                              eval_metric=_mae_metric,
+                              cross_features=False,
+                              linear_leaves=False).fit(X, y)
+    hist = m.validation_history_
+    assert len(hist) > 0
+    # The recorded series is the metric (MAE), not the training RMSE: on this
+    # data MAE and RMSE differ well beyond tolerance, and the two models pick
+    # early stops independently. Recompute the metric at the final model to
+    # anchor the units.
+    default = ChimeraBoostRegressor(n_estimators=150, random_state=0,
+                                    cross_features=False,
+                                    linear_leaves=False).fit(X, y)
+    assert not np.allclose(hist[:10], default.validation_history_[:10])
+
+
+def test_eval_metric_greater_is_better_negates():
+    X, y = _reg_data(seed=18)
+    kw = dict(n_estimators=150, random_state=0, cross_features=False,
+              linear_leaves=False)
+    lo = ChimeraBoostRegressor(eval_metric=_mae_metric, **kw).fit(X, y)
+    hi = ChimeraBoostRegressor(eval_metric=_neg_mae_metric, **kw).fit(X, y)
+    # Negating a lower-is-better metric and flagging greater_is_better must
+    # give the identical fit: same stored history, same chosen iteration.
+    np.testing.assert_allclose(lo.validation_history_,
+                               hi.validation_history_)
+    assert lo.best_iteration_ == hi.best_iteration_
+
+
+def test_eval_metric_receives_weights():
+    X, y = _reg_data(seed=19)
+    w = np.random.default_rng(20).uniform(0.5, 2.0, size=len(y))
+    seen = {"three_arg_calls": 0}
+
+    def metric(y_true, y_pred, sample_weight=None):
+        if sample_weight is not None:
+            seen["three_arg_calls"] += 1
+            assert len(sample_weight) == len(y_true)
+        return float(np.average(np.abs(y_true - y_pred),
+                                weights=sample_weight))
+
+    ChimeraBoostRegressor(n_estimators=60, random_state=0,
+                          eval_metric=metric, cross_features=False,
+                          linear_leaves=False).fit(X, y, sample_weight=w)
+    # The auto-split holdout carries its (non-uniform) row weights.
+    assert seen["three_arg_calls"] > 0
+
+
+def test_eval_metric_binary_classifier():
+    rng = np.random.default_rng(21)
+    X = rng.normal(size=(1500, 5))
+    p = 1.0 / (1.0 + np.exp(-(X[:, 0] - X[:, 1])))
+    y = (rng.random(1500) < p).astype(int)
+
+    def auc(y_true, y_pred):
+        order = np.argsort(y_pred)
+        ranks = np.empty(len(y_pred))
+        ranks[order] = np.arange(1, len(y_pred) + 1)
+        pos = y_true == 1
+        n1, n0 = pos.sum(), (~pos).sum()
+        return float((ranks[pos].sum() - n1 * (n1 + 1) / 2) / (n1 * n0))
+
+    auc.greater_is_better = True
+    m = ChimeraBoostClassifier(n_estimators=150, random_state=0,
+                               eval_metric=auc,
+                               cross_features=False).fit(X, y)
+    hist = m.validation_history_
+    # Stored negated: -AUC of a learning model lives in (-1, -0.5).
+    assert all(-1.0 <= v <= 0.0 for v in hist)
+    assert min(hist) < -0.7
+    proba = m.predict_proba(X[:20])
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0)
+
+
+def test_eval_metric_multiclass():
+    rng = np.random.default_rng(22)
+    X = rng.normal(size=(1500, 4))
+    y = np.argmax(X[:, :3] + 0.5 * rng.normal(size=(1500, 3)), axis=1)
+
+    def brier(Y_onehot, P):
+        return float(np.mean(np.sum((Y_onehot - P) ** 2, axis=1)))
+
+    m = ChimeraBoostClassifier(n_estimators=120, random_state=0,
+                               eval_metric=brier,
+                               cross_features=False).fit(X, y)
+    assert len(m.validation_history_) > 0
+    assert m.predict_proba(X[:10]).shape == (10, 3)
+
+
+def test_eval_metric_validation():
+    X = np.random.default_rng(0).normal(size=(100, 3))
+    y = X[:, 0]
+    with pytest.raises(ValueError, match="eval_metric"):
+        ChimeraBoostRegressor(eval_metric="rmse").fit(X, y)
+
+
+def test_eval_metric_none_bit_identical():
+    # The hook must not perturb the default path at all.
+    X, y = _reg_data(seed=23)
+    kw = dict(n_estimators=100, random_state=0)
+    a = ChimeraBoostRegressor(**kw).fit(X, y)
+    b = ChimeraBoostRegressor(eval_metric=None, **kw).fit(X, y)
+    np.testing.assert_array_equal(a.predict(X[:100]), b.predict(X[:100]))


### PR DESCRIPTION
Phase 3 backlog top pick: the custom objective + eval_metric hook, which unlocks the classic extra regression losses for free.

## What
- **Custom objectives.** `ChimeraBoostRegressor(loss=<instance>)` accepts a user objective: subclass `chimeraboost.CustomObjective`, implement `grad_hess(y, raw)` and `eval(y, raw, sample_weight=None)`, optionally override `init` / `transform`. Works through the whole stack — quantized histograms, MVS subsampling, bagging (picklable, worker processes), pickling. RMSE-only machinery (linear-leaf audition, cross-feature selection) correctly stays off for custom losses.
- **Four new built-in losses** on the same protocol: `"Huber"` (`delta`, fixed transition in y units) and the log-link family `"Poisson"` / `"Gamma"` / `"Tweedie"` (`tweedie_variance_power` in (1,2)). The regressor's `predict` now applies the loss link (`exp` for these; identity — same array, zero cost — for existing losses). y-domain violations (negative counts, non-positive gamma targets) raise clear errors at fit.
- **`eval_metric`** on both estimators: `metric(y_true, y_pred[, sample_weight]) -> float` scored on the validation set each round, driving early stopping and the internal selections instead of the training loss. A `greater_is_better = True` attribute is honored by negating the stored series, so every internal min()-based comparison is untouched.

## Safety
- **Bit-identical on defaults.** String losses take the exact old registry path; `eval_metric=None` scores validation exactly as before. The numerical-identity goldens are green, and a new test proves a `CustomObjective` reimplementation of squared error produces byte-identical predictions to `loss="RMSE"` on the same pinned config.
- No benchmark-relevant behavior changes, so no /experiment gate: the decision suites run defaults only (RMSE / Logloss, no eval_metric), which are exact-identity — the same class of change as H3's uniform-weight collapse.
- 546 tests green (21 new in `tests/test_custom_objectives.py`): convergence-vs-baseline for each new loss on matched synthetic noise models, Huber outlier robustness, log-link positivity + staged/pickle equality, y-domain and param validation, bagged custom-objective pickling, greater-is-better negation equivalence, weighted-metric threading.

## Docs
`docs/parameters.md` (loss table + eval_metric), `docs/recipes.md` (log-link recipe + custom objective example), CHANGELOG under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jf5H6AVHQx1FeMHjECDCFy