### PR TITLE
Warmup: one-command priming, coverage fixes, cold-start benchmark (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,39 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
   on the defaults, not on rung 3 — ``refit_full`` is a no-op inside bagged
   members. Where ``quality`` collides with a parameter you set yourself it
   wins and warns. Evidence: benchmarks/SELECT_PLAN.md.
+- **``chimeraboost-warmup`` command** (also ``python -m chimeraboost``) —
+  compiles the numba kernels and caches them on disk, so the wait lands where
+  you chose rather than inside the first ``fit``. Run it after installing,
+  and after every upgrade: numba stamps each cache entry with its source
+  file's mtime and size, so a new version silently resets the cache. This is
+  the closest thing to compiling at install time that numba supports —
+  ahead-of-time compilation (``numba.pycc``) requires ``numpy.distutils``,
+  removed in numpy 1.26, cannot compile ``prange``, and would make the wheel
+  platform-specific; and a pre-built cache cannot be shipped in a wheel
+  because its key includes the building machine's exact CPU model and
+  feature set as well as the installed file's timestamp.
+- **``warmup(shap=True)`` / ``chimeraboost-warmup --shap``** — the SHAP
+  kernels are ~3.7 s of compile that most callers never reach, so they stay
+  opt-in; without this the cost landed on the first ``shap_values`` call.
+- **A one-line notice on a cold first fit.** A silent 15-second first call is
+  indistinguishable from a hang. It prints to stderr only when the on-disk
+  cache really is cold — roughly once per installed version, not once per
+  session — and ``CHIMERABOOST_NO_NOTICE=1`` silences it, as does having
+  ``CHIMERABOOST_WARMUP`` set.
+- **``benchmarks/cold_start.py``** — a reproducible cold/warm/steady-state
+  measurement, including per-kernel compile cost. The numbers in
+  docs/deployment.md now come from it; previously they came from scratchpad
+  scripts that were never committed and had gone stale by six releases.
+
+### Fixed
+- **``warmup()`` missed the small-batch constant-leaf predictor.** A warmed
+  serving process still stalled ~0.31 s on its first single-row ``predict``
+  for a model without linear leaves — exactly the case warmup exists to
+  prevent. Now 0.2 ms. The guard test that should have caught this asserted
+  against a hand-written list of 11 kernels and, run in a full suite, passed
+  only because an earlier test compiled one of them as a side effect; it now
+  enumerates every numba kernel in the package and fails on any that warmup
+  leaves uncompiled without a written reason.
 
 ### Changed
 - **Vector-leaf multiclass.** ``MulticlassBoosting`` now grows ONE oblivious

--- a/README.md
+++ b/README.md
@@ -10,8 +10,13 @@
 * **Installation**
 
 ```
-pip install chimeraboost
+pip install chimeraboost && chimeraboost-warmup
 ```
+
+`chimeraboost-warmup` compiles the numba kernels once and caches them, so the
+first `fit` is not several seconds slower than the rest. Re-run it after each
+upgrade — an upgrade resets the cache. See
+[Deployment](https://bbstats.github.io/chimeraboost/deployment/).
 
 * **Sample code:**
 

--- a/benchmarks/cold_start.py
+++ b/benchmarks/cold_start.py
@@ -1,0 +1,304 @@
+"""Measure what a cold numba cache actually costs.
+
+ChimeraBoost's kernels are JIT-compiled on first use and cached on disk. A
+fresh machine -- or any machine right after `pip install -U`, which resets the
+cache -- pays that compile once, inside whatever call happens to be first.
+This script measures it instead of guessing, in three states:
+
+  cold    brand-new NUMBA_CACHE_DIR, fresh process: everything compiles
+  warm    same cache dir, fresh process: kernels load from disk
+  steady  a second call inside the warm process: no cache work at all
+
+Every measurement runs in a subprocess with NUMBA_CACHE_DIR pointed at a
+scratch directory, which is the only honest way to get a stone-cold cache
+without deleting files out of the installed package.
+
+    python benchmarks/cold_start.py                # the standard table
+    python benchmarks/cold_start.py --kernels      # + per-kernel compile cost
+    python benchmarks/cold_start.py --ladder       # + quality=1..5 timings
+
+Numbers in docs/deployment.md come from here; regenerate them rather than
+editing the table by hand.
+"""
+
+import argparse
+import json
+import os
+import pickle
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCENARIOS = ("import", "warmup", "fit-default", "predict-1row")
+
+
+# --------------------------------------------------------------------------
+# data
+# --------------------------------------------------------------------------
+
+def make_data(n=3000, seed=0):
+    """Mixed numeric + categorical binary task -- the default fit path,
+    including the ordered target statistics and cross features."""
+    rng = np.random.default_rng(seed)
+    Xn = rng.standard_normal((n, 8))
+    c1 = rng.integers(0, 40, size=n)      # high-ish cardinality
+    c2 = rng.integers(0, 7, size=n)
+    X = np.column_stack([Xn, c1, c2])
+    y = (Xn[:, 0] + 0.5 * Xn[:, 1] + (c1 % 3) + rng.standard_normal(n) * 0.5 > 1)
+    return X, y.astype(int)
+
+
+# --------------------------------------------------------------------------
+# child: one scenario, one process
+# --------------------------------------------------------------------------
+
+def run_child(scenario, out_path, kernels=False):
+    result = {}
+    t0 = time.perf_counter()
+    import chimeraboost
+    result["import"] = time.perf_counter() - t0
+    result["file"] = chimeraboost.__file__
+    result["version"] = chimeraboost.__version__
+
+    timers = _install_kernel_timers() if kernels else None
+
+    if scenario == "import":
+        result["first"] = result["import"]
+
+    elif scenario == "warmup":
+        t0 = time.perf_counter()
+        chimeraboost.warmup()
+        result["first"] = time.perf_counter() - t0
+        t0 = time.perf_counter()
+        chimeraboost.warmup()
+        result["steady"] = time.perf_counter() - t0
+
+    elif scenario == "fit-default":
+        from chimeraboost import ChimeraBoostClassifier
+        X, y = make_data()
+        t0 = time.perf_counter()
+        ChimeraBoostClassifier(random_state=0, cat_features=[8, 9]).fit(X, y)
+        result["first"] = time.perf_counter() - t0
+        t0 = time.perf_counter()
+        ChimeraBoostClassifier(random_state=0, cat_features=[8, 9]).fit(X, y)
+        result["steady"] = time.perf_counter() - t0
+
+    elif scenario == "predict-1row":
+        # The serving shape: a process that only unpickles a model and scores
+        # single rows never calls fit, so it meets the compile on request one.
+        with open(os.environ["CHIMERA_MODEL_PATH"], "rb") as fh:
+            model = pickle.load(fh)
+        X, _ = make_data()
+        t0 = time.perf_counter()
+        model.predict_proba(X[:1])
+        result["first"] = time.perf_counter() - t0
+        t0 = time.perf_counter()
+        model.predict_proba(X[:1])
+        result["steady"] = time.perf_counter() - t0
+
+    elif scenario == "ladder":
+        from chimeraboost import ChimeraBoostClassifier
+        from sklearn.metrics import roc_auc_score
+        X, y = make_data(n=4000)
+        Xtr, ytr, Xte, yte = X[:3000], y[:3000], X[3000:], y[3000:]
+        rungs = {}
+        for q in (1, 2, 3, 4, 5):
+            t0 = time.perf_counter()
+            m = ChimeraBoostClassifier(random_state=0, cat_features=[8, 9],
+                                       quality=q).fit(Xtr, ytr)
+            elapsed = time.perf_counter() - t0
+            rungs[q] = {"seconds": elapsed,
+                        "auc": float(roc_auc_score(yte, m.predict_proba(Xte)[:, 1]))}
+        result["rungs"] = rungs
+        result["first"] = sum(r["seconds"] for r in rungs.values())
+
+    else:
+        raise SystemExit(f"unknown scenario: {scenario}")
+
+    if timers is not None:
+        result["kernels"] = _collect_kernel_timers(timers)
+
+    Path(out_path).write_text(json.dumps(result))
+
+
+def _install_kernel_timers():
+    """Time every kernel's compile by wrapping its dispatcher.
+
+    `_compile_for_args` is numba's entry point for compiling a new
+    specialization, so wrapping it attributes wall time per kernel. Cache
+    *loads* go through a different path and are correctly excluded.
+    """
+    import importlib
+    from numba.core.dispatcher import Dispatcher
+    import chimeraboost
+    import pkgutil
+
+    timings = []
+    for mod_info in pkgutil.iter_modules(chimeraboost.__path__):
+        if mod_info.name.startswith("__"):
+            continue
+        mod = importlib.import_module("chimeraboost." + mod_info.name)
+        for obj in vars(mod).values():
+            if not isinstance(obj, Dispatcher):
+                continue
+            if getattr(obj, "_chimera_timed", False):
+                continue          # booster.py re-exports tree.py's kernels
+            obj._chimera_timed = True
+            name = obj.py_func.__name__
+
+            def wrap(dispatcher=obj, name=name):
+                original = dispatcher._compile_for_args
+
+                def timed(*args, **kwargs):
+                    t0 = time.perf_counter()
+                    out = original(*args, **kwargs)
+                    timings.append((time.perf_counter() - t0, name))
+                    return out
+                return timed
+
+            obj._compile_for_args = wrap()
+    return timings
+
+
+def _collect_kernel_timers(timings):
+    agg = {}
+    for seconds, name in timings:
+        agg[name] = agg.get(name, 0.0) + seconds
+    return dict(sorted(agg.items(), key=lambda kv: -kv[1]))
+
+
+# --------------------------------------------------------------------------
+# parent: drive the subprocesses
+# --------------------------------------------------------------------------
+
+def _launch(scenario, cache_dir, kernels=False, model_path=None):
+    env = dict(os.environ)
+    env["NUMBA_CACHE_DIR"] = str(cache_dir)
+    # Pin the package under test: the child must not resolve chimeraboost
+    # through an editable install pointing at some other checkout.
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    env.pop("CHIMERABOOST_WARMUP", None)
+    env["CHIMERABOOST_NO_NOTICE"] = "1"
+    if model_path:
+        env["CHIMERA_MODEL_PATH"] = str(model_path)
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as fh:
+        out_path = fh.name
+    cmd = [sys.executable, str(Path(__file__).resolve()),
+           "--child", scenario, "--out", out_path]
+    if kernels:
+        cmd.append("--kernels")
+    proc = subprocess.run(cmd, env=env, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise SystemExit(f"child '{scenario}' failed:\n{proc.stderr}")
+    # Read results from the file, not stdout: terminal output is unreliable
+    # on this box, the file is not.
+    data = json.loads(Path(out_path).read_text())
+    os.unlink(out_path)
+    return data
+
+
+def _build_model(tmp_root):
+    """Fit one model in this process and pickle it, so the predict scenario
+    can measure a fresh process that never fits."""
+    from chimeraboost import ChimeraBoostClassifier
+    X, y = make_data()
+    model = ChimeraBoostClassifier(random_state=0, cat_features=[8, 9]).fit(X, y)
+    path = tmp_root / "model.pkl"
+    with open(path, "wb") as fh:
+        pickle.dump(model, fh)
+    return path
+
+
+def _fmt(seconds):
+    if seconds is None:
+        return "-"
+    if seconds < 0.01:
+        return f"{seconds * 1e3:.1f} ms"
+    return f"{seconds:.2f} s"
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--child", help=argparse.SUPPRESS)
+    parser.add_argument("--out", help=argparse.SUPPRESS)
+    parser.add_argument("--kernels", action="store_true",
+                        help="also report per-kernel cold compile cost")
+    parser.add_argument("--ladder", action="store_true",
+                        help="also time quality=1..5 on a cold and warm cache")
+    args = parser.parse_args(argv)
+
+    if args.child:
+        return run_child(args.child, args.out, kernels=args.kernels) or 0
+
+    scenarios = list(SCENARIOS) + (["ladder"] if args.ladder else [])
+    tmp_root = Path(tempfile.mkdtemp(prefix="chimera_coldstart_"))
+    try:
+        model_path = _build_model(tmp_root)
+        rows, kernel_costs, meta = [], None, None
+        for scenario in scenarios:
+            cache_dir = tmp_root / f"cache_{scenario}"
+            cache_dir.mkdir()
+            want_kernels = args.kernels and scenario == "warmup"
+            cold = _launch(scenario, cache_dir, kernels=want_kernels,
+                           model_path=model_path)
+            warm = _launch(scenario, cache_dir, model_path=model_path)
+            meta = meta or cold
+            if want_kernels:
+                kernel_costs = cold.get("kernels")
+            rows.append((scenario, cold, warm))
+
+        _print_table(rows, meta, kernel_costs,
+                     ladder=[r for r in rows if r[0] == "ladder"])
+    finally:
+        shutil.rmtree(tmp_root, ignore_errors=True)
+    return 0
+
+
+def _print_table(rows, meta, kernel_costs, ladder):
+    import numba
+    print()
+    print(f"chimeraboost {meta['version']}  from {meta['file']}")
+    print(f"numba {numba.__version__}  numpy {np.__version__}  "
+          f"{numba.config.NUMBA_NUM_THREADS} threads")
+    print()
+    print(f"{'scenario':<16}{'cold':>10}{'warm':>10}{'steady':>10}"
+          f"{'cold/warm':>12}")
+    print("-" * 58)
+    for scenario, cold, warm in rows:
+        c, w = cold.get("first"), warm.get("first")
+        ratio = f"{c / w:.1f}x" if c and w else "-"
+        print(f"{scenario:<16}{_fmt(c):>10}{_fmt(w):>10}"
+              f"{_fmt(warm.get('steady')):>10}{ratio:>12}")
+    print()
+
+    if kernel_costs:
+        total = sum(kernel_costs.values())
+        print(f"cold compile by kernel ({total:.2f} s over "
+              f"{len(kernel_costs)} kernels)")
+        print("-" * 40)
+        for name, seconds in list(kernel_costs.items())[:12]:
+            print(f"  {name:<32}{seconds:6.2f}")
+        rest = list(kernel_costs.items())[12:]
+        if rest:
+            print(f"  {'(%d more)' % len(rest):<32}{sum(s for _, s in rest):6.2f}")
+        print()
+
+    for scenario, cold, warm in ladder:
+        print(f"{'quality':<10}{'cold s':>10}{'warm s':>10}{'AUC':>10}")
+        print("-" * 40)
+        for q in ("1", "2", "3", "4", "5"):
+            c = cold["rungs"].get(q, {})
+            w = warm["rungs"].get(q, {})
+            print(f"{q:<10}{c.get('seconds', 0):10.2f}{w.get('seconds', 0):10.2f}"
+                  f"{c.get('auc', 0):10.4f}")
+        print()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/tabarena/TIMING_FINDINGS.md
+++ b/benchmarks/tabarena/TIMING_FINDINGS.md
@@ -73,6 +73,12 @@ a separate PR.
 
 ## Repro scripts
 
-The probe/driver scripts used for the tables live in the session scratchpad;
-the essential pattern: run `python probe.py` variants as fresh subprocesses,
-deleting `chimeraboost/__pycache__/*.nb?` between runs for the cold cells.
+`python benchmarks/cold_start.py --kernels` (committed 2026-07-26, issue #34)
+reproduces the three-regime table above and adds the per-kernel compile
+breakdown. It gets a stone-cold cache by pointing `NUMBA_CACHE_DIR` at a fresh
+directory in each subprocess, which is cleaner than the original approach of
+deleting `chimeraboost/__pycache__/*.nb?` between runs.
+
+The probe/driver scripts used for the tables in this file predate that and
+lived only in the session scratchpad — which is why the numbers here and in
+docs/deployment.md drifted several releases out of date before anyone noticed.

--- a/chimeraboost/__main__.py
+++ b/chimeraboost/__main__.py
@@ -1,0 +1,8 @@
+"""``python -m chimeraboost`` — pre-compile the numba kernels."""
+
+from .warmup import main
+
+# Guarded so that merely importing this module (module enumeration, tooling)
+# does not run the command.
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -633,6 +633,11 @@ def _validate_fit_input(estimator, X, y, cat_features, sample_weight, *,
     """
     import scipy.sparse as sp
     from sklearn.exceptions import DataConversionWarning
+    if not getattr(estimator, "_is_bag_member", False):
+        # Members fit in worker processes; without this a cold bagged fit
+        # would print the notice once per member.
+        from .warmup import _maybe_notice_cold_compile
+        _maybe_notice_cold_compile()
     if y is None:
         raise ValueError(
             "This estimator requires y to be passed, but the target y is None.")
@@ -861,6 +866,10 @@ def _check_predict_input(estimator, X):
     mismatched input. Messages match scikit-learn's wording for compatibility."""
     from sklearn.utils.validation import check_is_fitted
     check_is_fitted(estimator)
+    # A process that only unpickles a model and serves it never calls fit, so
+    # the predict path needs its own notice.
+    from .warmup import _maybe_notice_cold_compile
+    _maybe_notice_cold_compile()
     # Enforce feature-name agreement with fit (reuse sklearn's logic): a
     # DataFrame whose columns are renamed or *reordered* relative to training
     # otherwise produces silently-wrong predictions. Warns when names are

--- a/chimeraboost/warmup.py
+++ b/chimeraboost/warmup.py
@@ -8,12 +8,20 @@ Long-lived processes never notice; fleets of short-lived workers (benchmark
 harnesses, serverless inference, ray/spark tasks) pay it on every task, where
 it can dwarf the actual fit/predict work.
 
-``warmup()`` runs three tiny synthetic fits + predictions chosen to touch
+``warmup()`` runs a few tiny synthetic fits + predictions chosen to touch
 every kernel on the default fit and predict paths, so subsequent real calls
 run at steady-state speed. Call it at import/startup time, outside anything
-you time or bill.
+you time or bill -- or run the ``chimeraboost-warmup`` command once after
+installing.
+
+Note that numba stamps each cache entry with its source file's modification
+time and size, so **upgrading ChimeraBoost invalidates the cache**: the first
+run after ``pip install -U`` pays the compile again.
 """
 
+import argparse
+import os
+import sys
 import threading
 import time
 
@@ -21,20 +29,72 @@ import numpy as np
 
 from .sklearn_api import ChimeraBoostClassifier, ChimeraBoostRegressor
 
+# Set once the cold-compile notice has been considered, so it prints at most
+# once per process. warmup() arms it up front -- its own fits are the compile.
+_NOTICE_DONE = False
 
-def warmup(verbose=False, background=False):
+
+def _cache_is_cold():
+    """True when numba's on-disk cache holds nothing usable for our kernels.
+
+    Checks one kernel per source file, because numba invalidates per ``.py``
+    (the cache entry is stamped with that file's mtime and size). An empty
+    index means no cache file, a numba version change, or -- the common case
+    after ``pip install -U chimeraboost`` -- a stale source stamp.
+
+    Reaches into numba internals, so any failure is read as "warm": a numba
+    reorganisation should silence the notice, never break a fit.
+    """
+    from .binning import _bin_matrix
+    from .tree import _build_split_descend_q
+    try:
+        for kernel in (_bin_matrix, _build_split_descend_q):
+            if kernel.signatures:
+                continue          # already compiled or cache-loaded here
+            if not kernel._cache._cache_file._load_index():
+                return True
+    except Exception:
+        return False
+    return False
+
+
+def _maybe_notice_cold_compile():
+    """Print one line to stderr when a cold compile is about to happen.
+
+    A silent 15-second first call is indistinguishable from a hang; this says
+    what it is. Fires at most once per process, and only when the disk cache
+    really is cold -- so a given machine sees it about once per release, not
+    once per session.
+    """
+    global _NOTICE_DONE
+    if _NOTICE_DONE:
+        return
+    _NOTICE_DONE = True
+    if os.environ.get("CHIMERABOOST_NO_NOTICE"):
+        return
+    if os.environ.get("CHIMERABOOST_WARMUP"):
+        return                    # already opted into paying it at import
+    if not _cache_is_cold():
+        return
+    print("chimeraboost: first run on this machine -- compiling numba kernels "
+          "(~15 s, one time, then cached on disk). Run `chimeraboost-warmup` "
+          "after installing to pay this up front; set CHIMERABOOST_NO_NOTICE=1 "
+          "to silence.", file=sys.stderr, flush=True)
+
+
+def warmup(verbose=False, background=False, shap=False):
     """Compile (or load from the on-disk cache) all default-path kernels.
 
     Covers binary classification with linear leaves, a categorical feature
     and a validation set; multiclass; regression with ordered boosting and
     non-uniform sample weights (the weighted ordered-TS kernel); and the
     gdiff cross-feature group-sum kernel — together these touch every fit-
-    and predict-path numba kernel except the SHAP kernels (compiled on the
-    first ``shap_values`` call).
+    and predict-path numba kernel except the SHAP kernels (``shap=True``).
 
-    Instead of calling this yourself, you can set the environment variable
-    ``CHIMERABOOST_WARMUP=1`` to run it automatically when ``chimeraboost``
-    is imported (``=background`` uses the daemon thread instead).
+    Instead of calling this yourself, run ``chimeraboost-warmup`` once after
+    installing, or set the environment variable ``CHIMERABOOST_WARMUP=1`` to
+    run it automatically when ``chimeraboost`` is imported (``=background``
+    uses a daemon thread instead).
 
     Parameters
     ----------
@@ -45,6 +105,9 @@ def warmup(verbose=False, background=False):
         overlaps the caller's own startup (data loading, connections). A fit
         issued before the thread finishes simply blocks on numba's per-kernel
         compile locks, so it is never slower than compiling inline.
+    shap : bool, default False
+        Also compile the SHAP kernels. Off by default: it adds ~3.7 s to a
+        cold warmup and most callers never use ``shap_values``.
 
     Returns
     -------
@@ -52,11 +115,14 @@ def warmup(verbose=False, background=False):
         Wall-clock seconds spent warming up, or the started daemon thread
         when ``background=True`` (``.join()`` it to wait for readiness).
     """
+    global _NOTICE_DONE
     if background:
-        t = threading.Thread(target=warmup, kwargs={"verbose": verbose},
+        t = threading.Thread(target=warmup,
+                             kwargs={"verbose": verbose, "shap": shap},
                              name="chimeraboost-warmup", daemon=True)
         t.start()
         return t
+    _NOTICE_DONE = True   # this call *is* the compile -- do not narrate it
     t0 = time.perf_counter()
     rng = np.random.default_rng(0)
 
@@ -83,7 +149,7 @@ def warmup(verbose=False, background=False):
     mc = ChimeraBoostClassifier(n_estimators=2, random_state=0)
     mc.fit(X[:320, :3], ym)
     mc.predict_proba(X[:8, :3])
-    mc.predict_proba(X[:1, :3])   # constant-forest serial twin
+    mc.predict_proba(X[:1, :3])   # vector-leaf serial twin
     _log("multiclass")
 
     # Regression, ordered boosting on (the LOO leaf-step kernel), with a
@@ -97,6 +163,11 @@ def warmup(verbose=False, background=False):
                                 ordered_boosting=True)
     reg.fit(X[:320], yr, cat_features=[3], sample_weight=sw)
     reg.predict(X[:8])
+    # 320 rows is below LINEAR_LEAVES_MIN_SAMPLES, so this model has constant
+    # leaves: a <= 4-row call here is the only thing that compiles the plain
+    # serial predict twin. Without it a warmed serving process still stalls
+    # ~0.3 s on its first single-row request.
+    reg.predict(X[:1])
     _log("regression + ordered boosting + weighted categoricals")
 
     # The gdiff (group-centered cross feature) kernel sits on the default
@@ -106,9 +177,16 @@ def warmup(verbose=False, background=False):
     _grouped_kahan_sum(np.zeros(4, dtype=np.int64), np.ones(4), 2)
     _log("gdiff group-sum kernel")
 
-    # The fused level kernel (`_build_split_descend`) has one signature for
+    # The fused level kernel (`_build_split_descend_q`) has one signature for
     # both its small-n and large-n branches, so the small fits above compile
     # everything on the tree-build path — no direct kernel calls needed.
+
+    # SHAP is opt-in: `_shap_forest_linear` is an expensive parallel kernel
+    # (~3.7 s cold) that most callers never reach. The same call also compiles
+    # the column-major `_predict_forest_linear`, which the SHAP path uses.
+    if shap:
+        clf.shap_values(X[:8])
+        _log("shap")
 
     return time.perf_counter() - t0
 
@@ -127,3 +205,43 @@ def _warmup_from_env(value):
     if value.strip().lower() in ("background", "thread", "bg"):
         return warmup(background=True)
     return warmup()
+
+
+def _cache_dir():
+    """Where numba put the compiled kernels, for the command to report."""
+    try:
+        from .binning import _bin_matrix
+        return _bin_matrix._cache.cache_path
+    except Exception:
+        return "(numba default)"
+
+
+def main(argv=None):
+    """``chimeraboost-warmup`` — compile the kernels now, not on first fit.
+
+    Run once after ``pip install`` (and again after every upgrade, which
+    invalidates numba's cache). Also reachable as
+    ``python -m chimeraboost.warmup`` or ``python -m chimeraboost``.
+    """
+    from . import __version__
+    parser = argparse.ArgumentParser(
+        prog="chimeraboost-warmup",
+        description="Compile ChimeraBoost's numba kernels and cache them on "
+                    "disk, so later runs start at full speed. Re-run after "
+                    "upgrading ChimeraBoost -- an upgrade resets the cache.")
+    parser.add_argument("--shap", action="store_true",
+                        help="also compile the SHAP kernels (~3.7 s more)")
+    parser.add_argument("--verbose", action="store_true",
+                        help="print per-stage timings")
+    parser.add_argument("--quiet", action="store_true",
+                        help="print nothing on success")
+    args = parser.parse_args(argv)
+    elapsed = warmup(verbose=args.verbose, shap=args.shap)
+    if not args.quiet:
+        print(f"chimeraboost {__version__}: kernels ready in {elapsed:.1f}s "
+              f"(cache: {_cache_dir()})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,25 +6,43 @@ fit-time memory.
 
 ## The first call pays the numba compile
 
-ChimeraBoost's kernels are JIT-compiled by numba on first use. In a fresh
-process with a cold cache, the first `fit` takes several seconds and the
-first `predict` over a second — steady-state they are milliseconds
-(numbers below). Compiled kernels are cached on disk per user, so later
-processes pay only a small cache-load cost.
+ChimeraBoost's kernels are JIT-compiled by numba on first use. With a cold
+cache the first `fit` takes seconds; steady-state it is milliseconds.
+Compiled kernels are cached on disk per user, so later processes pay only a
+small cache-load cost.
 
-Measured on a 12-core desktop (0.18-era code):
+Run this once after installing and the wait never lands on a real call:
 
-| First call in a fresh process | stone-cold | warm disk cache |
-|---|---|---|
-| `fit` (1K rows) | 4.4–9.3 s | ≈ 0.5 s |
-| `predict` (1K rows) | 1.3–1.8 s | ≈ 0.2 s |
+```
+pip install -U chimeraboost && chimeraboost-warmup
+```
+
+**Re-run it after every upgrade.** Numba stamps each cache entry with its
+source file's modification time and size, so installing a new ChimeraBoost
+version invalidates the cache and the next run compiles from scratch again.
+This surprises people who assumed the cost was once per machine.
+
+Measured on a 12-core desktop, regenerate with
+`python benchmarks/cold_start.py --kernels`:
+
+| First call in a fresh process | cold cache | warm cache | steady state |
+|---|---|---|---|
+| `import chimeraboost` | 1.35 s | 1.35 s | — |
+| `warmup()` | 13.2 s | 0.97 s | — |
+| `fit` (3K rows, 2 categorical) | 10.1 s | 0.83 s | 0.27 s |
+| `predict` (1 row, unpickled model) | 0.98 s | 0.27 s | 0.5 ms |
+
+Two thirds of that cold compile is two kernels: the linear-leaf solver and
+the fused tree-build level. They are parallel kernels, which are expensive to
+compile and several times faster to run — worth the trade, but it is why the
+number is seconds rather than milliseconds.
 
 The serving shape is the painful one: a process that only unpickles a model
-pays that first-predict cost on its first request. `warmup()` in a fresh
-process took 0.38 s and removed it entirely (first predict ≈ 1 ms after).
+pays the first-predict cost on its first request. `warmup()` removes it.
 
-For short-lived workers (serverless, per-request processes, benchmark
-harnesses that spawn fresh workers), pre-compile at import time:
+When you cannot run the command — serverless, per-request processes,
+benchmark harnesses that spawn fresh workers — compile from inside the
+process instead:
 
 ```python
 import chimeraboost
@@ -35,6 +53,20 @@ or set the environment variable `CHIMERABOOST_WARMUP=1` (compile at
 import) / `CHIMERABOOST_WARMUP=background` (compile on a daemon thread
 while your process boots). Timing a fresh worker without warmup measures
 numba's compiler, not the model.
+
+`warmup()` skips the SHAP kernels by default, since most callers never use
+them and they add ~3.7 s. If you serve explanations, use `warmup(shap=True)`
+or `chimeraboost-warmup --shap`.
+
+The first fit on a cold cache prints a one-line notice to stderr explaining
+the wait. It appears only when the cache really is cold — roughly once per
+installed version — and `CHIMERABOOST_NO_NOTICE=1` silences it.
+
+There is no way to move this compile into `pip install`. Numba's
+ahead-of-time compiler was retired, and a pre-built cache cannot be shipped
+in a wheel: its key includes the exact CPU model and feature set of the
+machine that built it, plus the installed file's timestamp. One command after
+install is the whole of the fix.
 
 ## Thread control
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -35,10 +35,18 @@ with sklearn.config_context(assume_finite=True):
 
 ## Why is the very first fit or predict slow?
 
-That is numba compiling the kernels (one-time per process, disk-cached per
-user). Call `chimeraboost.warmup()` — or set `CHIMERABOOST_WARMUP=1` — to
-pay it at import time instead of on the first call. See
-[Deployment](deployment.md) for numbers and short-lived-worker patterns.
+That is numba compiling the kernels (one-time, cached on disk per user). Run
+`chimeraboost-warmup` once after installing to pay it up front, or call
+`chimeraboost.warmup()` / set `CHIMERABOOST_WARMUP=1` to pay it at import
+time. See [Deployment](deployment.md) for numbers and short-lived-worker
+patterns.
+
+## Why did it get slow again after I upgraded?
+
+Numba stamps each cached kernel with its source file's timestamp and size, so
+installing a new ChimeraBoost version invalidates the cache and the next run
+recompiles. Put `chimeraboost-warmup` in the same script as your
+`pip install -U`.
 
 ## Why oblivious (symmetric) trees?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ dependencies = [
 Homepage = "https://github.com/bbstats/chimeraboost"
 Repository = "https://github.com/bbstats/chimeraboost"
 
+[project.scripts]
+chimeraboost-warmup = "chimeraboost.warmup:main"
+
 [project.optional-dependencies]
 dev = ["pytest", "pandas>=1.3"]
 docs = ["mkdocs-material>=9.5", "mkdocstrings[python]>=0.24", "black>=24.0"]

--- a/tests/test_warmup.py
+++ b/tests/test_warmup.py
@@ -1,36 +1,128 @@
 """warmup() must compile every default-path kernel without side effects."""
 
+import importlib
+import json
+import os
+import pathlib
+import subprocess
+import sys
 import threading
 
 import numpy as np
+import pytest
 
+import chimeraboost
 from chimeraboost import ChimeraBoostClassifier, warmup
-from chimeraboost.warmup import _warmup_from_env
+from chimeraboost.warmup import _cache_is_cold, _warmup_from_env, main
+
+# `chimeraboost.warmup` is the *function* -- the package re-exports it over the
+# module of the same name -- so reach the module through sys.modules to patch it.
+warmup_module = importlib.import_module("chimeraboost.warmup")
+
+# Kernels warmup() deliberately leaves uncompiled, each with the reason.
+# The coverage test asserts this set EXACTLY: a new kernel that nobody warms
+# fails it, and so does an entry here that quietly became covered (meaning the
+# reason below is stale). The previous hand-written list missed two real holes.
+NOT_WARMED = {
+    # Non-quantized tree build: quantize_gradients has been default-on since
+    # 0.18.0, so the default path uses the _q twin.
+    "chimeraboost.tree._build_split_descend",
+    # Reference oracles for the fused kernels, called only by
+    # tests/test_tree_kernels.py -- on no runtime path at all.
+    "chimeraboost.tree._build_histograms_into",
+    "chimeraboost.tree._best_split",
+    "chimeraboost.tree._build_and_split",
+    # Column-major predict twins; the row-major kernels are the default path.
+    "chimeraboost.tree._descend_leaves",
+    "chimeraboost.tree._descend_leaves_serial",
+    "chimeraboost.tree._predict_forest",
+    # SHAP, and the column-major predictor its path uses: opt-in via
+    # warmup(shap=True), ~3.7 s of compile most callers never need.
+    "chimeraboost.tree._shap_forest_linear",
+    "chimeraboost.tree._predict_forest_linear",
+    # Called only from inside _linear_leaf_fit, never from Python, so its own
+    # dispatcher records a signature when that kernel is *compiled* but not
+    # when it is loaded from a warm cache. Warming it is not possible and
+    # asserting on it would make this test depend on cache state.
+    "chimeraboost.tree._solve_small",
+}
+
+# warmup(shap=True) additionally covers these.
+WARMED_BY_SHAP = {
+    "chimeraboost.tree._shap_forest_linear",
+    "chimeraboost.tree._predict_forest_linear",
+}
+
+# Enumerate every @njit kernel in the package and report which warmup() left
+# uncompiled. Run as a subprocess so no earlier test can compile a kernel as a
+# side effect and mask a real coverage hole -- which is exactly how the old
+# hand-written version of this test passed while kernels went unwarmed.
+_PROBE = '''
+import importlib, json, pkgutil, sys
+from numba.core.dispatcher import Dispatcher
+import chimeraboost
+
+def kernels():
+    """Deduplicated by defining module + qualname: booster.py re-exports a
+    dozen of tree.py's dispatchers, so a raw scan double-counts them."""
+    out = {}
+    for mod_info in pkgutil.iter_modules(chimeraboost.__path__):
+        if mod_info.name.startswith("__"):
+            continue            # never import __main__ during enumeration
+        mod = importlib.import_module("chimeraboost." + mod_info.name)
+        for obj in vars(mod).values():
+            if isinstance(obj, Dispatcher):
+                f = obj.py_func
+                out[f"{f.__module__}.{f.__qualname__}"] = obj
+    return out
+
+found = kernels()
+chimeraboost.warmup(shap=json.loads(sys.argv[1]))
+uncovered = sorted(n for n, d in found.items() if not d.signatures)
+print(json.dumps({"total": len(found), "uncovered": uncovered,
+                  "file": chimeraboost.__file__}))
+'''
 
 
-def test_warmup_compiles_all_default_path_kernels():
-    elapsed = warmup()
-    assert elapsed > 0
+def _probe(tmp_path, shap):
+    """Run the enumeration probe in a clean interpreter.
 
-    from chimeraboost.binning import _bin_matrix
-    from chimeraboost.losses import _sigmoid
-    from chimeraboost.target_encoding import _ordered_ts
-    from chimeraboost.tree import (
-        _build_split_descend,
-        _leaf_values,
-        _linear_leaf_fit,
-        _linear_predict,
-        _loo_leaf_step,
-        _predict_forest_linear_rm,
-        _predict_forest_rm,
-        _predict_tree,
-    )
+    Written to a file rather than passed with ``-c``: quoting is unreliable on
+    the Windows box this repo is developed on. PYTHONPATH is pinned to the
+    package root pytest itself imported -- the script lives in a tmp dir, so
+    without it the child would resolve chimeraboost through the editable
+    install and silently test a different checkout.
+    """
+    script = tmp_path / "kernel_probe.py"
+    script.write_text(_PROBE)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(pathlib.Path(chimeraboost.__file__).parent.parent)
+    out = subprocess.run([sys.executable, str(script), json.dumps(bool(shap))],
+                         capture_output=True, text=True, timeout=900, env=env)
+    assert out.returncode == 0, out.stderr
+    result = json.loads(out.stdout.strip().splitlines()[-1])
+    assert result["file"] == chimeraboost.__file__, (
+        f"probe tested {result['file']}, not {chimeraboost.__file__}")
+    return result
 
-    for kernel in (_bin_matrix, _sigmoid, _ordered_ts, _build_split_descend,
-                   _leaf_values, _linear_leaf_fit, _linear_predict,
-                   _loo_leaf_step, _predict_tree, _predict_forest_rm,
-                   _predict_forest_linear_rm):
-        assert kernel.signatures, f"{kernel.py_func.__name__} not compiled by warmup()"
+
+def test_warmup_covers_every_kernel_except_the_documented_exclusions(tmp_path):
+    result = _probe(tmp_path, shap=False)
+    assert result["total"] >= 32, "kernel enumeration found suspiciously few"
+    assert set(result["uncovered"]) == NOT_WARMED
+
+
+def test_warmup_shap_covers_the_shap_kernels(tmp_path):
+    result = _probe(tmp_path, shap=True)
+    assert set(result["uncovered"]) == NOT_WARMED - WARMED_BY_SHAP
+
+
+def test_serial_predict_twin_is_warmed():
+    """The small-batch constant-leaf predictor: a warmed serving process must
+    not stall on its first single-row request."""
+    warmup()
+    from chimeraboost.tree import _predict_forest_rm_serial
+    assert _predict_forest_rm_serial.signatures
 
 
 def test_background_warmup_returns_daemon_thread_and_finishes():
@@ -65,3 +157,66 @@ def test_warmup_does_not_disturb_global_rng_or_model_output():
 
     again = ChimeraBoostClassifier(n_estimators=20, random_state=3).fit(X, y)
     np.testing.assert_array_equal(p_ref, again.predict_proba(X))
+
+
+def test_main_runs_and_reports(capsys):
+    assert main([]) == 0
+    out = capsys.readouterr().out
+    assert "kernels ready in" in out and chimeraboost.__version__ in out
+
+
+def test_main_quiet_prints_nothing(capsys):
+    assert main(["--quiet"]) == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_module_entry_points_run():
+    """python -m chimeraboost.warmup and python -m chimeraboost -- the only way
+    to catch a broken __main__ block or a bad entry-point target."""
+    for args in (["-m", "chimeraboost.warmup"], ["-m", "chimeraboost"]):
+        out = subprocess.run([sys.executable, *args, "--quiet"],
+                             capture_output=True, text=True, timeout=900)
+        assert out.returncode == 0, out.stderr
+
+
+def test_cache_cold_probe_reaches_numba_internals():
+    """_cache_is_cold() reads private numba attributes and swallows failures,
+    so this asserts the attribute chain still resolves. Without it a numba
+    upgrade would silently disable the notice instead of failing here."""
+    from chimeraboost.binning import _bin_matrix
+    assert _bin_matrix._cache._cache_file._load_index() is not None
+    assert isinstance(_cache_is_cold(), bool)
+
+
+def test_notice_prints_once_when_cold(monkeypatch, capsys):
+    w = warmup_module
+    monkeypatch.delenv("CHIMERABOOST_NO_NOTICE", raising=False)
+    monkeypatch.delenv("CHIMERABOOST_WARMUP", raising=False)
+    monkeypatch.setattr(w, "_cache_is_cold", lambda: True)
+    monkeypatch.setattr(w, "_NOTICE_DONE", False)
+
+    w._maybe_notice_cold_compile()
+    assert capsys.readouterr().err.count("compiling numba kernels") == 1
+
+    w._maybe_notice_cold_compile()
+    assert capsys.readouterr().err == ""
+
+
+@pytest.mark.parametrize("env", ["CHIMERABOOST_NO_NOTICE", "CHIMERABOOST_WARMUP"])
+def test_notice_suppressed_by_env(monkeypatch, capsys, env):
+    w = warmup_module
+    monkeypatch.setenv(env, "1")
+    monkeypatch.setattr(w, "_cache_is_cold", lambda: True)
+    monkeypatch.setattr(w, "_NOTICE_DONE", False)
+    w._maybe_notice_cold_compile()
+    assert capsys.readouterr().err == ""
+
+
+def test_warm_cache_fit_is_silent(capsys):
+    """The regression guard against the notice becoming chatty: a normal warm
+    fit must say nothing at all."""
+    X = np.random.default_rng(1).standard_normal((80, 3))
+    y = (X[:, 0] > 0).astype(int)
+    ChimeraBoostClassifier(n_estimators=5, random_state=0).fit(X, y)
+    captured = capsys.readouterr()
+    assert captured.err == "" and captured.out == ""


### PR DESCRIPTION
Closes #34 (validated answers + the fixes that are actually available).

## The questions, answered

**Compile during install — no.** `numba.pycc` still imports on numba 0.65.1, but constructing a `CC` fails: it needs `numpy.distutils`, removed in numpy 1.26 (we run numpy 2.4). It also cannot compile `prange`, which 19 of our 32 kernels use, and it would turn a pure-Python wheel into per-platform binaries.

**Ship a pre-built cache in the wheel — no.** Numba's cache key includes `codegen.magic_tuple()`, which on this box is `('x86_64-pc-windows-msvc', 'znver3', '+64bit,+adx,+aes,…')` — the exact CPU model and full feature string. Entries are additionally stamped with the source file's `(mtime, size)`, which changes when pip writes the file. Portability would need `NUMBA_CPU_NAME=generic` and `NUMBA_CPU_FEATURES=''` at build *and* run time, disabling SIMD everywhere to save 14 s once.

**Compile at import — already exists, stays opt-in.** `CHIMERABOOST_WARMUP=1` / `=background`. Making it the default just moves the same wait onto `import chimeraboost`, where it also hits processes that never fit a model.

**Why it recurs.** Numba stamps cache entries with each source file's mtime and size, so **every release invalidates the cache** — `pip install -U` silently returns you to cold. That was documented nowhere.

## Measured (`python benchmarks/cold_start.py --kernels`)

| scenario | cold | warm | steady |
|---|---|---|---|
| `import chimeraboost` | 1.35 s | 1.35 s | — |
| `warmup()` | 13.2 s | 0.97 s | — |
| `fit` (3K rows, 2 cat) | 10.1 s | 0.83 s | 0.27 s |
| `predict` (1 row, unpickled) | 0.98 s | 0.27 s | 0.5 ms |

Two kernels are 46% of the cold compile: `_linear_leaf_fit` 3.56 s and `_build_split_descend_q` 2.44 s.

## What changed

- **`chimeraboost-warmup`** console command (and `python -m chimeraboost`) — priming is one documented line after install, and after each upgrade.
- **Fixed a real coverage hole**: `warmup()` never compiled `_predict_forest_rm_serial`, so a *warmed* serving process still stalled **0.31 s** on its first single-row predict for a constant-leaf model. Now 0.2 ms.
- **Fixed the guard test that should have caught it.** It asserted a hand-written list of 11 kernels, and asserted one (`_build_split_descend`) that stopped being on the default path when `quantize_gradients` went default-on in 0.18.0. Run alone on `main` it **fails**; in a full run it passed only because `test_quantize.py` sorts earlier and compiled that kernel as a side effect. It now enumerates every numba dispatcher in the package, runs in a subprocess so ordering cannot mask a hole, and requires a written reason per deliberate exclusion.
- **`warmup(shap=True)` / `--shap`** — the first `shap_values` call was an undocumented 3.7 s stall; opt-in because most callers never reach it.
- **A one-line stderr notice** when the cache is genuinely cold, so a 15-second first call is not indistinguishable from a hang. Fires at most once per process, only on a real cold cache (≈ once per installed version), suppressed by `CHIMERABOOST_NO_NOTICE=1` or by having `CHIMERABOOST_WARMUP` set. A warm fit is silent — there is a test asserting exactly that.
- **`benchmarks/cold_start.py`** — the repo had no committed cold-start measurement (`TIMING_FINDINGS.md` admitted the probes were scratchpad-only), which is how `docs/deployment.md` drifted six releases stale. Docs now regenerate from it.

## Considered and rejected

Dropping `parallel=True` from the cheap kernels. Measured on one kernel: parallel costs 0.89 s to compile vs 0.13 s, but runs 11.6× faster at 100K elements and 4.1× at 5M. Trading ~1 s of one-time compile for a multiple of every round's runtime is a bad deal, so no kernel source is touched here.

## Verification

- `pytest tests/test_warmup.py -q` **alone**: 14 passed (the order-independence check the old test failed).
- `pytest -q`: **612 passed**, including the numerical-identity goldens.
- No kernel source changed, so model output is byte-identical — no `/experiment` gate owed.
- `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhVFYqJYDxrxbuxaRcysGf
