### PR TITLE
refit_full: opt-in full-data refit of the ES winner (all /experiment gates PASS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to ChimeraBoost are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+### Added
+- **``refit_full`` (default ``False``): full-data refit of the early-stopped
+  winner.** The automatic early-stopping split holds out 20% of the training
+  rows that the final model otherwise never learns from; with
+  ``refit_full=True`` the winning configuration (selected linear-leaf
+  variant, cross pairs, resolved learning rate) is retrained on 100% of the
+  rows at the selected budget, rounds scaled by the train-size ratio.
+  Temperature scaling transfers; ``validation_history_`` keeps the
+  early-stopped fit's curve. No-ops (bit-identical) with an explicit
+  ``eval_set``, ``early_stopping=False``, ``loss="Quantile"`` (its conformal
+  offset needs a genuine holdout), and inside bagged members (their OOB rows
+  are already an external eval set). Costs about one extra fit.
+  Evidence (benchmarks/REFIT_PLAN.md): Grinsztajn 48W-11L +2.0% (Brier
+  18W-5L +2.4%), high-card 10W-3L (Brier 8W-0L), OpenML one-shot 26W-8L
+  +1.3%, synth screen 95W-39L +1.0%.
+
 ## [0.24.0] - 2026-07-24
 ### Added
 - **Custom objectives.** The regressor's ``loss`` accepts a user objective

--- a/benchmarks/REFIT_PLAN.md
+++ b/benchmarks/REFIT_PLAN.md
@@ -1,0 +1,62 @@
+# REFIT — full-data refit of the ES winner (pre-registered 2026-07-24)
+
+## Mechanism
+
+The single-model auto fit carves `validation_fraction=0.2` for early stopping,
+selection and calibration; the shipped model never trains on those rows — a
+permanent 20% data tax. Once ES/selection/calibration have done their jobs,
+refit the winning configuration on 100% of the training data at the selected
+budget. Same family as AutoGluon `refit_full` and sklearn CV-then-refit; the
+bagging program's law ("more effective data per member beats sampling
+diversity" — B-samp, B2a) is the in-house precedent.
+
+## Design (implemented as `refit_full`, default False for the A/B)
+
+- Triggers ONLY on the auto-split path (early stopping active, no user
+  `eval_set`). Explicit eval_set / early_stopping=False / bag members
+  (explicit member OOB eval) / too-small-to-split: bit-identical no-op.
+- Quantile loss: no-op (the conformal offset's validity needs a genuine
+  holdout; refitting under it would silently break coverage).
+- Refit config = winner config pinned: selected linear_leaves variant,
+  selected cross_pairs, resolved lr (auto-lr would re-resolve at the new n and
+  change what T* means). Size-adaptive autos (mcw, cat_combinations) re-resolve
+  at full n by design.
+- Rounds: `ceil(T* / (1 - validation_fraction))` — the probe's refitX arm
+  (rounds scaled by the train-size ratio) beat plain T* on 8/10 sets
+  (+3.98% vs +3.43% mean). Fallback pre-registered: if tier 1 shows a loss
+  tail attributable to over-extension, drop to plain T* and re-screen.
+- Calibration transfer: temperature (clf) and CQR offset (reg quantile — moot,
+  no-op) are fit on the ES winner's val scores as today and applied to the
+  refit model's raw scores. `validation_history_` keeps the ES fit's curve.
+- User callbacks observe the ES fits only, not the refit (documented).
+
+## Probe evidence (benchmarks/probe_fulldata_refit.py, 10 sets x 3 seeds,
+config-pinned: cross off, reg ll=False)
+
+10/10 datasets improved; refit +3.43% mean, refitX +3.98%. Concentrated where
+learning curves are steep: cpu_act +10.2%, pol +6.7%, covertype +7.7%,
+electricity +4.6%, wine_quality +3.4%. Caveat carried forward: shipped-config
+deltas will be smaller where crosses/LL already fix the same underfit.
+
+## Pre-registered predictions
+
+- Tier 1 (synth screen): broad positive on the primary metric; effect
+  concentrated in small-n and high-signal/complex slices (steep learning
+  curves). Canaries exactly flat is NOT expected (this lever changes real
+  fits) — but at-ceiling sets should show no OVERFIT regression cluster.
+  Kill if: mean negative, or a systematic loss cluster in low-noise slices
+  (= T* transfer overfits without the ES safety net).
+- Tier 2: Grinsztajn AND hc sign tests, separately; expect broad wins on
+  both (mechanism is regime-independent). Fit cost expected ~+40-80% single
+  (one extra winner-length fit, no per-round val evals); speed verdict goes
+  to the Pareto refresh.
+- Gate: --openml one-shot, non-negative required.
+
+## Arms
+
+- BASE: current library, defaults (flag off; library byte-identical to main).
+- VARIANT: `--chimera-refit-full` (harness flag) => refit_full=True.
+
+## Results log
+
+(appended as runs complete)

--- a/benchmarks/REFIT_PLAN.md
+++ b/benchmarks/REFIT_PLAN.md
@@ -99,3 +99,10 @@ the DEFAULT FLIP (accuracy vs ×1.98 single-model fit) is Nathan's
 sign-off per the ship rules (precedent: cross_features 7.9× accepted
 "as long as we are Pareto and all python"). Ens8/bag members have no
 data tax — bagged points unchanged.
+
+**DECISION (Nathan, 2026-07-24): ship as an opt-in accuracy option
+(like `n_ensembles`), NOT the default.** Default stays `False`;
+documented in docs/parameters.md + recipes.md. Consequently no pareto
+or README refresh (the chart measures defaults, which are unchanged)
+and no TabArena re-read needed. The spliced 73.7%/93.0% single-model
+headline stays a plan-file fact, not a chart claim.

--- a/benchmarks/REFIT_PLAN.md
+++ b/benchmarks/REFIT_PLAN.md
@@ -59,4 +59,43 @@ deltas will be smaller where crosses/LL already fix the same underfit.
 
 ## Results log
 
