### PR TITLE
Post-hoc validation of the replay refit: public suite, PMLB, pickle compatibility, size scaling

### DIFF
--- a/benchmarks/REPLAY_PLAN.md
+++ b/benchmarks/REPLAY_PLAN.md
@@ -211,6 +211,55 @@ and the tie-break goes to the one that is a third cheaper.
 
 Defaults moved, so the Pareto chart is refreshed.
 
+## Post-hoc validation (2026-07-27, after #41/#42 merged)
+
+None of this can change the ship — it is confirmation on suites that took no
+part in the decision, plus two questions the decision suites cannot answer.
+
+**Public validation suite (22 datasets, n >= 50K, 3 seeds).** Never sealed,
+never blocking, zero overlap with the decision suites, and heavy on real
+high-cardinality categoricals — i.e. the regime where the leakage bug lived.
+`pub-scratch` vs `pub-replay`: **6W-6L-10T, mean −0.114%, median +0.000%.**
+All NINE multiclass datasets tied EXACTLY, which re-confirms the multiclass
+no-op on real large data rather than on synthetics. That is also why the
+whole-suite speed number looks modest (0.896x): those nine untouched datasets
+are 71% of the suite's compute. **On the 13 datasets replay actually touches:
+0.626x (−37.4%), faster on 13/13.** Mean is carried by two sets (rossmann
+−1.63%, BNP_Paribas −0.93%) against six wins.
+
+**PMLB (25 datasets, 3 seeds).** The suite most likely to find a weakness:
+small-data heavy, and REFIT_PLAN's gains concentrated in steep learning
+curves. It did not. **9W-5L-11T, mean −0.043%, median +0.000%** — more wins
+than losses. The one alarming cell, `pm:holdout/dis` at −3.00%, is seed noise:
+per-seed deltas −0.088 / +0.025 / −0.012 on a tiny, severely imbalanced
+binary set. Speed 0.962x summed, median 0.876x — small data saves least.
+
+**Backward compatibility.** Models fitted and pickled by the PRE-#41 library
+(566573a) load under the new code and predict **bit-identically**, for
+regression, binary and multiclass, despite their boosters predating the
+`replay_donor` attribute entirely (predict never reads it). An unpickled
+estimator still carries `refit_full=True`, so re-fitting an old model keeps
+the old behaviour rather than silently switching.
+
+**Size scaling (`benchmarks/replay_scaling.py`).** Every suite caps dataset
+size, so the headline was really "−35% at up to ~50K rows". Measured directly
+at 50K / 200K / 500K on mixed numeric+categorical data:
+
+| task | 50K | 200K | 500K |
+|---|--:|--:|--:|
+| regression | 27.5% | 28.9% | 28.4% |
+| binary | 27.0% | 29.0% | 27.2% |
+
+**The saving is FLAT at 27-29% across a 10x row range.** Combined with PMLB's
+~12% on few-thousand-row sets, the shape is: the saving climbs out of small
+data and then plateaus near 30%. It does NOT keep growing — do not promise
+more at giant n. (`scaling_giant.py` cannot measure this: it fits a fixed tree
+count with early stopping OFF, the one path on which no refit happens at all.)
+
+**Four independent suites now agree accuracy is a wash**: Grinsztajn +0.005%,
+high-card −0.017%, PMLB −0.043%, public −0.114%, all with medians of
+essentially zero, and two of the four played no part in the decision.
+
 ## Open / stackable
 
 - **`Sel25`** (auditions 100 -> 25) still stacks on top of this: it was

