### PR TITLE
Fix compare_runs' near-solved mean (+ A2 Phase 0 record)

### DIFF
--- a/.claude/skills/experiment/SKILL.md
+++ b/.claude/skills/experiment/SKILL.md
@@ -47,6 +47,11 @@ Ship rules:
   (user accepted 7.9× for cross_features: "as long as we are Pareto and all python").
 - Near-solved guards (`summarize.NEAR_SOLVED_NRMSE`, Brier `skip_best_below`) exist because
   %-vs-best explodes when best→0 — don't chase wins/losses on near-solved sets.
+  `compare_runs.py` applies the same guard to its MEAN (and prints a median beside it);
+  excluded sets are named in the output. Its sign test and PASS/FAIL bar still count every
+  dataset, so the guard can't flip a verdict recorded in an older plan file — `--keep-near-solved`
+  reproduces pre-fix numbers when auditing one. Every suite has such sets (gr: visualizing_soil,
+  SGEMM; hc: cjs; oml: mushroom, nursery), so read the median whenever the mean looks wild.
 - Bit-identical refactors: goldens + numerical-identity tests must pass exactly; keep old kernels
   as oracle tests when replacing kernels.
 

--- a/benchmarks/A2_PLAN.md
+++ b/benchmarks/A2_PLAN.md
@@ -110,10 +110,87 @@ deliverable either way.
 - Race fidelity at k=100 is *better* here than for constant-vs-linear, because
   depth changes the curve's whole trajectory rather than its late shape.
 
+## Phase 0 RESULTS (2026-07-25) — pre-registered A2 KILLED on cost
+
+Run: `python benchmarks/a2_phase0.py --seeds 3 --out a2-phase0`, 13 PMLB tune
+sets × 3 seeds × 4 configs = 156 fits. Full record in
+`benchmarks/results/a2-phase0.{json,md}` (gitignored).
+
+**Measurement guard applied.** `pm:tune/nursery` is solved to numerical zero
+(Brier ~1e-49 for every configuration) and manufactured a −8×10²¹% "mean
+delta" on the first pass. It is dropped by summarize.py's own near-solved
+convention (classification best Brier < 1e-3; regression best NRMSE < 0.02),
+leaving 36 of 39 cells. Everything below is on the retained cells.
+
+| bar | quantity | value | verdict |
+|---|---|--:|---|
+| B | test-oracle headroom (ceiling) | +2.587% | **PASS** (≥ +0.50%) |
+| A | validation-selected headroom, mean | +0.522% | **PASS** (≥ +0.30%) |
+| A | validation-selected win rate | 70.0% (21W-9L-6T) | **PASS** (≥ 55%) |
+| C | race fidelity @ k=100 | 83.3%, 0.119% regret | **PASS** (≥75%, ≤0.15%) |
+| D | projected fit-time multiple | **1.90×** | **FAIL** (≤ 1.35×) |
+
+Validation selection is real but weak: it recovers only **20% of the oracle
+ceiling**, and the sign test over cells is 21W-9L-6T, p=0.043. Median gain
++0.358%.
+
+**Why it dies: three extra auditions cost too much.** A k=100 audition is
+nearly a whole fit whenever the full fit is short, which is common here (mean
+323–382 rounds, and multiclass fits run ~100 rounds on the decision panel).
+Racing four configurations lands at 1.90×, far outside the bar.
+
+### What survives (POST-HOC — proves nothing until re-validated)
+
+Same curves, cheaper portfolios. Selection bias applies: these subsets were
+chosen knowing this panel, and seven-way subset search makes a p=0.012 worth
+roughly 0.08 after a Bonferroni correction.
+
+| portfolio | mean % | median % | W-L-T | p | cost k=50 | cost k=100 |
+|---|--:|--:|--:|--:|--:|--:|
+| **default+d4** | +0.398% | +0.000% | 16W-4L-16T | 0.012 | **1.12×** | **1.24×** |
+| default+d4+sub08 | +0.844% | +0.230% | 20W-9L-7T | 0.061 | 1.29× | 1.58× |
+| default+sub08 | +0.681% | +0.000% | 11W-10L-15T | 1.000 | 1.17× | 1.34× |
+| default+d8 | −0.125% | +0.000% | 6W-4L-26T | 0.754 | 1.16× | 1.32× |
+
+A two-way depth race (6 vs 4) clears every bar including cost. `d8` is simply
+bad here (12W-24L on its own) and belongs in no portfolio.
+
+### The size caveat that decides whether this transfers
+
+The gain is concentrated on small data, which is exactly where this project
+has been burned before ("small panels invert knob verdicts"):
+
+| n_train band | datasets | mean % vs default |
+|---|---|--:|
+| under 2,000 | SWD, LEV, contraceptive, yeast, segmentation | +1.09% to +7.41% |
+| 2,000–5,000 | hypothyroid, churn, texture | −5.52% to +0.22% |
+| over 4,900 | wind, puma8NH, coil2000, house_8L | +0.12% to +0.64% |
+
+On the larger half of the panel the gain collapses to roughly +0.1% to +0.6%,
+and the Grinsztajn and high-card suites are larger still. Two losses are
+genuine, not near-solved artifacts (hypothyroid Brier 0.026–0.039, texture
+0.014–0.023) — validation genuinely mispicks there. Note also that relative
+Brier deltas amplify small absolute gaps on easy multiclass sets, so the
+sign test is the trustworthy reading and the mean is not.
+
+### Verdict
+
+**A2 as pre-registered is KILLED at Phase 0** — Bar D fired and the plan
+required all four bars. The honest residual is narrower than the idea that
+was registered: not a config portfolio, but a **two-way depth race (6 vs 4)
+at k=50–100**, worth about +0.4% on small-to-mid data for 1.12–1.24× fit,
+with the transfer question unresolved because this panel skews small.
+
+That variant is a legitimate Phase 1 candidate but it was selected post hoc,
+so it is not evidence yet. It only becomes real if it survives the untouched
+instruments: synth screen → Grinsztajn + high-card (sign-tested separately)
+→ OpenML one-shot gate. **Nathan's call whether that is worth the run.**
+
 ## Phases
 
-- [ ] **Phase 0** — offline headroom + race simulation on PMLB tune
+- [x] **Phase 0** — offline headroom + race simulation on PMLB tune
       (`benchmarks/a2_phase0.py`). Bars A–D. No source change.
+      **Done 2026-07-25: A2 killed on cost; two-way depth race survives.**
 - [ ] **Phase 1** — if Phase 0 passes: implement the config race inside the
       existing `selection_rounds` audition, default-off flag, byte-identical
       when off, numerical-identity goldens green.