-(appended as runs complete)
+- 2026-07-24 tests: 556 green (10 new in tests/test_refit_full.py);
+  default-off paths bit-identical by construction + test.
+- **Tier 1 (synth screen) PASS**: base 20260724-125452 vs variant
+  20260724-125608 (worktree results/): **95W-39L-2T, mean +1.023%**
+  (sign bar 69, p≈0). Attribution: reg +2.19% (40-8), binary +0.17%
+  (p=.04), multi +0.72%; n<2000 +1.27% vs n>=2000 +0.89% (steep-curve
+  concentration as predicted); canaries flat (0-1-2, −0.16%); no
+  low-noise overfit cluster (noise_level t=−0.47); saturated slice
+  −0.84% p=.61 = the at-ceiling zone, noise-level. Fallback (drop the
+  rounds scaling) NOT triggered.
+- **Tier 2 Grinsztajn PASS**: certified base 20260723-192007
+  (fingerprint 27/27 exact) vs variant 20260724-125955:
+  **48W-11L, mean +2.000%** primary; **Brier 18W-5L +2.428%**; worst
+  loss −0.29% (credit). The reg CatBoost-gap cluster collapses:
+  Brazilian_houses +18.4/+19.8%, sulfur +11.3%, visualizing_soil
+  +13.5%, cpu_act +6.6%, pol +5.8%, superconduct +4.4%.
+  **Fit cost: ChimeraBoost summed 492→974 s = ×1.98** (the refit is a
+  second winner-length fit at 1.25× rows; expected).
+- **Tier 2 hc PASS**: certified base 20260720-210906 (fingerprint 12/12
+  exact) vs variant 20260724-130543: **10W-3L-1T, mean +0.571%**;
+  **Brier 8W-0L sweep** (the CatBoost high-card Brier regime). Losses:
+  eucalyptus −2.06%, okcupid −1.16% (both multiclass, small), Moneyball
+  −0.62%. Pooled gr+hc: 58W-14L-1T, ≈+1.73% dataset-weighted.
+- **OpenML one-shot gate PASS**: certified base 20260720-212313
+  (fingerprint 30/30 exact) vs variant 20260724-130721:
+  **26W-8L-2T, mean +1.270%** (worst loss diabetes −1.74%, 442-row toy).
+- **Headline (spliced 20260723-192007 field, control = fingerprinted
+  base): single win rate 55.7 → 73.7% (5-arm incl Ens8); external field
+  only 73.7 → 93.0%; CatBoost 50.9 → 43.4. Slowdown approx 4.9× →
+  ~9.7× (fit ×1.98) vs CatBoost 12.9× — CatBoost dominated on both
+  axes.** Canonical 5-arm chart re-run deferred to the default-flip
+  decision.
+
+## Verdict
+
+All pre-registered gates PASS. Feature ships default-OFF in the PR;
+the DEFAULT FLIP (accuracy vs ×1.98 single-model fit) is Nathan's
+sign-off per the ship rules (precedent: cross_features 7.9× accepted
+"as long as we are Pareto and all python"). Ens8/bag members have no
+data tax — bagged points unchanged.