--- a/benchmarks/replay_scaling.py
+++ b/benchmarks/replay_scaling.py
@@ -1,0 +1,81 @@
+"""Does the replay refit's saving hold as n grows?
+
+Every decision suite caps dataset size (Grinsztajn subsamples to 50K, the public
+suite subsamples too), so the measured -35% is really "-35% at up to ~50K rows".
+This walks the same comparison up the row count.
+
+Note that `scaling_giant.py` cannot answer this: it fits a fixed tree count with
+early stopping OFF, and that is precisely the path on which no refit happens at
+all. The refit only exists on the automatic-split path, so this script fits with
+ordinary defaults and varies only `refit_full`.
+
+    python benchmarks/replay_scaling.py --sizes 50000,200000,500000
+"""
+import argparse
+import time
+
+import numpy as np
+
+import chimeraboost
+from chimeraboost import ChimeraBoostClassifier, ChimeraBoostRegressor
+from chimeraboost.warmup import warmup
+
+
+def make_data(n, rng, n_num=12, n_cat=3, cardinality=200):
+    """Mixed numeric + categorical, with real categorical signal so the ordered
+    target encoder is exercised (that is where the refit does its extra work)."""
+    num = rng.standard_normal((n, n_num))
+    cat = rng.integers(0, cardinality, size=(n, n_cat))
+    cat_effect = rng.standard_normal(cardinality)[cat].sum(axis=1)
+    signal = (num[:, 0] + 0.7 * num[:, 1] * num[:, 2] - 0.5 * num[:, 3]
+              + 0.8 * cat_effect)
+    X = np.hstack([num, cat.astype(float)])
+    y = signal + 0.4 * rng.standard_normal(n)
+    return X, y, list(range(n_num, n_num + n_cat))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--sizes", default="50000,200000,500000")
+    ap.add_argument("--seed", type=int, default=0)
+    a = ap.parse_args()
+    sizes = [int(s) for s in a.sizes.split(",")]
+
+    print("chimeraboost:", chimeraboost.__file__, flush=True)
+    warmup()
+    print(f"\n{'task':6s} {'n':>9s} {'scratch_s':>10s} {'replay_s':>9s} "
+          f"{'ratio':>7s} {'saving':>8s} {'metric_d%':>10s}")
+    for n in sizes:
+        rng = np.random.default_rng(a.seed)
+        X, y, cat = make_data(n, rng)
+        cut = int(n * 0.75)
+        Xtr, Xte, ytr, yte = X[:cut], X[cut:], y[:cut], y[cut:]
+        for task in ("reg", "bin"):
+            if task == "reg":
+                Est, ytr_, yte_ = ChimeraBoostRegressor, ytr, yte
+            else:
+                thr = np.median(ytr)
+                Est = ChimeraBoostClassifier
+                ytr_, yte_ = (ytr > thr).astype(int), (yte > thr).astype(int)
+            secs, score = {}, {}
+            for name, mode in (("scratch", True), ("replay", "replay")):
+                est = Est(random_state=a.seed, refit_full=mode)
+                t0 = time.perf_counter()
+                est.fit(Xtr, ytr_, cat_features=cat)
+                secs[name] = time.perf_counter() - t0
+                if task == "reg":
+                    score[name] = float(np.sqrt(np.mean(
+                        (yte_ - est.predict(Xte)) ** 2)))
+                else:
+                    p = est.predict_proba(Xte)[:, 1]
+                    score[name] = float(np.mean((p - yte_) ** 2))
+            r = secs["replay"] / secs["scratch"]
+            # Lower is better for both metrics, so a positive delta is a win.
+            d = (score["scratch"] - score["replay"]) / score["scratch"] * 100
+            print(f"{task:6s} {n:9d} {secs['scratch']:10.1f} "
+                  f"{secs['replay']:9.1f} {r:7.3f} {(1 - r) * 100:7.1f}% "
+                  f"{d:+10.3f}", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Confirmation only. #41 and #42 have merged; nothing here can change that, and nothing here was allowed to. These are the suites that took no part in the decision, plus two questions the decision suites cannot answer.

Benchmarks and docs only — no library change.

## Public validation suite (22 datasets, n ≥ 50k, 3 seeds)

Never sealed, never blocking, no overlap with anything we decided on, and heavy on real high-cardinality categoricals — the regime where the leakage bug in #41 lived.

**6 wins / 6 losses / 10 ties, mean −0.114%, median +0.000%.**

All nine multiclass datasets tied *exactly*, which re-confirms the multiclass no-op on real large data rather than on synthetics. It also explains why the whole-suite speed ratio (0.896×) looks unimpressive: those nine untouched datasets are 71% of the suite's compute. On the 13 datasets replay actually touches it is **0.626× — 37% faster, on 13 of 13**.

The mean is carried by two datasets (rossmann −1.63%, BNP Paribas −0.93%) against six wins.

## PMLB (25 datasets, 3 seeds)

The suite most likely to find a weakness. It is small-data heavy, and the full-data refit's original gains concentrated in steep learning curves — so if replay gives something up, this is where it should show.

It didn't: **9 wins / 5 losses / 11 ties, mean −0.043%, median +0.000%.** More wins than losses.

One cell looks alarming — `holdout/dis` at −3.00% — but its per-seed deltas are −0.088, +0.025, −0.012. That is a tiny, severely imbalanced binary set with a noisy metric, swinging hard in both directions, not a regression.

## Backward compatibility

Models fitted and pickled by the pre-#41 library load under the new code and predict **bit-identically** — regression, binary and multiclass — even though their booster objects predate the `replay_donor` attribute entirely (predict never reads it). An unpickled estimator still carries `refit_full=True`, so re-fitting an old model keeps the old behaviour rather than silently switching.

## How the saving scales with n

Every suite caps dataset size, so "−35%" really meant "−35% at up to about 50k rows". Measured directly on mixed numeric/categorical data (`benchmarks/replay_scaling.py`, new here):

| task | 50k | 200k | 500k |
|---|--:|--:|--:|
| regression | 27.5% | 28.9% | 28.4% |
| binary | 27.0% | 29.0% | 27.2% |

**Flat at 27–29% across a tenfold change in rows.** Together with PMLB's ~12% on few-thousand-row sets, the shape is: the saving climbs out of small data and then plateaus near 30%. It does not keep growing, so nobody should promise more at giant n.

`scaling_giant.py` cannot answer this, which is why the new script exists: it fits a fixed tree count with early stopping switched off, and that is precisely the path on which no refit happens at all.

## Where that leaves things

Four independent suites now agree that accuracy is a wash, two of which played no part in the decision:

| suite | mean change | median |
|---|--:|--:|
| Grinsztajn | +0.005% | −0.005% |
| high-cardinality | −0.017% | +0.000% |
| PMLB | −0.043% | +0.000% |
| public | −0.114% | +0.000% |

666 tests green.

Still outstanding and deliberately not done here: TabArena is stale now that defaults have moved. It is the sealed holdout, so it is report-only and gets re-read at release rather than at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGecEaEUyD3qWMtMMR1ECx
