### PR TITLE
Release 0.25.0: version bump + CHANGELOG close-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to ChimeraBoost are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [0.25.0] - 2026-07-26
 ### Added
 - **``quality=1..5``: named operating points on the speed/accuracy curve.**
   ``1`` fast, ``2`` balanced (0.24.0's defaults), ``3`` accurate (the

--- a/chimeraboost/__init__.py
+++ b/chimeraboost/__init__.py
@@ -31,4 +31,4 @@ __all__ = [
     "CustomObjective",
     "warmup",
 ]
-__version__ = "0.24.0"
+__version__ = "0.25.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chimeraboost"
-version = "0.24.0"
+version = "0.25.0"
 description = "CatBoost-inspired gradient boosting in pure Python with a numba backend"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
0.25.0 is **already live on PyPI** (https://pypi.org/project/chimeraboost/0.25.0/) and tagged `v0.25.0`. This is the one remaining piece: the version-bump commit itself, which I could not push to `main` directly.

- `pyproject.toml` and `chimeraboost/__init__.py` → `0.25.0` (both, checked for the one-file-only trap)
- `CHANGELOG.md` `[Unreleased]` → `[0.25.0] - 2026-07-26`, version headers checked for merge clobbering

Until this merges, `main` reports `0.24.0` while PyPI serves `0.25.0` — the version-drift trap the release checklist warns about. The published artifact was built from exactly this tree, and `v0.25.0` tags commit `26235cb`, which becomes part of `main`'s history on merge.

602 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QL8dKTqwRwQj3j8yJSJVw3