--- a/benchmarks/probe_fulldata_refit.py
+++ b/benchmarks/probe_fulldata_refit.py
@@ -1,0 +1,156 @@
+"""Full-data refit probe: reclaim the 20% early-stopping data tax.
+
+Zero library change, public API only. The shipped single-model fit carves a
+20% validation split for early stopping / calibration and the final model never
+trains on those rows. The bagging program's design law ("more effective data
+per member beats sampling diversity" — B-samp, B2a) suggests the single-model
+analog: once ES has picked the tree count, REFIT on 100% of the training data
+at that count and learning rate, transferring the calibration temperature.
+
+Arms per (dataset, seed), config-pinned so both arms are the same model class
+(cross_features=False; regression pins linear_leaves=False — both need a val
+split to self-select, which arm B doesn't have):
+  base    shipped fit on Xtr (auto 80/20 ES split inside)
+  refit   early_stopping=False, n_estimators = base's best iteration,
+          learning_rate = base's resolved lr, fit on ALL of Xtr;
+          clf Brier scored at base's temperature (logit/T transfer)
+  refitX  same but rounds scaled by 1/0.8 (T* transfer sensitivity check)
+
+Run from benchmarks/:  python probe_fulldata_refit.py [key-substring ...]
+"""
+import json
+import sys
+import time
+
+import numpy as np
+from sklearn.model_selection import train_test_split
+
+import chimeraboost
+from chimeraboost import ChimeraBoostClassifier, ChimeraBoostRegressor
+from chimeraboost.warmup import warmup
+import run_benchmarks as rb
+
+REG = [
+    "gr:reg_num/cpu_act",
+    "gr:reg_num/pol",
+    "gr:reg_num/wine_quality",
+    "gr:reg_num/elevators",
+    "gr:reg_cat/house_sales",
+]
+BIN = [
+    "gr:clf_num/electricity",
+    "gr:clf_num/covertype",
+    "gr:clf_num/MagicTelescope",
+    "gr:clf_num/heloc",
+    "gr:clf_cat/road-safety",
+]
+SEEDS = (0, 1, 2)
+
+
+def rmse(y, p):
+    return float(np.sqrt(np.mean((np.asarray(y, float) - p) ** 2)))
+
+
+def brier_at_temperature(model, X, y01, T):
+    """Brier of `model`'s probabilities rescaled to temperature T. The model
+    was fit without a val split, so its own temperature_ is 1.0 and its
+    predict_proba logits ARE the raw scores."""
+    p1 = np.clip(model.predict_proba(X)[:, 1], 1e-12, 1 - 1e-12)
+    logit = np.log(p1 / (1.0 - p1)) * model.temperature_   # back to raw
+    p = 1.0 / (1.0 + np.exp(-logit / T))
+    return float(np.mean((p - y01) ** 2))
+
+
+def run_one(key, seed, is_reg):
+    X, y, cat, task = rb.DATASETS[key](1, np.random.default_rng(0))
+    Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.25,
+                                          random_state=seed)
+    pins = dict(cross_features=False)
+    if is_reg:
+        pins["linear_leaves"] = False
+    Est = ChimeraBoostRegressor if is_reg else ChimeraBoostClassifier
+
+    t0 = time.perf_counter()
+    base = Est(random_state=seed, **pins)
+    base.fit(Xtr, ytr, cat_features=cat)
+    t_base = time.perf_counter() - t0
+
+    booster = base.model_
+    t_star = len(booster.trees_)
+    lr = float(booster.lr_)
+
+    def refit(n_rounds):
+        m = Est(random_state=seed, early_stopping=False,
+                n_estimators=int(n_rounds), learning_rate=lr, **pins)
+        t0 = time.perf_counter()
+        m.fit(Xtr, ytr, cat_features=cat)
+        return m, time.perf_counter() - t0
+
+    re1, t_re1 = refit(t_star)
+    rex, t_rex = refit(int(np.ceil(t_star / 0.8)))
+
+    if is_reg:
+        y_te = np.asarray(yte, dtype=np.float64)
+        m_base = rmse(y_te, base.predict(Xte))
+        m_re1 = rmse(y_te, re1.predict(Xte))
+        m_rex = rmse(y_te, rex.predict(Xte))
+    else:
+        y01 = (np.asarray(yte) == base.classes_[1]).astype(np.float64)
+        T = float(base.temperature_)
+        # base's predict_proba already applies its temperature; score directly.
+        p_base = base.predict_proba(Xte)[:, 1]
+        m_base = float(np.mean((p_base - y01) ** 2))
+        m_re1 = brier_at_temperature(re1, Xte, y01, T)
+        m_rex = brier_at_temperature(rex, Xte, y01, T)
+
+    return dict(dataset=key, seed=seed, task="reg" if is_reg else "bin",
+                metric_base=m_base, metric_refit=m_re1, metric_refitx=m_rex,
+                t_star=t_star, lr=lr, t_base=t_base, t_refit=t_re1,
+                t_refitx=t_rex)
+
+
+def main():
+    print(f"chimeraboost: {chimeraboost.__file__}", flush=True)
+    rb._add_grinsztajn_datasets()
+    print("Warmup...", flush=True)
+    warmup()
+    panel = [k for k in REG + BIN
+             if not sys.argv[1:] or any(a in k for a in sys.argv[1:])]
+    rows = []
+    for key in panel:
+        is_reg = key in REG
+        for seed in SEEDS:
+            r = run_one(key, seed, is_reg)
+            rows.append(r)
+            print(f"{key} s{seed}: base {r['metric_base']:.5f}  "
+                  f"refit {r['metric_refit']:.5f}  refitX {r['metric_refitx']:.5f}"
+                  f"  (T*={r['t_star']}, base {r['t_base']:.1f}s "
+                  f"refit {r['t_refit']:.1f}s)", flush=True)
+        with open("results/fulldata_refit_probe.json", "w") as f:
+            json.dump(rows, f, indent=1)
+
+    print("\n=== full-data refit aggregate (per-dataset means over seeds) ===")
+    print(f"{'dataset':34s} {'metric':6s} {'base':>9s} {'refit':>9s} "
+          f"{'refitX':>9s} {'refit%':>8s} {'refitX%':>8s}")
+    d1s, dxs = [], []
+    for key in panel:
+        sub = [r for r in rows if r["dataset"] == key]
+        mb = float(np.mean([r["metric_base"] for r in sub]))
+        m1 = float(np.mean([r["metric_refit"] for r in sub]))
+        mx = float(np.mean([r["metric_refitx"] for r in sub]))
+        d1 = (mb - m1) / mb * 100
+        dx = (mb - mx) / mb * 100
+        d1s.append(d1)
+        dxs.append(dx)
+        met = "rmse" if sub[0]["task"] == "reg" else "brier"
+        print(f"{key:34s} {met:6s} {mb:9.5f} {m1:9.5f} {mx:9.5f} "
+              f"{d1:+8.2f} {dx:+8.2f}")
+    w1 = sum(d > 0 for d in d1s)
+    wx = sum(d > 0 for d in dxs)
+    print(f"\nrefit : {w1}/{len(d1s)} datasets improved, mean {np.mean(d1s):+.2f}%")
+    print(f"refitX: {wx}/{len(dxs)} datasets improved, mean {np.mean(dxs):+.2f}%")
+    print("wrote results/fulldata_refit_probe.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/probe_leaf_resample.py
+++ b/benchmarks/probe_leaf_resample.py
@@ -1,0 +1,215 @@
+"""LRE probe: structure-shared leaf-resampled ensembling (DL-takeaway B).
+
+Zero library change. Question: how much of the bag's accuracy lift can an
+ensemble capture when members SHARE the fitted tree structures and differ only
+by re-estimating every leaf value on a resampled row subset? If a large share
+survives, ensemble-grade strength becomes available at a fraction of the bag's
+fit cost (members skip prep, selection, histograms and split search entirely).
+
+Per (dataset, seed): 75/25 train/test, then 80/20 fit/val inside train.
+Arms (all see the same fit+val data):
+  single  default estimator, explicit eval_set=(val)
+  bag8    n_ensembles=8 (blessed member auto-params), explicit eval_set
+  lre8    8 members re-estimated on 80% row subsamples of the fit rows with
+          the single model's structures; reg averages raw scores, clf averages
+          sigmoid(raw / single's temperature)
+Identity guard: a full-row re-estimation must reproduce the single model's
+test predictions (proves the recurrence mirrors the fit loop exactly).
+
+Capture = (single - lre8) / (single - bag8) on the primary metric
+(RMSE reg / Brier clf), per dataset over seed-mean metrics.
+
+Run from benchmarks/:  python probe_leaf_resample.py
+"""
+import json
+import time
+
+import numpy as np
+from sklearn.model_selection import train_test_split
+
+import chimeraboost
+from chimeraboost import ChimeraBoostClassifier, ChimeraBoostRegressor
+from chimeraboost.tree import _leaf_values, _linear_leaf_fit, _linear_predict
+from chimeraboost.warmup import warmup
+import run_benchmarks as rb
+
+REG = [
+    "gr:reg_num/cpu_act",
+    "gr:reg_num/pol",
+    "gr:reg_num/wine_quality",
+    "gr:reg_num/elevators",
+    "gr:reg_cat/house_sales",
+]
+BIN = [
+    "gr:clf_num/electricity",
+    "gr:clf_num/covertype",
+    "gr:clf_num/MagicTelescope",
+    "gr:clf_num/heloc",
+    "gr:clf_cat/road-safety",
+]
+SEEDS = (0, 1, 2)
+K = 8
+FRAC = 0.8
+
+
+def lre_raw_scores(booster, Xb, y, member_rows, Xb_te):
+    """Re-run the leaf-value recurrence for each member row set with the
+    booster's fixed tree structures. Returns a list of raw test-score arrays.
+
+    Mirrors the plain fit path exactly: first Newton step from the current
+    gradients, `leaf_estimation_iterations - 1` refinement steps on constant
+    trees, hessian-weighted ridge refit on linear-leaf trees. Ordered boosting,
+    leaf-adjusting losses and gradient subsampling are asserted off (defaults).
+    """
+    assert not booster.ordered_boosting
+    assert not getattr(booster.loss_, "adjusts_leaves", False)
+    loss, l2, lr = booster.loss_, booster.l2_leaf_reg, booster.lr_
+    lei = int(booster.leaf_estimation_iterations or 1)
+    n_te = Xb_te.shape[1]
+    # Per-member contiguous column subsets (linear-leaf refits index Xb by row).
+    Xb_m = [np.ascontiguousarray(Xb[:, rows]) for rows in member_rows]
+    y_m = [y[rows] for rows in member_rows]
+    F = [np.full(rows.size, booster.init_) for rows in member_rows]
+    raw_te = [np.full(n_te, float(booster.init_)) for _ in member_rows]
+    for tree in booster.trees_:
+        leaf_fit = tree.apply(Xb)
+        leaf_te = tree.apply(Xb_te)
+        n_lv = tree.values.shape[0]
+        for k, rows in enumerate(member_rows):
+            lf = np.ascontiguousarray(leaf_fit[rows])
+            g, h = loss.grad_hess(y_m[k], F[k])
+            if tree.lin_coef is not None:
+                coef = _linear_leaf_fit(lf, g, h, n_lv, tree.lin_feats,
+                                        tree.centers_std, Xb_m[k], l2,
+                                        booster.linear_lambda, lr)
+                F[k] += _linear_predict(lf, tree.lin_feats, coef,
+                                        tree.centers_std, Xb_m[k])
+                raw_te[k] += _linear_predict(leaf_te, tree.lin_feats, coef,
+                                             tree.centers_std, Xb_te)
+            else:
+                vals = _leaf_values(lf, g, h, n_lv, l2, lr)
+                for _ in range(lei - 1):
+                    g2, h2 = loss.grad_hess(y_m[k], F[k] + vals[lf])
+                    vals = vals + _leaf_values(lf, g2, h2, n_lv, l2, lr)
+                F[k] += vals[lf]
+                raw_te[k] += vals[leaf_te]
+    return raw_te
+
+
+def binned(booster, X):
+    return np.ascontiguousarray(booster.prep_.transform(X).T)
+
+
+def rmse(y, p):
+    return float(np.sqrt(np.mean((np.asarray(y, float) - p) ** 2)))
+
+
+def brier(y01, p):
+    return float(np.mean((p - y01) ** 2))
+
+
+def run_one(key, seed, is_reg):
+    X, y, cat, task = rb.DATASETS[key](1, np.random.default_rng(0))
+    Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.25,
+                                          random_state=seed)
+    Xfit, Xval, yfit, yval = train_test_split(Xtr, ytr, test_size=0.20,
+                                              random_state=seed)
+    Est = ChimeraBoostRegressor if is_reg else ChimeraBoostClassifier
+
+    t0 = time.perf_counter()
+    single = Est(random_state=seed)
+    single.fit(Xfit, yfit, cat_features=cat, eval_set=(Xval, yval))
+    t_single = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    bag = Est(random_state=seed, n_ensembles=K)
+    bag.fit(Xfit, yfit, cat_features=cat, eval_set=(Xval, yval))
+    t_bag = time.perf_counter() - t0
+
+    booster = single.model_
+    Xb = binned(booster, Xfit)
+    Xb_te = binned(booster, Xte)
+    if is_reg:
+        y_enc = np.asarray(yfit, dtype=np.float64)
+        y_te = np.asarray(yte, dtype=np.float64)
+    else:
+        y_enc = (np.asarray(yfit) == single.classes_[1]).astype(np.float64)
+        y_te = (np.asarray(yte) == single.classes_[1]).astype(np.float64)
+
+    # Identity guard: full-row re-estimation reproduces the fitted model.
+    n = Xb.shape[1]
+    full = lre_raw_scores(booster, Xb, y_enc, [np.arange(n)], Xb_te)[0]
+    ref = booster.predict_raw(Xte)
+    np.testing.assert_allclose(full, ref, rtol=1e-7, atol=1e-9)
+
+    t0 = time.perf_counter()
+    rng = np.random.default_rng(seed + 1000)
+    rows = [np.sort(rng.choice(n, int(FRAC * n), replace=False))
+            for _ in range(K)]
+    raws = lre_raw_scores(booster, Xb, y_enc, rows, Xb_te)
+    t_lre = time.perf_counter() - t0
+
+    if is_reg:
+        m_single = rmse(y_te, single.predict(Xte))
+        m_bag = rmse(y_te, bag.predict(Xte))
+        m_lre = rmse(y_te, np.mean(raws, axis=0))
+    else:
+        T = single.temperature_
+        probs = [1.0 / (1.0 + np.exp(-r / T)) for r in raws]
+        m_single = brier(y_te, single.predict_proba(Xte)[:, 1])
+        m_bag = brier(y_te, bag.predict_proba(Xte)[:, 1])
+        m_lre = brier(y_te, np.mean(probs, axis=0))
+
+    return dict(dataset=key, seed=seed, task="reg" if is_reg else "bin",
+                metric_single=m_single, metric_bag=m_bag, metric_lre=m_lre,
+                trees=len(booster.trees_), t_single=t_single, t_bag=t_bag,
+                t_lre=t_lre)
+
+
+def main():
+    import sys
+    print(f"chimeraboost: {chimeraboost.__file__}", flush=True)
+    rb._add_grinsztajn_datasets()
+    print("Warmup...", flush=True)
+    warmup()
+    panel = [k for k in REG + BIN
+             if not sys.argv[1:] or any(a in k for a in sys.argv[1:])]
+    rows = []
+    for key in panel:
+        is_reg = key in REG
+        for seed in SEEDS:
+            r = run_one(key, seed, is_reg)
+            rows.append(r)
+            print(f"{key} s{seed}: single {r['metric_single']:.5f}  "
+                  f"bag8 {r['metric_bag']:.5f}  lre8 {r['metric_lre']:.5f}  "
+                  f"({r['trees']} trees, lre {r['t_lre']:.1f}s vs "
+                  f"fit {r['t_single']:.1f}s / bag {r['t_bag']:.1f}s)",
+                  flush=True)
+        with open("results/lre_probe.json", "w") as f:
+            json.dump(rows, f, indent=1)
+
+    # Aggregate: per-dataset seed means, then capture fraction.
+    print("\n=== LRE probe aggregate (per-dataset means over seeds) ===")
+    print(f"{'dataset':34s} {'metric':6s} {'single':>9s} {'bag8':>9s} "
+          f"{'lre8':>9s} {'bagWin%':>8s} {'lreWin%':>8s} {'capture':>8s}")
+    caps = []
+    for key in panel:
+        sub = [r for r in rows if r["dataset"] == key]
+        ms = float(np.mean([r["metric_single"] for r in sub]))
+        mb = float(np.mean([r["metric_bag"] for r in sub]))
+        ml = float(np.mean([r["metric_lre"] for r in sub]))
+        d_bag = (ms - mb) / ms * 100
+        d_lre = (ms - ml) / ms * 100
+        cap = d_lre / d_bag if d_bag > 1e-12 else float("nan")
+        if np.isfinite(cap):
+            caps.append(cap)
+        met = "rmse" if sub[0]["task"] == "reg" else "brier"
+        print(f"{key:34s} {met:6s} {ms:9.5f} {mb:9.5f} {ml:9.5f} "
+              f"{d_bag:+8.2f} {d_lre:+8.2f} {cap:8.2f}")
+    print(f"\nmean capture fraction (lre share of bag lift): "
+          f"{np.mean(caps):.2f}  (n={len(caps)} datasets)")
+    print("wrote results/lre_probe.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -627,7 +627,8 @@ def _run_chimera(task, Xtr, ytr, Xte, yte, cat, threads, lr=None,
                  mcw=None,
                  cat_combinations=None, leaf_estimation_iterations=None,
                  linear_leaves=False, linear_lambda=1.0, cross_features=False,
-                 cat_smoothing=None, selection_rounds=None, quantize=False):
+                 cat_smoothing=None, selection_rounds=None, quantize=False,
+                 refit_full=False):
     t = time.time()
     Est = ChimeraBoostRegressor if task == "regression" else ChimeraBoostClassifier
     # None = use the class default. For ordered_boosting that's False (Reg) /