--- a/benchmarks/A2_PLAN.md
+++ b/benchmarks/A2_PLAN.md
@@ -1,0 +1,121 @@
+# A2 — config-portfolio audition on the early-stopping split
+
+Pre-registered before any result was read (the A1_PLAN / REFIT_PLAN convention:
+design, predictions and kill bars first, evidence appended after).
+
+## Why
+
+ChimeraBoost already selects *structure* on the early-stopping split — constant
+vs linear leaves, plain vs cross-augmented, and since 0.15 it does so through a
+cheap capped audition (`selection_rounds=100`). That pattern has shipped five
+times. What it has never been pointed at is *capacity*: `depth`, row subsampling
+and friends are fixed global constants chosen once on Grinsztajn.
+
+The external evidence for making capacity per-dataset is the strongest of the
+remaining program items: TabRepo (2311.02971) reports AutoGluon-1.0's portfolio
+of a handful of configurations reaching ~75% win rate against tuned single
+configs, and Better-by-Default (2407.04491) finds the best default *differs by
+task type* — regression wants deeper trees than classification, and row
+subsampling belongs on. A portfolio raced on our existing audition machinery is
+the GBDT-side analog of the in-context adaptation that makes tabular foundation
+models strong on unseen data, which is what this whole program is chasing.
+
+**Honest prior against it.** Our own PMLB random-search study found that broad
+hyperparameter tuning buys essentially nothing that transfers: the search winner
+*anti*-generalized (−1.87% out of sample) and only `min_child_weight` carried
+transferable signal — and the classifier already makes that one size-adaptive.
+A2 is not refuted by that result, because A2 does not claim a better global
+default; it claims that picking per dataset on held-out validation data beats
+any fixed choice. But the study says the headroom is probably thin, so Phase 0
+exists to measure the headroom before a line of library source changes.
+
+## Instrument — and a protocol call
+
+A2 is a hyperparameter question, so Phase 0 runs on the **PMLB tuning fold**
+(`pm:tune/*`, 13 sets: 5 regression, 3 binary, 5 multiclass) — the one suite
+this project tunes hyperparameters against. Grinsztajn, the high-card suite and
+the OpenML gate are **not** touched in Phase 0; measuring accuracy headroom on
+a decision suite and then designing to it would be tuning on the instrument that
+later has to judge the result. TabArena stays sealed as always.
+
+If Phase 0 passes, the change goes through the normal `/experiment` protocol:
+synthetic screen (tier 1) → Grinsztajn + high-card, sign-tested separately
+(tier 2) → OpenML one-shot gate.
+
+Phase 0 mirrors the decision-suite protocol exactly: same loaders, same
+`train_test_split(test_size=0.25, random_state=seed)`, same
+`rng = default_rng(1000 + seed)`, same shared budget (2000 rounds, patience 50),
+and `fit(X, y)` with **no** explicit eval_set so every fit uses the estimator's
+own internal early-stopping split — out-of-box default behavior.
+
+## The portfolio
+
+Four configurations, everything not named left at the shipped default:
+
+| id | config | why it is in the portfolio |
+|---|---|---|
+| `default` | `depth=6` | the shipped default, the incumbent |
+| `d4` | `depth=4` | shallower for small/noisy targets |
+| `d8` | `depth=8` | Better-by-Default: regression wants more capacity |
+| `sub08` | `depth=6, subsample=0.8` | Better-by-Default: row subsampling on |
+
+Each is fit to full early stopping so its whole validation curve is recorded;
+the race is then simulated **offline** from those curves at several budgets.
+No library source changes in Phase 0.
+
+## What Phase 0 measures
+
+1. **Test oracle headroom** — per-cell best config by *test* metric vs the
+   fixed default. The ceiling: nothing downstream can beat this.
+2. **Validation-selected headroom** — pick by lowest full-early-stopping
+   validation loss (ties to `default`), then read that pick's *test* metric.
+   This is what A2 could actually deliver, and it is the number that matters.
+3. **Race fidelity at k** — would judging on only the first k rounds of each
+   curve pick the same config as the full fits, for k in {50, 100, 200, 500}?
+   Plus the test regret conceded when it mispicks.
+4. **Cost** — measured fit seconds per config, and the projected fit-time
+   multiple of a k-round audition per extra portfolio member.
+
+## Pre-registered kill bars
+
+All four must hold for A2 to proceed to a library implementation.
+
+- **Bar A — capturable headroom.** Validation-selected config beats the fixed
+  default by **≥ +0.30% mean** on the primary metric across cells, and wins in
+  **≥ 55%** of non-tied cells. (Calibration: the program's own estimate is that
+  ~+0.25% broad ≈ +12pp of head-to-head win rate, so +0.30% is a real Pareto
+  move rather than noise.)
+- **Bar B — oracle sanity.** Test-oracle headroom **≥ +0.50%**. If even the
+  cheating oracle cannot clear this, there is nothing worth racing and A2 dies
+  regardless of Bar A.
+- **Bar C — race fidelity.** At k=100 the raced pick reproduces the full-fit
+  validation pick on **≥ 75%** of cells with **≤ 0.15% mean test regret**. This
+  is the known trap: the constant-vs-linear race already mispicks about a third
+  of regression selections because those curves genuinely cross late.
+- **Bar D — cost.** Projected default fit-time multiple **≤ 1.35×**. The Pareto
+  point must move up more than it moves right; at today's 4.9× slowdown, 1.35×
+  lands near 6.6× and the strength gain has to pay for that.
+
+Failing Bar A or B is a **KILL** and gets written into the ledger as such —
+seven of the last seven categorical levers died this way and the record is the
+deliverable either way.
+
+## Predictions (stated before the run)
+
+- Test-oracle headroom clears Bar B, mostly on the multiclass sets (5 of 13),
+  where the shipped defaults have had the least tuning attention.
+- Validation selection recovers well under half of the oracle — small PMLB
+  validation splits are noisy, and the oracle is fit on the test metric.
+- Bar A is the coin flip and the one most likely to kill A2.
+- Race fidelity at k=100 is *better* here than for constant-vs-linear, because
+  depth changes the curve's whole trajectory rather than its late shape.
+
+## Phases
+
+- [ ] **Phase 0** — offline headroom + race simulation on PMLB tune
+      (`benchmarks/a2_phase0.py`). Bars A–D. No source change.
+- [ ] **Phase 1** — if Phase 0 passes: implement the config race inside the
+      existing `selection_rounds` audition, default-off flag, byte-identical
+      when off, numerical-identity goldens green.
+- [ ] **Phase 2** — `/experiment`: synth screen → Grinsztajn + high-card →
+      OpenML one-shot gate. Default flip is Nathan's call, as always.

--- a/benchmarks/a2_phase0.py
+++ b/benchmarks/a2_phase0.py
@@ -1,0 +1,331 @@
+"""A2 Phase 0 — config-portfolio headroom + offline race simulation.
+
+Pre-registered design and kill bars: benchmarks/A2_PLAN.md.
+
+Fits every portfolio configuration to full early stopping on the PMLB TUNING
+fold (the one suite this project tunes hyperparameters against — Grinsztajn,
+the high-card suite, the OpenML gate and TabArena are all untouched here), and
+records each fit's whole validation curve, its test metrics and its wall time.
+The race is then simulated offline from those curves, so no library source
+changes and no extra fits are needed to answer "what budget would we need".
+
+Protocol mirrors the decision suites exactly: same loaders, same
+default_rng(1000 + seed), same 25% test split, same shared budget, and
+fit(X, y) with NO explicit eval_set so every fit uses the estimator's own
+internal early-stopping split (out-of-box default behavior).
+
+    python benchmarks/a2_phase0.py --seeds 3 --out a2-phase0
+    python benchmarks/a2_phase0.py --report-only --out a2-phase0
+"""
+import argparse
+import io
+import json
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import numpy as np
+from sklearn.model_selection import train_test_split
+
+import run_benchmarks as rb
+from chimeraboost import ChimeraBoostClassifier, ChimeraBoostRegressor
+
+# Everything not named here stays at the shipped default.
+PORTFOLIO = {
+    "default": dict(depth=6),
+    "d4":      dict(depth=4),
+    "d8":      dict(depth=8),
+    "sub08":   dict(depth=6, subsample=0.8),
+}
+RACE_BUDGETS = (50, 100, 200, 500)
+
+
+def _loss(task, metrics):
+    """Lower-is-better primary loss, on the north-star convention:
+    RMSE for regression, Brier for classification."""
+    return metrics["rmse"] if task == "regression" else metrics["brier"]
+
+
+def _pct_better(task, base, cand):
+    """Percent by which `cand` improves on `base` (positive = cand better)."""
+    b, c = _loss(task, base), _loss(task, cand)
+    return 100.0 * (b - c) / b if b else 0.0
+
+
+def run(args):
+    rb._add_pmlb_datasets()
+    keys = args.datasets or [k for k in rb.DATASETS if k.startswith("pm:tune/")]
+    keys.sort()
+
+    print("Warmup (compiling numba kernels)...")
+    from chimeraboost.warmup import warmup
+    warmup()
+    print(f"chimeraboost from: {__import__('chimeraboost').__file__}")
+
+    threads = args.threads or os.cpu_count() or 1
+    records = []
+    for key in keys:
+        for seed in range(args.seeds):
+            rng = np.random.default_rng(1000 + seed)
+            X, y, cat, task = rb.DATASETS[key](args.scale, rng)
+            strat = y if task != "regression" else None
+            Xtr, Xte, ytr, yte = train_test_split(
+                X, y, test_size=0.25, random_state=seed, stratify=strat)
+            for cfg_id, cfg in PORTFOLIO.items():
+                Est = (ChimeraBoostRegressor if task == "regression"
+                       else ChimeraBoostClassifier)
+                m = Est(n_estimators=rb.MAX_ITERS,
+                        early_stopping_rounds=rb.PATIENCE,
+                        thread_count=threads, random_state=0, **cfg)
+                t0 = time.time()
+                m.fit(Xtr, ytr, cat_features=cat)
+                secs = time.time() - t0
+                metrics = rb._compute_metrics(task, yte, m, Xte)
+                hist = [float(v) for v in (m.validation_history_ or [])]
+                records.append({
+                    "dataset": key, "seed": seed, "task": task,
+                    "config": cfg_id, "secs": secs,
+                    "n_train": int(Xtr.shape[0]),
+                    "rmse": metrics.get("rmse"),
+                    "brier": metrics.get("brier"),
+                    "f1_macro": metrics.get("f1_macro"),
+                    "valid_history": hist,
+                    "rounds": len(hist),
+                })
+                print(f"  {key} seed{seed} {cfg_id:8s} "
+                      f"loss={_loss(task, metrics):.5f} "
+                      f"rounds={len(hist):4d} {secs:6.1f}s")
+
+    out = {"portfolio": {k: v for k, v in PORTFOLIO.items()},
+           "seeds": args.seeds, "records": records}
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                        "results", f"{args.out}.json")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as fh:
+        json.dump(out, fh)
+    print(f"\nwrote {path}")
+    return out
+
+
+# --------------------------------------------------------------------------
+# Offline analysis
+# --------------------------------------------------------------------------
+def _cells(records):
+    """Group records into (dataset, seed) cells -> {config: record}."""
+    cells = {}
+    for r in records:
+        cells.setdefault((r["dataset"], r["seed"]), {})[r["config"]] = r
+    return cells
+
+
+def _pick_by_val(cell, k=None):
+    """Lowest best-validation-loss config; ties go to `default` (the incumbent
+    rule everywhere else in this codebase)."""
+    best_id, best_val = "default", np.inf
+    for cfg_id, r in cell.items():
+        h = r["valid_history"]
+        if not h:
+            continue
+        v = min(h[:k]) if k else min(h)
+        if v < best_val:
+            best_id, best_val = cfg_id, v
+        elif v == best_val and cfg_id == "default":
+            best_id = cfg_id
+    return best_id
+
+
+def report(data):
+    records = data["records"]
+    cells = _cells(records)
+    lines = []
+
+    def emit(s=""):
+        print(s)
+        lines.append(s)
+
+    emit("# A2 Phase 0 - config-portfolio headroom (PMLB tune fold)")
+    emit()
+    emit(f"{len(cells)} cells (dataset x seed), "
+         f"{len(PORTFOLIO)} configs, seeds={data['seeds']}")
+    emit()
+
+    # ---- per-config summary vs default -----------------------------------
+    emit("## Each configuration vs the shipped default")
+    emit()
+    emit("| config | mean % vs default | wins | losses | ties | mean fit s |")
+    emit("|---|--:|--:|--:|--:|--:|")
+    for cfg_id in PORTFOLIO:
+        deltas, w, l, t, secs = [], 0, 0, 0, []
+        for cell in cells.values():
+            if cfg_id not in cell or "default" not in cell:
+                continue
+            d = _pct_better(cell[cfg_id]["task"], cell["default"], cell[cfg_id])
+            deltas.append(d)
+            secs.append(cell[cfg_id]["secs"])
+            if d > 0:
+                w += 1
+            elif d < 0:
+                l += 1
+            else:
+                t += 1
+        emit(f"| {cfg_id} | {np.mean(deltas):+.3f}% | {w} | {l} | {t} | "
+             f"{np.mean(secs):.1f} |")
+    emit()
+
+    # ---- Bars A and B ----------------------------------------------------
+    oracle_d, valsel_d, valsel_w, valsel_l, valsel_t = [], [], 0, 0, 0
+    pick_counts, oracle_counts = {}, {}
+    for cell in cells.values():
+        if "default" not in cell:
+            continue
+        task = cell["default"]["task"]
+        best = min(cell.values(), key=lambda r: _loss(r["task"], r))
+        oracle_d.append(_pct_better(task, cell["default"], best))
+        oracle_counts[best["config"]] = oracle_counts.get(best["config"], 0) + 1
+        pick = _pick_by_val(cell)
+        pick_counts[pick] = pick_counts.get(pick, 0) + 1
+        d = _pct_better(task, cell["default"], cell[pick])
+        valsel_d.append(d)
+        if d > 0:
+            valsel_w += 1
+        elif d < 0:
+            valsel_l += 1
+        else:
+            valsel_t += 1
+
+    non_tied = valsel_w + valsel_l
+    win_rate = 100.0 * valsel_w / non_tied if non_tied else 0.0
+    bar_a = np.mean(valsel_d) >= 0.30 and win_rate >= 55.0
+    bar_b = np.mean(oracle_d) >= 0.50
+
+    emit("## Bars A and B - is there headroom, and can validation see it?")
+    emit()
+    emit("| quantity | value | bar | verdict |")
+    emit("|---|--:|---|---|")
+    emit(f"| Test-oracle headroom (ceiling) | {np.mean(oracle_d):+.3f}% "
+         f"| >= +0.50% | {'PASS' if bar_b else 'FAIL'} |")
+    emit(f"| Validation-selected headroom | {np.mean(valsel_d):+.3f}% "
+         f"| >= +0.30% | {'PASS' if np.mean(valsel_d) >= 0.30 else 'FAIL'} |")
+    emit(f"| Validation-selected win rate | {win_rate:.1f}% "
+         f"({valsel_w}W-{valsel_l}L-{valsel_t}T) | >= 55% "
+         f"| {'PASS' if win_rate >= 55.0 else 'FAIL'} |")
+    emit()
+    emit(f"Oracle picks: {oracle_counts}")
+    emit(f"Validation picks: {pick_counts}")
+    emit()
+    recovered = (100.0 * np.mean(valsel_d) / np.mean(oracle_d)
+                 if np.mean(oracle_d) else 0.0)
+    emit(f"Validation selection recovers {recovered:.0f}% of the oracle.")
+    emit()
+
+    # ---- Bar C — race fidelity ------------------------------------------
+    emit("## Bar C - would a capped race pick the same configuration?")
+    emit()
+    emit("| k rounds | agreement with full-fit pick | mean test regret |")
+    emit("|--:|--:|--:|")
+    bar_c = False
+    for k in RACE_BUDGETS:
+        agree, regrets = 0, []
+        for cell in cells.values():
+            if "default" not in cell:
+                continue
+            full_pick = _pick_by_val(cell)
+            race_pick = _pick_by_val(cell, k=k)
+            if race_pick == full_pick:
+                agree += 1
+            else:
+                task = cell["default"]["task"]
+                regrets.append(max(0.0, _pct_better(task, cell[race_pick],
+                                                    cell[full_pick])))
+        n = len([c for c in cells.values() if "default" in c])
+        ag = 100.0 * agree / n if n else 0.0
+        mean_regret = float(np.sum(regrets) / n) if n else 0.0
+        if k == 100:
+            bar_c = ag >= 75.0 and mean_regret <= 0.15
+        emit(f"| {k} | {ag:.1f}% | {mean_regret:.3f}% |")
+    emit()
+
+    # ---- Bar D — cost ----------------------------------------------------
+    emit("## Bar D - projected cost")
+    emit()
+    per_cfg_secs, per_cfg_rounds = {}, {}
+    for cfg_id in PORTFOLIO:
+        rs = [r for r in records if r["config"] == cfg_id]
+        per_cfg_secs[cfg_id] = float(np.mean([r["secs"] for r in rs]))
+        per_cfg_rounds[cfg_id] = float(np.mean([r["rounds"] for r in rs]))
+    base_secs = per_cfg_secs["default"]
+    # An audition costs k rounds of its config's per-round cost; the winner
+    # still runs its own full fit (the fallback design already in the library).
+    extra = 0.0
+    for cfg_id in PORTFOLIO:
+        if cfg_id == "default":
+            continue
+        per_round = per_cfg_secs[cfg_id] / max(per_cfg_rounds[cfg_id], 1)
+        extra += per_round * min(100, per_cfg_rounds[cfg_id])
+    projected = (base_secs + extra) / base_secs
+    bar_d = projected <= 1.35
+    emit("| config | mean fit s | mean rounds |")
+    emit("|---|--:|--:|")
+    for cfg_id in PORTFOLIO:
+        emit(f"| {cfg_id} | {per_cfg_secs[cfg_id]:.1f} | "
+             f"{per_cfg_rounds[cfg_id]:.0f} |")
+    emit()
+    emit(f"Projected fit-time multiple with 3 extra k=100 auditions: "
+         f"{projected:.2f}x (bar <= 1.35x) "
+         f"{'PASS' if bar_d else 'FAIL'}")
+    emit()
+    # Diagnostic only -- the bar above stays as pre-registered. This says what a
+    # cheaper portfolio shape would cost, to inform a Phase 1 redesign if the
+    # headroom bars pass. An audition is only cheap when the full fit runs many
+    # more than k rounds, which is exactly what short multiclass fits do not do.
+    emit("Cost of cheaper portfolio shapes (diagnostic, not the bar):")
+    emit()
+    emit("| extra configs | k=50 | k=100 |")
+    emit("|---|--:|--:|")
+    others = [c for c in PORTFOLIO if c != "default"]
+    for n_extra in (1, 2, 3):
+        row = []
+        for k in (50, 100):
+            cost = 0.0
+            for cfg_id in others[:n_extra]:
+                per_round = per_cfg_secs[cfg_id] / max(per_cfg_rounds[cfg_id], 1)
+                cost += per_round * min(k, per_cfg_rounds[cfg_id])
+            row.append(f"{(base_secs + cost) / base_secs:.2f}x")
+        emit(f"| {n_extra} | {row[0]} | {row[1]} |")
+    emit()
+
+    emit("## Verdict")
+    emit()
+    for name, ok in (("A (capturable headroom)", bar_a),
+                     ("B (oracle sanity)", bar_b),
+                     ("C (race fidelity @ k=100)", bar_c),
+                     ("D (cost)", bar_d)):
+        emit(f"- Bar {name}: {'PASS' if ok else 'FAIL'}")
+    emit()
+    emit("**A2 PROCEEDS**" if all((bar_a, bar_b, bar_c, bar_d))
+         else "**A2 KILLED at Phase 0**")
+    return "\n".join(lines)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--seeds", type=int, default=3)
+    ap.add_argument("--scale", type=float, default=1.0)
+    ap.add_argument("--threads", type=int, default=0)
+    ap.add_argument("--datasets", nargs="*")
+    ap.add_argument("--out", default="a2-phase0")
+    ap.add_argument("--report-only", action="store_true")
+    args = ap.parse_args()
+
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                        "results", f"{args.out}.json")
+    data = json.load(open(path)) if args.report_only else run(args)
+    text = report(data)
+    with io.open(path.replace(".json", ".md"), "w", encoding="utf-8") as fh:
+        fh.write(text + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/a2_phase0.py
+++ b/benchmarks/a2_phase0.py
@@ -88,6 +88,10 @@ def run(args):
                     "dataset": key, "seed": seed, "task": task,
                     "config": cfg_id, "secs": secs,
                     "n_train": int(Xtr.shape[0]),
+                    # Target scale, so the near-solved regression guard can be
+                    # applied downstream (same rule as summarize.py).
+                    "y_std": (float(np.std(y)) if task == "regression"
+                              else None),
                     "rmse": metrics.get("rmse"),
                     "brier": metrics.get("brier"),
                     "f1_macro": metrics.get("f1_macro"),
@@ -120,6 +124,53 @@ def _cells(records):
     return cells
 
 
+def _retain(cells):
+    """Drop near-perfectly-solved cells, using summarize.py's exact convention:
+    classification cells whose best Brier is below 1e-3, and regression cells
+    whose best NRMSE (best RMSE / target std) is below NEAR_SOLVED_NRMSE.
+
+    This is not optional bookkeeping. On such a cell every configuration scores
+    a practically-zero loss, so the ratio between two of them is pure numerical
+    noise -- pm:tune/nursery lands at a Brier of ~1e-49 and manufactured a
+    -8e21% "mean delta" before this guard was applied.
+    """
+    from summarize import NEAR_SOLVED_NRMSE
+    keep, dropped = {}, []
+    for key, cell in cells.items():
+        losses = [_loss(r["task"], r) for r in cell.values()]
+        task = next(iter(cell.values()))["task"]
+        if task == "regression":
+            y_std = next(iter(cell.values())).get("y_std")
+            near = bool(y_std) and (min(losses) / y_std) < NEAR_SOLVED_NRMSE
+        else:
+            near = min(losses) < 1e-3
+        if near:
+            dropped.append(key)
+        else:
+            keep[key] = cell
+    return keep, dropped
+
+
+def _sign_test(deltas, eps=0.0):
+    """Wins/losses/ties + two-sided binomial p, on deltas where positive means
+    the variant is better (mirrors research/cascade.sign_test, sign flipped)."""
+    import math
+    wins = sum(1 for d in deltas if d > eps)
+    losses = sum(1 for d in deltas if d < -eps)
+    ties = len(deltas) - wins - losses
+    n = wins + losses
+    if n == 0:
+        return dict(wins=wins, losses=losses, ties=ties, n=n, p=1.0)
+    try:
+        from scipy.stats import binomtest
+        p = binomtest(min(wins, losses), n, 0.5,
+                      alternative="two-sided").pvalue
+    except Exception:
+        z = abs(wins - losses) / math.sqrt(n)
+        p = math.erfc(z / math.sqrt(2))
+    return dict(wins=wins, losses=losses, ties=ties, n=n, p=float(p))
+
+
 def _pick_by_val(cell, k=None):
     """Lowest best-validation-loss config; ties go to `default` (the incumbent
     rule everywhere else in this codebase)."""
@@ -145,10 +196,19 @@ def report(data):
         print(s)
         lines.append(s)
 
+    all_cells = cells
+    cells, dropped = _retain(cells)
+
     emit("# A2 Phase 0 - config-portfolio headroom (PMLB tune fold)")
     emit()
-    emit(f"{len(cells)} cells (dataset x seed), "
+    emit(f"{len(cells)} cells (dataset x seed) retained of {len(all_cells)}, "
          f"{len(PORTFOLIO)} configs, seeds={data['seeds']}")
+    if dropped:
+        emit()
+        emit(f"Dropped as near-perfectly solved (summarize.py convention): "
+             f"{sorted({d[0] for d in dropped})} "
+             f"({len(dropped)} cells). Every configuration scores a "
+             f"practically-zero loss there, so percentage deltas are noise.")
     emit()
 
     # ---- per-config summary vs default -----------------------------------
@@ -202,15 +262,20 @@ def report(data):
 
     emit("## Bars A and B - is there headroom, and can validation see it?")
     emit()
+    st = _sign_test(valsel_d)
     emit("| quantity | value | bar | verdict |")
     emit("|---|--:|---|---|")
     emit(f"| Test-oracle headroom (ceiling) | {np.mean(oracle_d):+.3f}% "
          f"| >= +0.50% | {'PASS' if bar_b else 'FAIL'} |")
-    emit(f"| Validation-selected headroom | {np.mean(valsel_d):+.3f}% "
+    emit(f"| Validation-selected headroom (mean) | {np.mean(valsel_d):+.3f}% "
          f"| >= +0.30% | {'PASS' if np.mean(valsel_d) >= 0.30 else 'FAIL'} |")
+    emit(f"| Validation-selected headroom (median) | "
+         f"{np.median(valsel_d):+.3f}% | - | - |")
     emit(f"| Validation-selected win rate | {win_rate:.1f}% "
          f"({valsel_w}W-{valsel_l}L-{valsel_t}T) | >= 55% "
          f"| {'PASS' if win_rate >= 55.0 else 'FAIL'} |")
+    emit(f"| Sign test vs default | {st['wins']}W-{st['losses']}L-"
+         f"{st['ties']}T, p={st['p']:.3f} | - | - |")
     emit()
     emit(f"Oracle picks: {oracle_counts}")
     emit(f"Validation picks: {pick_counts}")
@@ -294,6 +359,78 @@ def report(data):
                 cost += per_round * min(k, per_cfg_rounds[cfg_id])
             row.append(f"{(base_secs + cost) / base_secs:.2f}x")
         emit(f"| {n_extra} | {row[0]} | {row[1]} |")
+    emit()
+
+    # ---- secondary: cheaper sub-portfolios -------------------------------
+    # POST-HOC. The pre-registered portfolio is the four configs above; this
+    # section asks what a cheaper subset would have delivered on the SAME
+    # curves, because Bar D is the only bar the full portfolio failed. Picking
+    # a subset by its score on this panel is a garden-of-forking-paths risk, so
+    # nothing here is evidence on its own -- any subset carried forward must be
+    # re-validated out of sample by the /experiment protocol (synth screen ->
+    # Grinsztajn + high-card -> OpenML one-shot gate).
+    emit("## Secondary (POST-HOC) - what would a cheaper subset have done?")
+    emit()
+    emit("Same curves, no new fits. Selection bias applies: these subsets are")
+    emit("chosen with knowledge of this panel and prove nothing until they are")
+    emit("re-validated out of sample.")
+    emit()
+    emit("| portfolio | mean % | median % | W-L-T | p | k=50 fidelity | cost k=50 | cost k=100 |")
+    emit("|---|--:|--:|--:|--:|--:|--:|--:|")
+    from itertools import combinations
+    others = [c for c in PORTFOLIO if c != "default"]
+    subsets = []
+    for n in range(1, len(others) + 1):
+        subsets.extend(combinations(others, n))
+    for extra in subsets:
+        members = ("default",) + extra
+        deltas, agree50 = [], 0
+        for cell in cells.values():
+            sub = {k: v for k, v in cell.items() if k in members}
+            if "default" not in sub:
+                continue
+            task = sub["default"]["task"]
+            pick = _pick_by_val(sub)
+            deltas.append(_pct_better(task, sub["default"], sub[pick]))
+            if _pick_by_val(sub, k=50) == pick:
+                agree50 += 1
+        s = _sign_test(deltas)
+        costs = []
+        for k in (50, 100):
+            c = 0.0
+            for cfg_id in extra:
+                per_round = per_cfg_secs[cfg_id] / max(per_cfg_rounds[cfg_id], 1)
+                c += per_round * min(k, per_cfg_rounds[cfg_id])
+            costs.append((base_secs + c) / base_secs)
+        emit(f"| default+{'+'.join(extra)} | {np.mean(deltas):+.3f}% | "
+             f"{np.median(deltas):+.3f}% | {s['wins']}W-{s['losses']}L-"
+             f"{s['ties']}T | {s['p']:.3f} | "
+             f"{100.0 * agree50 / max(len(deltas), 1):.0f}% | "
+             f"{costs[0]:.2f}x | {costs[1]:.2f}x |")
+    emit()
+
+    # ---- per-dataset breakdown ------------------------------------------
+    # The size question: this project has been burned before by small panels
+    # inverting knob verdicts. If the winning configuration tracks n_train,
+    # a per-dataset RACE is defensible where a global default flip is not.
+    emit("## Per-dataset breakdown (does the winner track dataset size?)")
+    emit()
+    emit("| dataset | task | n_train | validation picks | mean % vs default |")
+    emit("|---|---|--:|---|--:|")
+    by_ds = {}
+    for (ds, seed), cell in cells.items():
+        by_ds.setdefault(ds, []).append(cell)
+    for ds in sorted(by_ds, key=lambda d: by_ds[d][0]["default"]["n_train"]):
+        picks, deltas = {}, []
+        for cell in by_ds[ds]:
+            task = cell["default"]["task"]
+            p = _pick_by_val(cell)
+            picks[p] = picks.get(p, 0) + 1
+            deltas.append(_pct_better(task, cell["default"], cell[p]))
+        c0 = by_ds[ds][0]["default"]
+        pick_s = ", ".join(f"{k}x{v}" for k, v in sorted(picks.items()))
+        emit(f"| {ds.replace('pm:tune/', '')} | {c0['task'][:5]} | "
+             f"{c0['n_train']} | {pick_s} | {np.mean(deltas):+.3f}% |")
     emit()
 
     emit("## Verdict")

--- a/benchmarks/compare_runs.py
+++ b/benchmarks/compare_runs.py
@@ -15,29 +15,99 @@ hold the other models fixed, but the deltas are diluted).
 ChimeraBoost vs an arm's ChimeraBoostEns2).
 --metric brier judges on Brier instead: classification sets only (regression
 records carry no Brier), oriented so NEW wins = lower Brier.
+
+NEAR-SOLVED DATASETS
+--------------------
+A dataset every model solves to a practically-zero loss carries no information
+about a change, but it wrecks a RELATIVE mean: the ratio of two tiny numbers is
+numerical noise. Measured on a real historical screen, one such dataset
+(syn:v2/117, base Brier ~0) contributed -12555% by itself and dragged the
+reported mean of an 88-dataset comparison to -144.7% while the sign test read
+54 wins / 31 losses. The old floor here (`abs(base) > 1e-12`) only caught
+values that were literally zero to floating point, and silently scored them as
+0.0 -- everything in the wide band between 1e-12 and "actually solved" sailed
+through and distorted the mean.
+
+The exclusion now uses the same thresholds as the rest of the analysis stack
+(summarize.py, make_tables.py): regression drops when best NRMSE (RMSE / target
+std) is below NEAR_SOLVED_NRMSE, classification when best Brier is below
+NEAR_SOLVED_BRIER. Excluded datasets are always named in the output -- never
+dropped silently. `--keep-near-solved` restores the old unguarded arithmetic
+for auditing numbers quoted in older plan files.
+
+The SIGN TEST and its PASS/FAIL bar deliberately still run over every shared
+dataset, so this fix cannot silently flip a historical verdict. The sign test
+is sign-based and was never distorted by this. The retained-only sign test is
+printed alongside as a diagnostic, with a warning if the two disagree.
 """
 import argparse
 import json
+import os
+import sys
 from collections import defaultdict
 
 import numpy as np
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from summarize import NEAR_SOLVED_NRMSE  # noqa: E402  (shared with make_tables)
 
-def per_dataset_metric(path, model=None, metric="primary"):
-    recs = json.load(open(path))["records"]
+# Classification analog of NEAR_SOLVED_NRMSE, matching summarize.primary_scores.
+NEAR_SOLVED_BRIER = 1e-3
+
+
+def load_run(path, model=None, metric="primary"):
+    """(metric values, rmse, brier, dataset metadata), each keyed by dataset
+    and averaged over seeds. rmse/brier come along regardless of the compared
+    metric because the near-solved test needs them."""
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
     sign = -1.0 if metric == "brier" else 1.0   # orient higher = better
-    bucket = defaultdict(list)
-    for r in recs:
+    bucket, rmse, brier = defaultdict(list), defaultdict(list), defaultdict(list)
+    for r in data["records"]:
         if model is not None and r["model"] != model:
             continue
-        if r["metrics"].get(metric) is None:
+        m = r["metrics"]
+        if m.get("rmse") is not None:
+            rmse[r["dataset"]].append(m["rmse"])
+        if m.get("brier") is not None:
+            brier[r["dataset"]].append(m["brier"])
+        if m.get(metric) is None:
             continue
-        bucket[r["dataset"]].append(sign * r["metrics"][metric])
-    return {ds: float(np.mean(v)) for ds, v in bucket.items()}
+        bucket[r["dataset"]].append(sign * m[metric])
+
+    def _mean(d):
+        return {k: float(np.mean(v)) for k, v in d.items()}
+
+    return _mean(bucket), _mean(rmse), _mean(brier), data.get("datasets", {})
 
 
-def per_dataset_primary(path, model=None):
-    return per_dataset_metric(path, model, "primary")
+def is_near_solved(ds, ds_meta, rmse_b, rmse_n, brier_b, brier_n):
+    """Is `ds` solved well enough that a relative delta on it is meaningless?
+
+    Uses the best (lowest) loss either run achieved, mirroring summarize's
+    "best across models" rule.
+
+    The two rules degrade differently on an older JSON with no dataset
+    metadata, and deliberately so. The regression rule needs y_std to form an
+    NRMSE, so without it a dataset is never excluded. The Brier rule needs no
+    metadata at all -- a Brier below 1e-3 is solved whatever the record says --
+    so it still applies to anything that recorded one. Regression records carry
+    no Brier, so they cannot be caught by it accidentally.
+    """
+    meta = ds_meta.get(ds) or {}
+    if meta.get("task") == "regression":
+        y_std = meta.get("y_std")
+        vals = [v for v in (rmse_b.get(ds), rmse_n.get(ds)) if v is not None]
+        return bool(y_std) and bool(vals) and min(vals) / y_std < NEAR_SOLVED_NRMSE
+    vals = [v for v in (brier_b.get(ds), brier_n.get(ds)) if v is not None]
+    return bool(vals) and min(vals) < NEAR_SOLVED_BRIER
+
+
+def _sign_counts(pairs):
+    """(wins, losses, ties) over (base, new) pairs on a higher-is-better metric."""
+    wins = sum(1 for b, n in pairs if n - b > 1e-9)
+    losses = sum(1 for b, n in pairs if n - b < -1e-9)
+    return wins, losses, len(pairs) - wins - losses
 
 
 def main():
@@ -53,43 +123,79 @@ def main():
     ap.add_argument("--metric", choices=["primary", "brier"], default="primary",
                     help="judge metric; brier = classification only, "
                          "oriented so NEW wins = lower Brier.")
+    ap.add_argument("--keep-near-solved", action="store_true",
+                    help="do NOT exclude near-solved datasets from the mean "
+                         "(reproduces pre-fix numbers quoted in older plans).")
     args = ap.parse_args()
     base_label, new_label = args.base_label, args.new_label
 
-    base = per_dataset_metric(args.base_path, args.model, args.metric)
-    new = per_dataset_metric(args.new_path, args.model_new or args.model,
-                             args.metric)
+    base, rmse_b, brier_b, meta_b = load_run(
+        args.base_path, args.model, args.metric)
+    new, rmse_n, brier_n, meta_n = load_run(
+        args.new_path, args.model_new or args.model, args.metric)
+    ds_meta = {**meta_b, **meta_n}
     shared = sorted(set(base) & set(new))
+
+    near = set() if args.keep_near_solved else {
+        ds for ds in shared
+        if is_near_solved(ds, ds_meta, rmse_b, rmse_n, brier_b, brier_n)}
 
     wins = losses = ties = 0
     print(f"{'dataset':22s} {base_label:>12s} {new_label:>12s} {'delta':>12s}  result")
-    rel_deltas = []
+    rel_deltas, all_pairs = [], []
     for ds in shared:
         b, n = base[ds], new[ds]
         d = n - b                       # primary is higher-better
-        # relative improvement (guard tiny/zero base)
-        rel = d / abs(b) if abs(b) > 1e-12 else 0.0
-        rel_deltas.append(rel)
+        all_pairs.append((b, n))
         if d > 1e-9:
             wins += 1; tag = f"{new_label} wins"
         elif d < -1e-9:
             losses += 1; tag = f"{base_label} wins"
         else:
             ties += 1; tag = "tie"
+        if ds in near:
+            print(f"{ds:22s} {b:12.4f} {n:12.4f} {d:+12.4f}  {tag}  "
+                  f"(near-solved: excluded from mean)")
+            continue
+        # relative improvement (guard tiny/zero base)
+        rel = d / abs(b) if abs(b) > 1e-12 else 0.0
+        rel_deltas.append(rel)
         print(f"{ds:22s} {b:12.4f} {n:12.4f} {d:+12.4f}  {tag}  ({rel:+.2%})")
 
-    n = len(shared)
+    n_ds = len(shared)
     mtag = args.model or ""
     if args.model_new and args.model_new != args.model:
         mtag = f"{mtag}->{args.model_new}"
     print(f"\n{new_label} vs {base_label}: {wins} wins / {losses} losses / {ties} ties  "
-          f"(of {n} datasets)"
+          f"(of {n_ds} datasets)"
           + (f"  [model={mtag}]" if mtag else ""))
-    print(f"mean relative change in {args.metric} (+ = better): "
-          f"{np.mean(rel_deltas):+.3%}")
-    need = n // 2 + 1
+
+    if near:
+        print(f"excluded {len(near)} near-solved dataset(s) from the mean "
+              f"(regression NRMSE < {NEAR_SOLVED_NRMSE}, "
+              f"classification Brier < {NEAR_SOLVED_BRIER}): "
+              + ", ".join(sorted(near)))
+    if rel_deltas:
+        print(f"mean relative change in {args.metric} (+ = better): "
+              f"{np.mean(rel_deltas):+.3%}   "
+              f"[median {np.median(rel_deltas):+.3%}, n={len(rel_deltas)}]")
+    else:
+        print(f"mean relative change in {args.metric}: n/a (no scored datasets)")
+
+    need = n_ds // 2 + 1
     verdict = "PASS" if wins >= need else "FAIL"
     print(f"sign-test bar (> half = {need}+ wins): {verdict}")
+
+    # Diagnostic only: the bar above intentionally stays over ALL datasets so
+    # this guard cannot silently flip a verdict recorded in an older plan file.
+    if near:
+        kept = [p for ds, p in zip(shared, all_pairs) if ds not in near]
+        kw, kl, kt = _sign_counts(kept)
+        k_need = len(kept) // 2 + 1
+        k_verdict = "PASS" if kw >= k_need else "FAIL"
+        note = "" if k_verdict == verdict else "   <-- DISAGREES with the bar above"
+        print(f"  (excluding near-solved: {kw} wins / {kl} losses / {kt} ties, "
+              f"bar {k_need}+ = {k_verdict}){note}")
 
 
 if __name__ == "__main__":

--- a/tests/test_compare_runs.py
+++ b/tests/test_compare_runs.py
@@ -1,0 +1,138 @@
+"""compare_runs' near-solved guard.
+
+A dataset every model solves to a practically-zero loss carries no information
+about a change, but it destroys a RELATIVE mean: the ratio of two tiny numbers
+is numerical noise. On a real historical screen one such dataset (syn:v2/117)
+contributed -12555% alone and dragged an 88-dataset mean to -144.7% while the
+sign test read 54 wins / 31 losses.
+
+Contracts pinned here:
+  * near-solved datasets are excluded from the mean, by the same thresholds the
+    rest of the analysis stack uses (summarize.NEAR_SOLVED_NRMSE / 1e-3 Brier);
+  * they are NAMED in the output, never dropped silently;
+  * the sign test and its PASS/FAIL bar still count every shared dataset, so
+    the guard cannot silently flip a verdict recorded in an older plan file;
+  * --keep-near-solved reproduces the old unguarded arithmetic for auditing.
+
+Deterministic fixtures only -- no benchmark runs, no network.
+"""
+import json
+import os
+import sys
+
+import pytest
+
+BENCH = os.path.join(os.path.dirname(__file__), "..", "benchmarks")
+sys.path.insert(0, BENCH)
+
+import compare_runs  # noqa: E402
+
+
+def _write(tmp_path, name, brier_solved, brier_real, rmse_solved, rmse_real):
+    """One run JSON: two classification sets (one solved) and two regression
+    sets (one solved). y_std makes reg_solved's NRMSE 0.005 and reg_real's 0.1."""
+    datasets = {
+        "bin_solved": {"task": "binary"},
+        "bin_real": {"task": "binary"},
+        "reg_solved": {"task": "regression", "y_std": 100.0},
+        "reg_real": {"task": "regression", "y_std": 10.0},
+    }
+    records = [
+        {"dataset": "bin_solved", "model": "M", "seed": 0, "fit_time": 1.0,
+         "metrics": {"primary": 1.0, "brier": brier_solved}},
+        {"dataset": "bin_real", "model": "M", "seed": 0, "fit_time": 1.0,
+         "metrics": {"primary": 0.8, "brier": brier_real}},
+        {"dataset": "reg_solved", "model": "M", "seed": 0, "fit_time": 1.0,
+         "metrics": {"primary": -rmse_solved, "rmse": rmse_solved}},
+        {"dataset": "reg_real", "model": "M", "seed": 0, "fit_time": 1.0,
+         "metrics": {"primary": -rmse_real, "rmse": rmse_real}},
+    ]
+    path = os.path.join(str(tmp_path), name)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump({"datasets": datasets, "records": records}, fh)
+    return path
+
+
+@pytest.fixture
+def pair(tmp_path):
+    base = _write(tmp_path, "base.json", 1e-9, 0.20, 0.5, 1.0)
+    # bin_solved moves from 1e-9 to 1e-6: a 100000% relative "regression" that
+    # is entirely numerical noise. Everything else moves by a sane amount.
+    new = _write(tmp_path, "new.json", 1e-6, 0.19, 0.6, 0.9)
+    return base, new
+
+
+def test_near_solved_identified_by_shared_thresholds(pair):
+    base, new = pair
+    _, rmse_b, brier_b, meta = compare_runs.load_run(base, "M", "brier")
+    _, rmse_n, brier_n, _ = compare_runs.load_run(new, "M", "brier")
+    flag = lambda ds: compare_runs.is_near_solved(  # noqa: E731
+        ds, meta, rmse_b, rmse_n, brier_b, brier_n)
+    assert flag("bin_solved")      # Brier 1e-9 < 1e-3
+    assert not flag("bin_real")    # Brier 0.20
+    assert flag("reg_solved")      # NRMSE 0.005 < 0.02
+    assert not flag("reg_real")    # NRMSE 0.1
+
+
+def test_the_two_rules_degrade_differently_without_metadata(pair):
+    """On an older JSON with no dataset metadata the rules must differ, by
+    design: the regression rule cannot form an NRMSE without y_std and so
+    excludes nothing, while the Brier rule needs no metadata and still bites."""
+    base, new = pair
+    _, rmse_b, brier_b, _ = compare_runs.load_run(base, "M", "brier")
+    _, rmse_n, brier_n, _ = compare_runs.load_run(new, "M", "brier")
+    flag = lambda ds: compare_runs.is_near_solved(  # noqa: E731
+        ds, {}, rmse_b, rmse_n, brier_b, brier_n)
+    assert flag("bin_solved")        # Brier 1e-9 is solved, metadata or not
+    assert not flag("reg_solved")    # no y_std -> cannot judge -> kept
+
+
+def _main(capsys, monkeypatch, argv):
+    monkeypatch.setattr(sys, "argv", ["compare_runs.py"] + argv)
+    compare_runs.main()
+    return capsys.readouterr().out
+
+
+def test_solved_dataset_excluded_from_mean_and_named(pair, capsys, monkeypatch):
+    base, new = pair
+    out = _main(capsys, monkeypatch,
+                [base, new, "BASE", "NEW", "--model", "M", "--metric", "brier"])
+    assert "near-solved: excluded from mean" in out
+    assert "bin_solved" in out            # named, not silently dropped
+    # Only bin_real survives, at +5% (0.20 -> 0.19 Brier).
+    assert "+5.000%" in out
+    assert "n=1" in out
+
+
+def test_unguarded_mode_reproduces_the_old_blowup(pair, capsys, monkeypatch):
+    base, new = pair
+    out = _main(capsys, monkeypatch,
+                [base, new, "BASE", "NEW", "--model", "M", "--metric", "brier",
+                 "--keep-near-solved"])
+    assert "near-solved" not in out
+    # bin_solved's -99900% swamps bin_real's +5% -> a hugely negative mean.
+    line = [l for l in out.splitlines() if "mean relative change" in l][0]
+    assert "-49" in line or "-50" in line  # ~ -49947%
+
+
+def test_sign_test_bar_still_counts_every_dataset(pair, capsys, monkeypatch):
+    """The guard must not silently flip a verdict recorded in an older plan."""
+    base, new = pair
+    out = _main(capsys, monkeypatch,
+                [base, new, "BASE", "NEW", "--model", "M", "--metric", "brier"])
+    # 2 shared classification sets: bin_solved loses, bin_real wins.
+    assert "1 wins / 1 losses / 0 ties  (of 2 datasets)" in out
+    # ...and the retained-only sign test is reported alongside as a diagnostic.
+    assert "excluding near-solved: 1 wins / 0 losses" in out
+
+
+def test_regression_guard_uses_nrmse_not_raw_rmse(pair, capsys, monkeypatch):
+    """reg_solved has the SMALLER raw RMSE but is excluded on NRMSE; reg_real
+    has a larger RMSE and is kept. A raw-magnitude rule would get this wrong."""
+    base, new = pair
+    out = _main(capsys, monkeypatch,
+                [base, new, "BASE", "NEW", "--model", "M"])
+    rows = {l.split()[0]: l for l in out.splitlines()
+            if l and l.split()[0].startswith("reg_")}
+    assert "near-solved" in rows["reg_solved"]
+    assert "near-solved" not in rows["reg_real"]


### PR DESCRIPTION
Two benchmarks-only changes. **No library change** — 569 tests pass.

---

# 1. Bug fix: `compare_runs.py` reported a meaningless mean

`compare_runs` is the tool every `/experiment` ship decision runs through, and the ship rule is *"decisive sign test **+ mean improvement** on Grinsztajn AND a **non-negative** OpenML gate"* — so the mean is load-bearing. It had **no near-solved guard at all**, while `summarize.py` and `make_tables.py` both do.

### Demonstrated on a real historical screen

`synv2-baseline` vs `synv2-depth4`, `--metric brier`:

| | mean | median | note |
|---|--:|--:|---|
| before | **−144.741%** | — | sign test simultaneously read 54W / 31L **PASS** |
| after | **−2.140%** | +0.409% | 3 excluded sets named in the output |

A single dataset caused it: `syn:v2/117` has a base Brier of ~0 and contributed **−12,555%** on its own. The old floor (`abs(base) > 1e-12`) only caught values that were zero to floating point — and silently scored those as `0.0`. Everything in the band between 1e-12 and "actually solved" sailed straight through.

### Not a synthetic-only problem

Every suite has such datasets, including both decision suites and the gate:

| dataset | suite | flagged in | best loss |
|---|---|--:|---|
| `gr:reg_cat/visualizing_soil` | Grinsztajn | 53 runs | NRMSE 0.0047 |
| `gr:reg_cat/SGEMM_GPU_kernel_performance` | Grinsztajn | 51 runs | NRMSE 0.0145 |
| `hc:cjs` | high-card | 26 runs | Brier 1.6e-37 |
| `oml:mushroom` | OpenML gate | 24 runs | Brier 6.0e-62 |
| `oml:nursery` | OpenML gate | 16 runs | Brier 4.6e-42 |

### Deliberately conservative

The **sign test and its PASS/FAIL bar still count every shared dataset**, so this cannot silently flip a verdict recorded in an older plan file. The retained-only sign test prints alongside as a diagnostic, excluded sets are always named, and `--keep-near-solved` reproduces pre-fix numbers exactly when auditing an old figure.

### Checked and NOT changed

- `synth_report.py` already passes `denom_floor=0.01` on its Brier path — protected as invoked. (Its `1e-12` default is a latent trap for direct callers only; I overstated this mid-investigation before checking the call site.)
- `a1_screen_read.py` excludes the canaries explicitly. **A1's recorded "Brier 23W-8L +5.0%" reproduces exactly** (23W-8L-0T, +4.974%), so that evidence stands.

`tests/test_compare_runs.py` pins the contracts.

---

# 2. A2 Phase 0 record: config-portfolio audition KILLED on cost

Pre-registered in `benchmarks/A2_PLAN.md` before any result was read. Ran on the **PMLB tuning fold only** — A2 is a hyperparameter question, and measuring headroom on a decision suite would mean tuning on the instrument that later judges the result.

| bar | quantity | value | verdict |
|---|---|--:|---|
| B | test-oracle headroom | +2.587% | PASS |
| A | validation-selected headroom | +0.522% mean, +0.358% median | PASS |
| A | validation-selected win rate | 70.0% (21W-9L-6T, p=0.043) | PASS |
| C | race fidelity @ k=100 | 83.3%, 0.119% regret | PASS |
| D | projected fit-time multiple | **1.90×** | **FAIL** (≤1.35×) |

A k=100 audition is nearly a whole fit whenever the full fit is short — the norm for multiclass. Validation selection also recovers only **20% of the oracle ceiling**.

**What survives (post-hoc, not evidence yet):** a two-way depth race (6 vs 4) clears every bar at 1.12–1.24× for +0.398%. But seven-way subset search makes that p=0.012 worth ~0.08 corrected, and the gain concentrates at `n_train < 2000` (+1.1% to +7.4%), collapsing to +0.1–0.6% on the larger half — which is the regime the decision suites occupy. Whether it earns a full `/experiment` run is your call.

Grinsztajn, high-card, the OpenML gate and TabArena were not touched by any of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018u2u5K96eQ8aamSM5j6tsu