@@ -636,6 +637,8 @@ def _run_chimera(task, Xtr, ytr, Xte, yte, cat, threads, lr=None,
     kw = {} if ordered_boosting is None else {"ordered_boosting": ordered_boosting}
     if quantize:
         kw["quantize_gradients"] = True
+    if refit_full:
+        kw["refit_full"] = True
     if leaf_estimation_iterations is not None:
         kw["leaf_estimation_iterations"] = leaf_estimation_iterations
     if mcw is not None:
@@ -1164,6 +1167,11 @@ def main():
                     dest="no_linear_leaves",
                     help="force linear_leaves=False for both classes (ablation "
                          "arm vs the class defaults).")
+    ap.add_argument("--chimera-refit-full", action="store_true",
+                    dest="refit_full",
+                    help="refit_full=True on the single ChimeraBoost arm: "
+                         "retrain the ES winner on 100%% of train at the "
+                         "selected budget (REFIT_PLAN.md A/B arm).")
     ap.add_argument("--chimera-selection-rounds", type=int, default=None,
                     dest="selection_rounds",
                     help="cap the internal selection fits at this many rounds; "
@@ -1306,7 +1314,8 @@ def main():
                        else args.cross_features,
                        selection_rounds="full" if args.full_selection
                        else args.selection_rounds,
-                       quantize=args.chimera_quantize)
+                       quantize=args.chimera_quantize,
+                       refit_full=args.refit_full)
 
     # Split the thread budget across parallel jobs: GBDT thread scaling is
     # sublinear, so running J seeds at threads/J each beats one fit at all cores.

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -41,7 +41,7 @@ def _fit_temperature(raw, y, multiclass):
 _SKLEARN_ONLY = frozenset({"early_stopping", "validation_fraction",
                            "n_ensembles", "ensemble_n_jobs", "max_samples",
                            "cat_features", "cross_features",
-                           "selection_rounds"})
+                           "selection_rounds", "refit_full"})
 
 
 def _validate_hyperparams(estimator):
@@ -107,6 +107,9 @@ def _validate_hyperparams(estimator):
     if p.get("n_ensembles") is not None:
         _pos_int("n_ensembles")
     _in_range("max_samples", 0.0, 1.0, lo_incl=False)
+    v = p.get("refit_full")
+    if v is not None and not isinstance(v, (bool, np.bool_)):
+        raise ValueError(f"refit_full must be True, False or None; got {v!r}.")
     # Regressor-only loss / alpha (the classifier picks its loss automatically).
     if "loss" in p:
         loss = p["loss"]
@@ -949,6 +952,51 @@ def _stop_if_behind(k, target_best):
     return cb
 
 
+def _refit_on_full(est, winner, X_full, y_full, sw_full, cat_features, kw,
+                   loss_kwargs=None):
+    """Retrain ``winner``'s configuration on all rows (benchmarks/
+    REFIT_PLAN.md): rounds scaled by the train-size ratio, resolved learning
+    rate pinned so the early-stopped budget keeps its meaning, selected
+    linear-leaf variant and cross pairs carried over. The winner's ES curves
+    are copied so ``validation_history_`` keeps reporting the curve that
+    chose the budget. Size-adaptive autos (the classifier's min_child_weight,
+    cat_combinations) re-resolve at the full row count; user callbacks
+    observed the ES fits and are not re-run."""
+    t_star = len(winner.trees_)
+    rounds = min(int(np.ceil(t_star / (1.0 - est.validation_fraction))),
+                 int(est.n_estimators))
+    rkw = dict(kw)
+    rkw["n_estimators"] = rounds
+    rkw["early_stopping_rounds"] = None
+    rkw["learning_rate"] = float(winner.lr_)
+    # The classifier's auto min_child_weight is size-adaptive (the regressor
+    # resolves None to a flat 1.0 before kw is built).
+    if est.min_child_weight is None and loss_kwargs is None:
+        rkw["min_child_weight"] = _auto_min_child_weight(len(X_full))
+    if est.cat_combinations is None:
+        rkw["cat_combinations"] = _auto_cat_combinations(
+            cat_features, est.n_features_in_, len(X_full))
+    rkw.pop("linear_leaves", None)
+    if loss_kwargs is not None:      # scalar regressor path
+        b = GradientBoosting(loss=est.loss, loss_kwargs=loss_kwargs,
+                             linear_leaves=winner.linear_leaves,
+                             cross_pairs=winner.cross_pairs, **rkw)
+    elif getattr(est, "_multiclass", False):
+        b = MulticlassBoosting(linear_leaves=winner.linear_leaves,
+                               cross_pairs=winner.cross_pairs, **rkw)
+    else:
+        b = GradientBoosting(loss="Logloss",
+                             linear_leaves=winner.linear_leaves,
+                             cross_pairs=winner.cross_pairs, **rkw)
+    if est.verbose:
+        print(f"refit_full: retraining on all {len(X_full)} rows for "
+              f"{rounds} rounds (early stopping chose {t_star})")
+    b.fit(X_full, y_full, cat_features=cat_features, sample_weight=sw_full)
+    b.train_history_ = winner.train_history_
+    b.valid_history_ = winner.valid_history_
+    return b
+
+
 def _add_callback(callbacks, extra):
     """Compose the user callbacks argument (None, a callable, or a sequence)
     with one internal callback; extra=None returns callbacks unchanged."""
@@ -1107,6 +1155,16 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         only ~0.63n unique rows at n rows of compute). 1.0 restores the
         classic full-size with-replacement bootstrap. Unsampled rows are
         each member's early-stopping eval set either way.
+    refit_full : bool, default False
+        After the automatic early-stopping split has chosen the tree budget
+        (and model selection / calibration have used it), retrain the winning
+        configuration on 100% of the rows — rounds scaled by the train-size
+        ratio, learning rate pinned — so the final model does not pay the
+        holdout data tax. Only affects fits that used the automatic split
+        (an explicit ``eval_set`` or ``early_stopping=False`` is unchanged);
+        ``loss="Quantile"`` ignores it to keep its conformal holdout honest.
+        ``validation_history_`` keeps the early-stopped fit's curve. Costs
+        roughly one extra fit.
     cat_features : list of int or str, or None, default None
         Default categorical columns, given as integer positions and/or column
         names (names resolved against the DataFrame at fit). Used when ``fit`` is
@@ -1152,7 +1210,8 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                  early_stopping=True, validation_fraction=0.2,
                  n_ensembles=None, ensemble_n_jobs=-1, max_samples=0.8,
                  cat_features=None, quantize_gradients=True,
-                 eval_metric=None, delta=1.0, tweedie_variance_power=1.5):
+                 eval_metric=None, delta=1.0, tweedie_variance_power=1.5,
+                 refit_full=False):
         self.n_estimators = n_estimators
         self.learning_rate = learning_rate
         self.depth = depth
@@ -1186,6 +1245,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         self.ensemble_n_jobs = ensemble_n_jobs
         self.max_samples = max_samples
         self.quantize_gradients = quantize_gradients
+        self.refit_full = refit_full
 
     def fit(self, X, y, cat_features=None, eval_set=None, groups=None,
             sample_weight=None, callbacks=None):
@@ -1279,6 +1339,10 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                     UserWarning, stacklevel=2)
 
         es_active = bool(self.early_stopping)
+        # Kept for the optional full-data refit below: the auto split
+        # reassigns X/y, but the refit retrains on every row.
+        X_full, y_full, sw_full = X, y, sample_weight
+        auto_split = False
         if es_active and eval_set is None:
             split = _make_eval_split(
                 X, y, self.validation_fraction, self.random_state,
@@ -1287,6 +1351,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
             if split is None:
                 es_active = False  # data too small to hold out a val set
             else:
+                auto_split = True
                 train_idx, val_idx = split
                 if self.verbose and not getattr(self, "_is_bag_member", False):
                     print(f"early_stopping=True: holding out {len(val_idx)} "
@@ -1504,6 +1569,20 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                     resid.shape[0])
             if k >= 1:
                 self.quantile_offset_ = float(resid[k - 1])
+
+        # Full-data refit (benchmarks/REFIT_PLAN.md): the auto-split holdout
+        # is a pure data tax once early stopping, selection and calibration
+        # have consumed it — retrain the winning configuration on 100% of the
+        # rows at the selected budget, rounds scaled by the train-size ratio,
+        # the resolved learning rate pinned so the budget keeps its meaning.
+        # Only the auto-split path ever paid the tax (explicit eval_set /
+        # early_stopping=False are untouched); Quantile keeps its genuine
+        # conformal holdout instead.
+        if (self.refit_full and auto_split and self.loss != "Quantile"
+                and self.model_.trees_):
+            self.model_ = _refit_on_full(
+                self, self.model_, X_full, y_full, sw_full, cat_features, kw,
+                loss_kwargs=loss_kwargs)
         return self
 
     def _transform_raw(self, raw):
@@ -1726,6 +1805,16 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         only ~0.63n unique rows at n rows of compute). 1.0 restores the
         classic full-size with-replacement bootstrap. Unsampled rows are
         each member's early-stopping eval set either way.
+    refit_full : bool, default False
+        After the automatic early-stopping split has chosen the tree budget
+        (and model selection / temperature scaling have used it), retrain the
+        winning configuration on 100% of the rows — rounds scaled by the
+        train-size ratio, learning rate pinned — so the final model does not
+        pay the holdout data tax. Only affects fits that used the automatic
+        split (an explicit ``eval_set`` or ``early_stopping=False`` is
+        unchanged); the calibrated temperature transfers to the refit model.
+        ``validation_history_`` keeps the early-stopped fit's curve. Costs
+        roughly one extra fit.
     cat_features : list of int or str, or None, default None
         Default categorical columns, given as integer positions and/or column
         names (names resolved against the DataFrame at fit). Used when ``fit`` is
@@ -1765,7 +1854,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                  early_stopping=True, validation_fraction=0.2,
                  n_ensembles=None, ensemble_n_jobs=-1, max_samples=0.8,
                  cat_features=None, quantize_gradients=True,
-                 eval_metric=None):
+                 eval_metric=None, refit_full=False):
         self.n_estimators = n_estimators
         self.learning_rate = learning_rate
         self.depth = depth
@@ -1795,6 +1884,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         self.ensemble_n_jobs = ensemble_n_jobs
         self.max_samples = max_samples
         self.quantize_gradients = quantize_gradients
+        self.refit_full = refit_full
 
     def fit(self, X, y, cat_features=None, eval_set=None, groups=None,
             sample_weight=None, callbacks=None):
@@ -1887,6 +1977,10 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
             sample_weight = np.asarray(sample_weight, dtype=np.float64)
 
         es_active = bool(self.early_stopping)
+        # Kept for the optional full-data refit below: the auto split
+        # reassigns X/y, but the refit retrains on every row.
+        X_full, y_full, sw_full = X, y, sample_weight
+        auto_split = False
         if es_active and eval_set is None:
             split = _make_eval_split(
                 X, y, self.validation_fraction, self.random_state,
@@ -1895,6 +1989,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
             if split is None:
                 es_active = False  # data too small to hold out a val set
             else:
+                auto_split = True
                 train_idx, val_idx = split
                 if self.verbose and not getattr(self, "_is_bag_member", False):
                     print(f"early_stopping=True: holding out {len(val_idx)} "
@@ -2096,6 +2191,16 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         if cal_Xv is not None:
             raw = self.model_.predict_raw(cal_Xv)
             self.temperature_ = _fit_temperature(raw, cal_y, self._multiclass)
+
+        # Full-data refit (benchmarks/REFIT_PLAN.md): reclaim the auto-split
+        # data tax after early stopping, selection and temperature scaling
+        # have consumed the holdout. The temperature above was calibrated on
+        # the ES winner's validation scores and transfers to the refit model.
+        if self.refit_full and auto_split and self.model_.trees_:
+            y_refit = (y_full if self._multiclass else
+                       (y_full == self.classes_[1]).astype(np.float64))
+            self.model_ = _refit_on_full(
+                self, self.model_, X_full, y_refit, sw_full, cat_features, kw)
         return self
 
     def predict_proba(self, X):

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -84,6 +84,7 @@ The classifier picks its loss automatically: binary logloss for 2 classes, softm
 | `early_stopping` | `True` | Hold out a validation split and stop on a plateau. Set `False` to build a fixed `n_estimators` trees. |
 | `early_stopping_rounds` | `None`→`50` | Patience when early stopping is active. `50` is the sweet spot across the Grinsztajn suite; raising it to `100`–`300` helps only large, high-signal datasets (e.g. covertype, electricity, pol) and costs ~25–35% more trees, so it is not worth it as a default — bump it yourself for that kind of data. |
 | `validation_fraction` | `0.2` | Held-out fraction (stratified for classifiers). Ignored when `eval_set` is passed to `fit`. |
+| `refit_full` | `False` | Accuracy mode: after early stopping has chosen the tree budget on the automatic split, retrain the winning configuration on 100% of the rows at that budget (rounds scaled by the train-size ratio). Roughly doubles fit time; broad accuracy gain everywhere the automatic split ran. No effect with an explicit `eval_set`, `early_stopping=False`, `loss="Quantile"`, or inside bagged members. |
 
 See [Recipes → early stopping](recipes.md#early-stopping) for `eval_set` and `groups`.
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -169,6 +169,20 @@ Members fit in parallel worker processes by default, splitting the thread
 budget so a bagged fit uses the same cores a single fit would; pass
 `ensemble_n_jobs=1` to fit them sequentially instead.
 
+## Full-data refit
+
+`refit_full=True` is the cheaper accuracy lever: after early stopping has
+chosen the tree budget on the automatic validation split, the winning
+configuration is retrained on 100% of the rows at that budget, so the final
+model does not pay the 20% holdout data tax. About 2x fit time for a broad
+accuracy gain — largest on small or high-signal data. It composes with
+everything above but is a no-op inside bagged members (their held-out rows
+already serve as an external eval set).
+
+```python
+reg = ChimeraBoostRegressor(refit_full=True, random_state=0).fit(X_train, y_train)
+```
+
 `feature_importances_` and `shap_values` average across the bag automatically.
 
 ## Early stopping

--- a/tests/test_refit_full.py
+++ b/tests/test_refit_full.py
@@ -1,0 +1,123 @@
+"""Full-data refit (``refit_full=True``; benchmarks/REFIT_PLAN.md)."""
+
+import numpy as np
+import pytest
+
+from chimeraboost import ChimeraBoostClassifier, ChimeraBoostRegressor
+
+
+def _reg_data(n=3000, seed=0):
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((n, 6))
+    y = 2.0 * X[:, 0] + X[:, 1] * X[:, 2] + 0.3 * rng.standard_normal(n)
+    return X, y
+
+
+def _clf_data(n=3000, k=2, seed=0):
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((n, 6))
+    score = X[:, 0] + 0.5 * X[:, 1] * X[:, 2] + 0.5 * rng.standard_normal(n)
+    if k == 2:
+        y = (score > 0).astype(int)
+    else:
+        y = np.digitize(score, np.quantile(score, [1 / 3, 2 / 3]))
+    return X, y
+
+
+def test_default_off_is_identical():
+    X, y = _reg_data()
+    a = ChimeraBoostRegressor(n_estimators=100, random_state=0).fit(X, y)
+    b = ChimeraBoostRegressor(n_estimators=100, random_state=0,
+                              refit_full=False).fit(X, y)
+    np.testing.assert_array_equal(a.predict(X), b.predict(X))
+
+
+def test_refit_changes_predictions_and_extends_rounds():
+    X, y = _reg_data()
+    base = ChimeraBoostRegressor(n_estimators=200, random_state=0).fit(X, y)
+    re = ChimeraBoostRegressor(n_estimators=200, random_state=0,
+                               refit_full=True).fit(X, y)
+    t_star = len(base.model_.trees_)
+    expect = min(int(np.ceil(t_star / (1 - re.validation_fraction))), 200)
+    assert len(re.model_.trees_) == expect
+    assert not np.array_equal(base.predict(X), re.predict(X))
+    # The ES fit's curve is preserved for introspection.
+    assert re.validation_history_ == base.validation_history_
+
+
+def test_refit_trains_on_the_holdout_rows():
+    # The RMSE booster's init is the mean of ITS training targets: the base
+    # model's is the 80% split's mean, the refit's must be the full-data mean.
+    X, y = _reg_data(n=2500)
+    base = ChimeraBoostRegressor(n_estimators=100, random_state=0).fit(X, y)
+    re = ChimeraBoostRegressor(n_estimators=100, random_state=0,
+                               refit_full=True).fit(X, y)
+    assert re.model_.init_ == pytest.approx(float(np.mean(y)), abs=1e-12)
+    assert base.model_.init_ != pytest.approx(float(np.mean(y)), abs=1e-9)
+
+
+def test_noop_with_explicit_eval_set():
+    X, y = _reg_data()
+    ev = (X[:400], y[:400])
+    a = ChimeraBoostRegressor(n_estimators=100, random_state=0).fit(
+        X[400:], y[400:], eval_set=ev)
+    b = ChimeraBoostRegressor(n_estimators=100, random_state=0,
+                              refit_full=True).fit(X[400:], y[400:],
+                                                   eval_set=ev)
+    np.testing.assert_array_equal(a.predict(X), b.predict(X))
+
+
+def test_noop_without_early_stopping():
+    X, y = _reg_data()
+    a = ChimeraBoostRegressor(n_estimators=60, early_stopping=False,
+                              random_state=0).fit(X, y)
+    b = ChimeraBoostRegressor(n_estimators=60, early_stopping=False,
+                              random_state=0, refit_full=True).fit(X, y)
+    np.testing.assert_array_equal(a.predict(X), b.predict(X))
+
+
+def test_quantile_keeps_conformal_holdout():
+    X, y = _reg_data()
+    a = ChimeraBoostRegressor(loss="Quantile", alpha=0.9, n_estimators=80,
+                              random_state=0).fit(X, y)
+    b = ChimeraBoostRegressor(loss="Quantile", alpha=0.9, n_estimators=80,
+                              random_state=0, refit_full=True).fit(X, y)
+    np.testing.assert_array_equal(a.predict(X), b.predict(X))
+    assert b.quantile_offset_ == a.quantile_offset_
+
+
+def test_binary_classifier_refit_and_temperature_transfer():
+    X, y = _clf_data()
+    base = ChimeraBoostClassifier(n_estimators=150, random_state=0).fit(X, y)
+    re = ChimeraBoostClassifier(n_estimators=150, random_state=0,
+                                refit_full=True).fit(X, y)
+    assert re.temperature_ == base.temperature_   # calibrated pre-refit
+    p = re.predict_proba(X)
+    assert p.shape == (len(X), 2)
+    assert not np.array_equal(base.predict_proba(X), p)
+    assert len(re.model_.trees_) >= len(base.model_.trees_)
+
+
+def test_multiclass_refit():
+    X, y = _clf_data(k=3)
+    re = ChimeraBoostClassifier(n_estimators=120, random_state=0,
+                                refit_full=True).fit(X, y)
+    base = ChimeraBoostClassifier(n_estimators=120, random_state=0).fit(X, y)
+    assert re.predict_proba(X).shape == (len(X), 3)
+    assert set(np.unique(re.predict(X))) <= set(np.unique(y))
+    assert len(re.model_.trees_) >= len(base.model_.trees_)
+
+
+def test_bagged_members_unaffected():
+    X, y = _reg_data(n=2500)
+    a = ChimeraBoostRegressor(n_estimators=80, random_state=0,
+                              n_ensembles=3, ensemble_n_jobs=1).fit(X, y)
+    b = ChimeraBoostRegressor(n_estimators=80, random_state=0, n_ensembles=3,
+                              ensemble_n_jobs=1, refit_full=True).fit(X, y)
+    np.testing.assert_array_equal(a.predict(X), b.predict(X))
+
+
+def test_refit_full_validation():
+    X, y = _reg_data(n=500)
+    with pytest.raises(ValueError, match="refit_full"):
+        ChimeraBoostRegressor(refit_full="yes").fit(X, y)


### PR DESCRIPTION
## What

New `refit_full` parameter (both estimators, **default False — opt-in by decision**, like `n_ensembles`): after the automatic early-stopping split has chosen the tree budget — and selection / temperature scaling / conformal calibration have consumed the holdout — retrain the winning configuration on **100% of the training rows** at the selected budget (rounds scaled by the train-size ratio, resolved learning rate pinned, selected linear-leaf variant and cross pairs carried over). The calibrated temperature transfers to the refit model.

The mechanism: the auto split is a permanent 20% data tax on the final model. Bit-identical no-ops: explicit `eval_set`, `early_stopping=False`, `loss="Quantile"` (keeps its conformal holdout honest), bagged members (their OOB eval set is already external). Costs ~one extra fit (measured ×1.98 summed on Grinsztajn).

## Evidence (pre-registered: benchmarks/REFIT_PLAN.md)

| Gate | Result |
|---|---|
| Synth screen (136 sets) | 95W-39L-2T, +1.02% — mechanism-consistent (small-n concentration, canaries flat) |
| Grinsztajn (59 sets) | **48W-11L, +2.00%** primary; Brier 18W-5L +2.43%; worst loss −0.29% |
| High-card (14 sets) | 10W-3L-1T, +0.57%; **Brier 8W-0L sweep** |
| OpenML one-shot | 26W-8L-2T, +1.27% |

The historic regression CatBoost-gap cluster collapses: Brazilian_houses +18–20%, sulfur +11.3%, visualizing_soil +13.5%, cpu_act +6.6%, pol +5.8%.

With the flag on, the single model's head-to-head win rate in the certified 5-arm field goes **55.7% → 73.7%** (external field only: **93.0%**) at ~10× slowdown vs CatBoost's 12.9× — recorded in the plan file as the opt-in headline (the shipped chart measures defaults, which are unchanged).

Also in this branch: the LRE probe (structure-shared leaf-resampled ensembling — clean kill, capture −0.14; the bag's lift is structural diversity) and the full-data-refit probe, both recorded in `benchmarks/`.

## Decision record

Nathan (2026-07-24): ship as an **opt-in accuracy option, not the default**. Docs added (parameters.md, recipes.md). No pareto/README/TabArena refresh needed — defaults are byte-identical.

556 tests green (10 new in `tests/test_refit_full.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jf5H6AVHQx1FeMHjECDCFy
