### PR TITLE
Shared-tree multi-quantile head (quantile vector leaf)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to ChimeraBoost are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
+### Added
+- **`ChimeraBoostQuantileRegressor`: a whole predictive distribution from one
+  booster, with predictions that cannot cross.** One tree structure per round
+  serves every level in `quantiles` (default 0.05 ... 0.95), each leaf holding
+  a K-vector whose entries are the exact per-level empirical quantiles of the
+  leaf's residuals. `predict` returns the grid, or a central interval, or the
+  mean by integrating the quantile function.
+
+  The ordering guarantee is structural rather than a repair applied at predict
+  time: the model starts from the sorted global quantiles and every leaf
+  vector is projected onto increments that cannot reorder anything, so
+  `diff(Q, axis=1) >= 0` holds exactly, at every intermediate `staged_predict`
+  stage too. Measured crossing rate 0.0000 against 0.18-0.21 for 19
+  independently fitted LightGBM quantile boosters. Intervals can still be
+  narrower than the pooled one where the data is quiet — a narrowing budget
+  buys that back, which a plain monotone-increment construction cannot express
+  at all.
+
+  The split search runs once per round instead of once per level, so the
+  saving grows with data width: **3.4x the fit speed of 19 independent
+  boosters at 5 features, 4.8x at 32, 7.8x at 128**, with pinball loss within
+  3% throughout and better on wide data. `conformalize=True` calibrates the
+  intervals on a fold held out before the early-stopping split (worst coverage
+  error 0.7 points at n = 10 000). New `chimeraboost.quantile_metrics` scores
+  a predicted grid: per-level pinball, CRPS, and coverage with width.
+  Full record in `benchmarks/QUANTILE_PLAN.md`; defaults elsewhere are
+  untouched.
+
 ### Changed
 - **``refit_full`` now defaults to ``"replay"``: the same full-data refit for
   about two thirds of the fit time.** Refitting the early-stopping winner on

--- a/benchmarks/QUANTILE_PLAN.md
+++ b/benchmarks/QUANTILE_PLAN.md
@@ -1,0 +1,146 @@
+# Shared-tree multi-quantile head
+
+One booster, an arbitrary tau grid, a K-vector in every leaf. Replaces "fit K
+independent quantile boosters" for estimating a whole predictive
+distribution.
+
+Run: `python benchmarks/quantile_head.py` (alone). Writes
+`benchmarks/results/quantile-head.md`.
+
+## What the split search actually is
+
+Pinball loss has hessian 1 in every channel, so for a fixed candidate split
+the exact summed-across-tau gain collapses to a norm:
+
+```
+gain = ‖G_L‖²/(n_L+l2) + ‖G_R‖²/(n_R+l2) - ‖G_P‖²/(n_P+l2)
+```
+
+By Parseval this equals the sum of projected gains over **any** orthonormal
+basis. So projecting the K gradient columns onto one direction is the rank-1
+truncation of the exact gain, not a different algorithm, and the only question
+is which direction to keep. `exact_splits=True` computes the norm form
+directly, at K histogram channels per feature; it is the reference arm.
+
+A second structural fact makes the whole thing cheap. Row i's gradient is
+`e(r_i) - taus`, where `r_i` is the row's PIT rank (how many of its own K
+estimates the target falls above) and `e(r)` is the step vector that turns on
+at r. A row's entire gradient is therefore one integer, so projecting onto `c`
+is just scoring that rank by `phi(r) = sum(c[r:])`. The fit never builds an
+(n, K) gradient at all: one binary search per row into that row's own sorted
+score vector, then a table lookup (`tree._project_pinball`).
+
+It also says what the candidate directions ARE. Taking `c` polynomial in tau
+of degree 0, 1, 2 makes phi degree 1, 2, 3 in the rank: location, spread,
+skew.
+
+## Decisions, each measured
+
+**Which direction (`split_projection`).** Excess pinball over the oracle,
+x1000, 3 seeds, four regimes (see the results file for the current run):
+
+| arm | location | scale | mixed | extreme | TOTAL |
+|:--|--:|--:|--:|--:|--:|
+| rotate (default) | 13.161 | 21.082 | 30.541 | 55.735 | **120.520** |
+| sum | 13.056 | 17.222 | 43.150 | 72.966 | 146.394 |
+| gram | 12.715 | 17.573 | 43.264 | 72.996 | 146.548 |
+| exact | 15.651 | 20.705 | 28.039 | 48.404 | 112.799 |
+
+- **The literal channel sum is dead.** On a symmetric grid the tau and 1-tau
+  pushes are equal and opposite, so a region that is centred correctly but too
+  narrow sums to exactly zero. It is competitive only where nothing but the
+  centre moves.
+- **`rotate` lands within 7% of the exact gain** at one histogram per round
+  instead of K.
+- **Measuring the direction instead of cycling ("gram") did not pay.** Two
+  failure modes, both instructive. Raw gradient energy is dominated by
+  per-row Bernoulli noise, which is largest at the median, so the top
+  eigenvector collapses onto the location contrast and inherits its blindness
+  to spread. Whitening by the no-signal (Brownian-bridge) covariance fixes
+  that but is ill-conditioned -- the null's eigenvalues fall like 1/k², so its
+  inverse amplifies exactly the high-frequency directions carrying only
+  sampling noise, and unrestricted whitening measured four times worse than
+  cycling on location-driven data. Restricting the ratio to the Legendre
+  subspace makes it well-posed and it still only ties. Kept as an option, not
+  the default.
+
+**Cycle weighting.** Two rounds of location per round of spread beat uniform
+cycling at both K=3 and K=19, and every schedule that also spent rounds on
+skew was worse. `_ROTATE_PATTERN = (0, 0, 1)`.
+
+## Why predictions cannot cross
+
+Init is the sorted global quantiles, every committed leaf vector is projected
+onto an admissible set, IEEE addition is monotone, and the packed predictor
+accumulates trees in identical order for every channel. So
+`diff(pred, axis=1) >= 0` holds exactly. Measured crossing rate: **0.0000**
+everywhere, against 0.18-0.21 for K independent LightGBM boosters.
+
+**The obvious construction does not work.** "Commit only non-decreasing
+increments" is sound but far too strong: a sum of non-decreasing vectors is
+non-decreasing, so the predicted interval could never be NARROWER than the
+pooled one, and the low-noise half of heteroscedastic data becomes
+inexpressible. Forcing it by sorting is worse still -- it reverses a narrowing
+update into a widening one, which is self-reinforcing. Measured: pinball
+2.9e7 against an oracle of 0.35, i.e. divergence.
+
+What works is a **narrowing budget**. `gap[k]` is a lower bound on
+`Q_k(x) - Q_{k-1}(x)` valid for ANY input row, not just training rows: a row's
+gap is the initial gap plus, per tree, the increment gap at whichever leaf it
+lands in, and each of those is at least the minimum over that tree's leaves.
+Each round may give away at most the currently guaranteed gap, and the
+realized minimum is subtracted afterwards. The admissible set
+`{v : v_k - v_{k-1} >= -b_k}` becomes plain monotonicity under
+`u_k = v_k + sum(b_1..b_k)`, so the projection is isotonic regression
+(pool-adjacent-violators, which averages violators -- a sort permutes them and
+can flip a contrast's sign). A floor at 1e-9 of the initial spread keeps the
+guaranteed margin far above float64 accumulation error.
+
+## Conformalization
+
+`conformalize=True` carves a calibration fold **before** the early-stopping
+split, so it sees no training, no stopping decision and no model selection.
+
+The correction is a per-level **scale about the predicted median**, not the
+usual additive widening. An additive correction that shrinks an interval is a
+non-monotone offset vector, and the only way to apply one safely is out of the
+narrowing budget -- which the fit has already spent, so it projects away to
+nothing (measured: offsets of exactly 0). Scaling has no such problem, and
+shrinking is what is actually needed: a shrunk-fit quantile model is
+systematically over-dispersed, because every round's step is scaled by the
+learning rate so the grid never fully contracts. Measured raw coverage at
+nominal 0.70 was 0.844.
+
+Fails loudly when the fold cannot support the requested levels
+(`ceil((n+1)(1-alpha)) <= n` needs `n >= (1-alpha)/alpha`).
+
+## Acceptance ledger
+
+Target from the build request, against K = 19 LightGBM 4.6.0 quantile
+boosters sharing one Dataset, 300 rounds, depth 4, lr 0.1, n = 20 000,
+3 seeds.
+
+| criterion | target | measured | verdict |
+|:--|:--|:--|:--|
+| pinball vs K LightGBM boosters | match within noise | ratio 1.029 (5 features) to 0.996 (128) | **PASS** |
+| fit wall clock | >= K/2 = 9.5x faster | 3.4x (5 features) rising to 7.8x (128) | **MISS** |
+| crossing rate, no predict-time patch | exactly 0 | 0.0000 at every width; LightGBM 0.18-0.21 | **PASS** |
+| CQR coverage at n=10k | within 2 points of nominal | worst 0.73 points | **PASS** |
+
+**On the speed miss.** The saving is concentrated in the split search, which
+runs once per round instead of K times, so the speedup grows with how wide the
+data is: 3.4x at 5 features, 4.8x at 32, 6.0x at 64, 7.8x at 128, and still
+climbing. It does not reach 9.5x in the tested range because the leaf refit is
+irreducibly K quantile selections per leaf and is ~90% of a round at ordinary
+widths, while a single LightGBM quantile round is very cheap. Three
+optimizations already landed and are in the numbers above: the PIT-rank
+projection (no (n, K) gradient, -35% fit), a K-aware serial/parallel dispatch
+threshold (the leaf refit does K times the scalar path's per-row work, so the
+fork/join break-even arrives at K times fewer rows, +65%), and parallelizing
+the refit over (leaf, channel) pairs rather than leaves, since real oblivious
+trees are badly unbalanced.
+
+Tried and reverted: gathering leaf residuals channel-major in one pass. It
+trades K forward strided reads for a transposing write and measured slower --
+the per-channel scan is prefetcher-friendly and the leaf's slice of the score
+matrix stays resident across the K passes.

--- a/benchmarks/quantile_head.py
+++ b/benchmarks/quantile_head.py
@@ -1,0 +1,284 @@
+"""Acceptance benchmark for the shared-tree multi-quantile head.
+
+Answers four questions, each against a stated reference:
+
+  1. Accuracy   -- does one shared tree structure match K independent
+                   LightGBM quantile boosters on pinball loss? The true
+                   conditional quantiles are known in closed form here, so
+                   both are also scored against the oracle floor.
+  2. Speed      -- is it at least K/2 times faster to fit than those K
+                   boosters? The saving is concentrated in the split search,
+                   while several per-round costs scale with K, so the answer
+                   depends on how wide the data is. The feature sweep reports
+                   where the K/2 line is actually crossed rather than quoting
+                   one flattering shape.
+  3. Crossing   -- ours must be exactly zero. Independent per-level models are
+                   not, and the table says by how much.
+  4. Coverage   -- do the intervals hold what they claim, before and after
+                   conformalization?
+
+Also ablates the split projection, since "which direction do we collapse the
+K gradient columns onto" is the head's one real design decision.
+
+Run alone -- one benchmark at a time, or the timings are noise.
+    python benchmarks/quantile_head.py [--quick]
+Writes: benchmarks/results/quantile-head.md
+"""
+
+import argparse
+import os
+import sys
+import time
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import chimeraboost  # noqa: E402
+from chimeraboost import ChimeraBoostQuantileRegressor  # noqa: E402
+from chimeraboost import quantile_metrics as qm  # noqa: E402
+from chimeraboost.warmup import warmup  # noqa: E402
+
+TAUS = np.round(np.arange(0.05, 0.951, 0.05), 10)
+
+
+def make_data(n, p, seed, regime="mixed"):
+    """Heteroscedastic Gaussian data whose conditional quantiles are known.
+
+    The centre depends on one column and the spread on another, so the oracle
+    quantile is ``mu(x) + sigma(x) * Phi^-1(tau)`` exactly.
+    """
+    from scipy.stats import norm
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((n, p))
+    if regime == "location":
+        mu, sd = 2.0 * X[:, 0], np.ones(n)
+    elif regime == "scale":
+        mu, sd = np.zeros(n), 0.3 + 2.7 * (X[:, 1] > 0)
+    elif regime == "extreme":
+        mu, sd = 2.0 * X[:, 0], 0.1 + 2.0 * (X[:, 1] > 0)
+    else:
+        mu, sd = 2.0 * X[:, 0], 0.4 + 1.6 * (X[:, 1] > 0)
+    # A little extra structure so the split search has something to find.
+    mu = mu + np.sin(X[:, 2] * 2.0) + 0.5 * X[:, 3] * X[:, 4]
+    y = mu + sd * rng.standard_normal(n)
+    q_oracle = mu[:, None] + sd[:, None] * norm.ppf(TAUS)[None, :]
+    return X, y, q_oracle
+
+
+def fit_chimera(Xt, yt, Xv, rounds, **kw):
+    m = ChimeraBoostQuantileRegressor(
+        quantiles=TAUS, n_estimators=rounds, learning_rate=0.1, depth=4,
+        random_state=0, early_stopping=False, **kw)
+    t0 = time.perf_counter()
+    m.fit(Xt, yt)
+    fit_s = time.perf_counter() - t0
+    t0 = time.perf_counter()
+    Q = m.predict(Xv)
+    return Q, fit_s, time.perf_counter() - t0
+
+
+def fit_lightgbm(Xt, yt, Xv, rounds):
+    """K independent LightGBM quantile boosters -- the strong version of the
+    baseline: one shared Dataset built once, so it is not charged K times for
+    binning the same rows."""
+    import lightgbm as lgb
+    t0 = time.perf_counter()
+    ds = lgb.Dataset(Xt, label=yt, free_raw_data=False)
+    boosters = []
+    for tau in TAUS:
+        params = {"objective": "quantile", "alpha": float(tau),
+                  "learning_rate": 0.1, "num_leaves": 16, "max_depth": 4,
+                  "min_data_in_leaf": 20, "verbose": -1, "seed": 0,
+                  "deterministic": True, "num_threads": 0}
+        boosters.append(lgb.train(params, ds, num_boost_round=rounds))
+    fit_s = time.perf_counter() - t0
+    t0 = time.perf_counter()
+    Q = np.column_stack([b.predict(Xv) for b in boosters])
+    return Q, fit_s, time.perf_counter() - t0
+
+
+def pinball(y, Q):
+    r = np.asarray(y)[:, None] - Q
+    return float(np.maximum(TAUS * r, (TAUS - 1.0) * r).mean())
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--rounds", type=int, default=300)
+    ap.add_argument("--n", type=int, default=20000)
+    ap.add_argument("--seeds", type=int, default=3)
+    ap.add_argument("--quick", action="store_true",
+                    help="one seed, fewer shapes")
+    args = ap.parse_args()
+    if args.quick:
+        args.seeds = 1
+
+    print(f"chimeraboost: {chimeraboost.__file__}")
+    try:
+        import lightgbm
+        print(f"lightgbm: {lightgbm.__version__}")
+        have_lgb = True
+    except ImportError:
+        print("(skip LightGBM -- not installed)")
+        have_lgb = False
+    print(f"K = {TAUS.size} levels, K/2 speed target = {TAUS.size / 2:.1f}x")
+    print("warming JIT...", flush=True)
+    warmup()
+
+    lines = ["# Multi-quantile head: acceptance", "",
+             f"K = {TAUS.size} levels (0.05 ... 0.95), "
+             f"{args.rounds} rounds, depth 4, lr 0.1, "
+             f"{args.seeds} seed(s), n = {args.n}.", ""]
+
+    # ---------------------------------------------------------------- 1 + 2
+    widths = [8, 20] if args.quick else [5, 8, 16, 32, 64, 128]
+    print(f"\n{'=' * 78}\nHEAD TO HEAD vs K independent LightGBM quantile "
+          f"boosters\n{'=' * 78}")
+    hdr = (f"{'features':>9s}{'ChimB pin':>11s}{'LGBM pin':>11s}"
+           f"{'oracle':>10s}{'ratio':>8s}{'ChimB fit':>11s}{'LGBM fit':>11s}"
+           f"{'speedup':>9s}{'ChimB xs':>10s}{'LGBM xs':>9s}")
+    print(hdr)
+    print("-" * len(hdr))
+    tbl = ["## Accuracy and speed vs K independent LightGBM boosters", "",
+           "`ratio` is our pinball over LightGBM's (1.00 = identical, lower is "
+           "better). `speedup` is their fit wall clock over ours; the target "
+           f"is K/2 = {TAUS.size / 2:.1f}x. `xs` columns are crossing rates.",
+           "",
+           "| features | ChimB pinball | LGBM pinball | oracle | ratio | "
+           "ChimB fit s | LGBM fit s | speedup | ChimB crossing | "
+           "LGBM crossing |",
+           "|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|"]
+    for p in widths:
+        cp = lp = op = cf = lf = cx = lx = 0.0
+        for s in range(args.seeds):
+            X, y, Qo = make_data(args.n, p, s)
+            c = int(args.n * 0.75)
+            Xt, yt, Xv, yv, Qov = X[:c], y[:c], X[c:], y[c:], Qo[c:]
+            Q, f, _ = fit_chimera(Xt, yt, Xv, args.rounds)
+            cp += pinball(yv, Q)
+            cf += f
+            cx += qm.crossing_rate(Q)
+            op += pinball(yv, Qov)
+            if have_lgb:
+                Ql, fl, _ = fit_lightgbm(Xt, yt, Xv, args.rounds)
+                lp += pinball(yv, Ql)
+                lf += fl
+                lx += qm.crossing_rate(Ql)
+        k = args.seeds
+        cp, lp, op, cf, lf, cx, lx = (v / k for v in
+                                      (cp, lp, op, cf, lf, cx, lx))
+        ratio = cp / lp if lp else float("nan")
+        speed = lf / cf if cf else float("nan")
+        print(f"{p:9d}{cp:11.5f}{lp:11.5f}{op:10.5f}{ratio:8.3f}"
+              f"{cf:11.2f}{lf:11.2f}{speed:8.1f}x{cx:10.4f}{lx:9.4f}")
+        tbl.append(f"| {p} | {cp:.5f} | {lp:.5f} | {op:.5f} | {ratio:.3f} | "
+                   f"{cf:.2f} | {lf:.2f} | {speed:.1f}x | {cx:.4f} | "
+                   f"{lx:.4f} |")
+    lines += tbl + [""]
+
+    # ------------------------------------------------------------------- 3
+    print(f"\n{'=' * 78}\nSPLIT PROJECTION ABLATION (excess pinball over the "
+          f"oracle, x1000)\n{'=' * 78}")
+    arms = [("rotate (default)", dict()), ("sum", dict(split_projection="sum")),
+            ("gram", dict(split_projection="gram")),
+            ("exact", dict(exact_splits=True))]
+    regimes = ["location", "scale", "mixed"] if args.quick else \
+        ["location", "scale", "mixed", "extreme"]
+    hdr = f"{'arm':18s}" + "".join(f"{r:>11s}" for r in regimes) + \
+        f"{'TOTAL':>11s}{'fit s':>9s}"
+    print(hdr)
+    print("-" * len(hdr))
+    tbl = ["## Split-projection ablation", "",
+           "Excess pinball over the oracle, x1000 (lower is better). "
+           "`location` moves only the centre, `scale` only the spread, "
+           "`extreme` is a 21x spread ratio. `sum` is the literal "
+           "channel sum; `exact` scores the true summed-across-level gain at "
+           "K histogram channels per feature.", "",
+           "| arm | " + " | ".join(regimes) + " | TOTAL | fit s |",
+           "|:--|" + "--:|" * (len(regimes) + 2)]
+    n_ab = 8000 if not args.quick else 4000
+    for name, kw in arms:
+        tot = 0.0
+        secs = 0.0
+        cells = []
+        for reg in regimes:
+            ex = 0.0
+            for s in range(args.seeds):
+                X, y, Qo = make_data(n_ab, 10, s, reg)
+                c = int(n_ab * 0.7)
+                Q, f, _ = fit_chimera(X[:c], y[:c], X[c:], args.rounds, **kw)
+                ex += (pinball(y[c:], Q) - pinball(y[c:], Qo[c:])) * 1000
+                secs += f
+            ex /= args.seeds
+            tot += ex
+            cells.append(ex)
+        print(f"{name:18s}" + "".join(f"{v:11.3f}" for v in cells)
+              + f"{tot:11.3f}{secs / (len(regimes) * args.seeds):9.2f}")
+        tbl.append(f"| {name} | " + " | ".join(f"{v:.3f}" for v in cells)
+                   + f" | {tot:.3f} | "
+                     f"{secs / (len(regimes) * args.seeds):.2f} |")
+    lines += tbl + [""]
+
+    # ------------------------------------------------------------------- 4
+    print(f"\n{'=' * 78}\nINTERVAL COVERAGE AND WIDTH (n = 10000 train, 20000 "
+          f"test)\n{'=' * 78}")
+    # Averaged over seeds: a single calibration fold of a few thousand rows
+    # carries about a point of coverage noise on its own, which would
+    # otherwise be most of what the table shows.
+    cov_p, cov_c = [], []
+    for s in range(args.seeds):
+        X, y, _ = make_data(30000, 12, s)
+        Xt, yt, Xv, yv = X[:10000], y[:10000], X[10000:], y[10000:]
+        plain = ChimeraBoostQuantileRegressor(
+            quantiles=TAUS, n_estimators=400, random_state=0).fit(Xt, yt)
+        conf = ChimeraBoostQuantileRegressor(
+            quantiles=TAUS, n_estimators=400, random_state=0,
+            conformalize=True).fit(Xt, yt)
+        cov_p.append(qm.interval_coverage(yv, plain.predict(Xv), TAUS))
+        cov_c.append(qm.interval_coverage(yv, conf.predict(Xv), TAUS))
+    hdr = (f"{'interval':>11s}{'nominal':>9s}{'plain cov':>11s}"
+           f"{'CQR cov':>10s}{'plain wid':>11s}{'CQR wid':>10s}{'err pp':>9s}")
+    print(hdr)
+    print("-" * len(hdr))
+    tbl = ["## Interval coverage and width", "",
+           "Trained on 10 000 rows, scored on 20 000 fresh ones. `err pp` is "
+           "the conformalized coverage minus nominal, in percentage points; "
+           "the acceptance target is within 2.", "",
+           "| interval | nominal | plain coverage | CQR coverage | "
+           "plain width | CQR width | err pp |",
+           "|:--|--:|--:|--:|--:|--:|--:|"]
+    worst = 0.0
+    mean_p = [{k: np.mean([r[i][k] for r in cov_p]) for k in cov_p[0][i]}
+              for i in range(len(cov_p[0]))]
+    mean_c = [{k: np.mean([r[i][k] for r in cov_c]) for k in cov_c[0][i]}
+              for i in range(len(cov_c[0]))]
+    for a, b in zip(mean_p, mean_c):
+        err = (b["coverage"] - b["nominal"]) * 100
+        worst = max(worst, abs(err))
+        lbl = f"{a['lo']:.2f}-{a['hi']:.2f}"
+        print(f"{lbl:>11s}{a['nominal']:9.2f}{a['coverage']:11.4f}"
+              f"{b['coverage']:10.4f}{a['width']:11.4f}{b['width']:10.4f}"
+              f"{err:9.2f}")
+        tbl.append(f"| {lbl} | {a['nominal']:.2f} | {a['coverage']:.4f} | "
+                   f"{b['coverage']:.4f} | {a['width']:.4f} | "
+                   f"{b['width']:.4f} | {err:+.2f} |")
+    print(f"\nworst conformalized coverage error: {worst:.2f} pp "
+          f"({'PASS' if worst <= 2.0 else 'FAIL'} vs the 2 pp target)")
+    print(f"crossing rate, plain: {qm.crossing_rate(plain.predict(Xv)):.6f}  "
+          f"conformalized: {qm.crossing_rate(conf.predict(Xv)):.6f}")
+    tbl += ["", f"Worst conformalized coverage error **{worst:.2f} pp** "
+                f"({'PASS' if worst <= 2.0 else 'FAIL'} against the 2 pp "
+                f"target). Crossing rate 0 in both columns.", ""]
+    lines += tbl
+
+    out = os.path.join(os.path.dirname(os.path.abspath(__file__)), "results",
+                       "quantile-head.md")
+    os.makedirs(os.path.dirname(out), exist_ok=True)
+    with open(out, "w", encoding="utf-8") as fh:
+        fh.write("\n".join(lines) + "\n")
+    print(f"\nwrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/chimeraboost/__init__.py
+++ b/chimeraboost/__init__.py
@@ -17,7 +17,9 @@ from .sklearn_api import (
     ChimeraBoostRegressor,
     ChimeraBoostClassifier,
 )
+from .quantile_api import ChimeraBoostQuantileRegressor
 from .losses import CustomObjective
+from . import quantile_metrics
 from .warmup import warmup, _warmup_from_env
 
 # CHIMERABOOST_WARMUP=1 -> compile the numba kernels at import ("background"
@@ -28,7 +30,9 @@ _warmup_from_env(_os.environ.get("CHIMERABOOST_WARMUP"))
 __all__ = [
     "ChimeraBoostRegressor",
     "ChimeraBoostClassifier",
+    "ChimeraBoostQuantileRegressor",
     "CustomObjective",
+    "quantile_metrics",
     "warmup",
 ]
 __version__ = "0.25.0"

--- a/chimeraboost/booster.py
+++ b/chimeraboost/booster.py
@@ -10,10 +10,14 @@ from contextlib import contextmanager
 
 import numpy as np
 
-from .losses import LOSSES, MultiSoftmax
+from .losses import LOSSES, MultiSoftmax, MultiQuantile
 from .preprocessing import FeaturePreprocessor, as_model_array
 from .binning import _SERIAL_PREDICT_N
 from .tree import (build_oblivious_tree, replay_oblivious_tree,
+                   build_oblivious_tree_exact, alloc_exact_hist, _SMALL_N,
+                   _leaf_quantiles_vec, _leaf_quantiles_vec_serial,
+                   _leaf_quantiles_vec_w, _leaf_quantiles_vec_w_serial,
+                   _project_pinball, _add_leaf_values,
                    _loo_leaf_step, _leaf_values,
                    _leaf_values_vec, _linear_predict,
                    _predict_forest_rm, _predict_forest_rm_serial,
@@ -1013,3 +1017,459 @@ class MulticlassBoosting(_BaseBooster):
             F[:, k] = kernel(Xb, feats, thrs, depths, vals, voff,
                              self.init_[k])
         return F
+
+
+# Rows sampled to estimate the gradient covariance for the split direction.
+# The top eigenvector is a direction, not a precise quantity, and it does not
+# need every row; capping keeps the Gram a few percent of round cost on large
+# data instead of growing with n.
+_GRAM_MAX_ROWS = 16384
+
+# Which contrast each round uses under ``split_projection="rotate"``, cycled.
+# Two rounds of location per round of spread: location carries most of the
+# available gain, but a pure location diet is blind to spread entirely.
+# Measured across location-only, spread-only, mixed and extreme
+# heteroscedastic regimes at both K=3 and K=19; this beat uniform cycling,
+# location-only, and every schedule that also spent rounds on skew. See
+# benchmarks/QUANTILE_PLAN.md.
+_ROTATE_PATTERN = (0, 0, 1)
+
+
+def _fixed_contrasts(taus, n_basis=2):
+    """Orthonormal split directions for ``split_projection`` of "sum" (the
+    first only) and "rotate" (cycled by `_ROTATE_PATTERN`).
+
+    Why polynomials in tau. Every row's pinball gradient is
+    ``e(r_i) - taus``, where ``r_i`` is the row's PIT rank -- how many of its
+    own K estimates the target falls above -- and ``e(r)`` is the step vector
+    that turns on at r. A row's whole gradient is therefore one number, so
+    projecting on a direction ``c`` is exactly scoring that rank by
+    ``phi(r) = sum(c[r:])``. Taking c polynomial in tau of degree 0 and 1
+    makes phi degree 1 and 2 in the rank:
+
+    * degree 1 (c constant) -- location. Finds regions where the whole
+      predictive distribution sits in the wrong place. This is the plain
+      channel sum, and it is the ONLY direction "sum" ever uses.
+    * degree 2 (c linear) -- spread. Finds regions whose width is wrong, which
+      the location contrast cannot see at all: on a symmetric grid the tau and
+      1-tau pushes are equal and opposite, so a correctly-centred but
+      too-narrow region sums to exactly zero.
+
+    A degree-3 (skew) contrast is available by raising ``n_basis`` but is not
+    used by default: across every regime measured it took rounds away from
+    location and spread without paying them back.
+
+    Gram-Schmidt keeps the directions orthonormal on the actual grid (they are
+    already near-orthogonal on a uniform one), and unit norm keeps the
+    projected curvature at exactly 1 per row.
+    """
+    K = taus.shape[0]
+    s = 2.0 * taus - 1.0                       # tau -> [-1, 1]
+    raw = [np.ones(K), s, 1.5 * s * s - 0.5]   # Legendre P0, P1, P2
+    basis = []
+    for v in raw[:max(1, n_basis)]:
+        v = v.astype(np.float64).copy()
+        for b in basis:
+            v -= (v @ b) * b
+        nrm = float(np.sqrt(v @ v))
+        if nrm > 1e-9:                # degenerate on very short grids
+            basis.append(v / nrm)
+    return basis
+
+
+def _null_whitener(grad, taus):
+    """Cholesky factor of the gradient covariance expected under NO x-signal.
+
+    A row's gradient is ``e(r_i) - taus`` for its PIT rank r, so when the rank
+    carries no information about x the covariance is the Brownian-bridge form
+    ``min(p_j, p_k) - p_j p_k`` -- fixed by the realized marginal rates p
+    alone, no fitting involved. Whitening by it is what stops the split
+    direction being chosen by noise: the raw gradient variance in channel k is
+    ``tau_k(1 - tau_k)``, four times larger at the median than at the 5%
+    tail, so the largest-energy direction is the median one whether or not
+    anything about the median depends on x.
+
+    Estimated from the realized rates rather than from ``taus`` so that a
+    globally miscalibrated model does not leak into the whitener.
+    """
+    p = np.clip(grad.mean(axis=0) + taus, 1e-6, 1.0 - 1e-6)
+    N = np.minimum(p[:, None], p[None, :]) - np.outer(p, p)
+    # Ridge for a strictly positive-definite factorization; scaled to the
+    # matrix so it is negligible relative to the real structure.
+    N += np.eye(p.shape[0]) * (1e-8 * float(np.trace(N)) / p.shape[0] + 1e-300)
+    try:
+        return np.linalg.cholesky(N)
+    except np.linalg.LinAlgError:
+        return None
+
+
+def _gram_direction(grad, taus, basis, rng):
+    """Best signal-to-noise split direction WITHIN the Legendre subspace.
+
+    With unit hessians the exact summed-across-tau split gain is
+    ``‖G_L‖²/(n_L+l2) + ‖G_R‖²/(n_R+l2) - ‖G_P‖²/(n_P+l2)``, which by Parseval
+    equals the sum of projected gains over any orthonormal basis. Projecting
+    onto one direction is therefore the rank-1 truncation of the exact gain
+    rather than a different algorithm, and the question is only which
+    direction to keep.
+
+    Same subspace "rotate" cycles through -- location, spread, skew (see
+    `_fixed_contrasts`) -- but weighted by what this round's gradients
+    actually show instead of taken in turn. Maximizes ``c'Cc / c'Nc`` over the
+    subspace, C being the centered gradient covariance and N the covariance
+    expected with no x-signal at all (`_null_whitener`). That is a 3x3
+    generalized eigenproblem, solved exactly.
+
+    Three corrections separate a useful direction from a useless one, and each
+    was measured rather than assumed:
+
+    * Centering. A gradient component shared by every row contributes exactly
+      zero gain (``n_L + n_R - n = 0``), so the raw second moment can point
+      somewhere no split is able to exploit.
+    * Whitening. Raw energy is dominated by per-row Bernoulli noise, largest
+      at the median; without whitening this collapses onto the location
+      contrast and inherits its blindness to spread.
+    * The subspace. Whitening across all of R^K is ill-conditioned -- the
+      Brownian-bridge null has eigenvalues falling like 1/k², so its inverse
+      amplifies exactly the high-frequency directions that carry only sampling
+      noise. Restricting to the low-order polynomials keeps the ratio
+      well-posed. Measured: unrestricted whitening was four times worse than
+      cycling on location-driven data.
+
+    Returns None on a degenerate covariance, leaving the caller on the
+    location contrast.
+    """
+    n = grad.shape[0]
+    G = grad
+    if n > _GRAM_MAX_ROWS:
+        # With replacement: this estimates a direction only, and it avoids the
+        # permutation cost of sampling without replacement on large n.
+        G = grad[rng.integers(0, n, size=_GRAM_MAX_ROWS)]
+    L = _null_whitener(G, taus)
+    if L is None:
+        return None
+    B = np.stack(basis, axis=1)                  # (K, n_basis), orthonormal
+    Gc = G - G.mean(axis=0)
+    GB = Gc @ B
+    Cb = GB.T @ GB                               # B'CB
+    LB = L.T @ B
+    Nb = LB.T @ LB                               # B'NB
+    Nb += np.eye(Nb.shape[0]) * (1e-12 * float(np.trace(Nb)) + 1e-300)
+    try:
+        M = np.linalg.solve(Nb, Cb)
+        vals, vecs = np.linalg.eig(M)
+    except np.linalg.LinAlgError:
+        return None
+    w = np.real(vecs[:, int(np.argmax(np.real(vals)))])
+    c = B @ w
+    nrm = float(np.sqrt(c @ c))
+    if nrm < 1e-250:
+        return None
+    c = c / nrm                        # unit norm keeps min_child_weight exact
+    # Pin the sign (largest-magnitude component positive) so repeated fits are
+    # reproducible. Gain is even in the direction, so this changes no split.
+    if c[np.argmax(np.abs(c))] < 0.0:
+        c = -c
+    return c
+
+
+class MultiQuantileBoosting(_BaseBooster):
+    """Multi-quantile booster: one VECTOR-LEAF tree per round, K quantiles.
+
+    Each round grows a single oblivious tree whose leaves hold a K-vector, one
+    entry per level in ``quantiles``. Two things make this more than K boosters
+    stapled together:
+
+    * The split search runs on a 1-d projection of the K pinball-gradient
+      columns, so the scalar split kernels (quantized path included) are reused
+      verbatim -- one histogram per round rather than K. `_gram_direction`
+      explains why any single projection is the rank-1 truncation of the exact
+      summed-across-tau gain rather than a different algorithm;
+      `_fixed_contrasts` explains which directions are worth truncating to,
+      and why the plain channel sum is the worst available choice.
+    * Leaf values are the EXACT per-tau empirical quantile of the leaf's
+      residuals (`tree._leaf_quantiles_vec`), not a Newton step -- the vector
+      form of the override the scalar MAE/Quantile path already applies.
+
+    The starting vector is the sorted global quantiles and every committed
+    leaf vector is projected onto the non-crossing set before it is added, so
+    every partial sum is monotone in tau: predictions cannot cross, and there
+    is no predict-time repair anywhere in this class. The projection is NOT a
+    sort -- see `tree._project_leaf_row` for why sorting both diverges and
+    makes narrow intervals inexpressible, and `_fit_impl` for the narrowing
+    budget that keeps the guarantee valid for rows the fit never saw.
+
+    Known limitation, by construction: within one round, gradient signal
+    orthogonal to the chosen direction cannot drive a split. The exact leaf
+    refit still expresses that shape within whatever partition it is handed,
+    so the failure mode is graceful, and the direction is re-measured every
+    round -- once a mode is fit its energy drops and the next mode takes over
+    without any schedule. ``exact_splits=True`` removes the limitation at K
+    times the histogram cost.
+    """
+
+    def __init__(self, quantiles=None, split_projection="rotate",
+                 exact_splits=False, **kw):
+        super().__init__(**kw)
+        taus = (np.arange(0.05, 0.9501, 0.05) if quantiles is None
+                else np.asarray(quantiles, dtype=np.float64))
+        self.quantiles = np.ascontiguousarray(taus, dtype=np.float64)
+        self.split_projection = split_projection
+        self.exact_splits = bool(exact_splits)
+
+    def _split_direction(self, grad, m, rng):
+        """Unit-norm direction to project this round's gradient columns onto.
+
+        Unit norm matters beyond tidiness: the pinball hessian is 1, so the
+        projected curvature is exactly 1 per row, which keeps
+        ``min_child_weight`` and ``l2_leaf_reg`` meaning precisely what they
+        mean on today's scalar Quantile path.
+
+        "rotate" is the default because it measured best of the cheap arms --
+        see benchmarks/QUANTILE_PLAN.md. Cycling guarantees each contrast a
+        fixed share of rounds; picking the strongest one greedily ("gram")
+        sounds better and is not, because on data whose only signal is spread
+        it drifts onto the location contrast and never comes back."""
+        basis = self._contrasts_
+        if self.split_projection == "gram":
+            v = _gram_direction(grad, self.quantiles, basis, rng)
+            return basis[0] if v is None else v
+        if self.split_projection == "rotate":
+            i = _ROTATE_PATTERN[m % len(_ROTATE_PATTERN)]
+            return basis[min(i, len(basis) - 1)]
+        return basis[0]         # "sum": the literal channel sum
+
+    def _fit_impl(self, X, y, cat_features=None, eval_set=None,
+                  sample_weight=None, callbacks=None, prep_cache=None):
+        """Fit one vector-leaf quantile tree per boosting round. Same
+        `cat_features` / `eval_set` / `sample_weight` semantics as the scalar
+        booster. (Called via the base ``fit``, which owns the thread limit.)"""
+        X = as_model_array(X, bool(cat_features))
+        y = np.ascontiguousarray(y, dtype=np.float64)
+        n_samples = X.shape[0]
+        w = self._normalize_weights(sample_weight, n_samples)
+
+        taus = self.quantiles
+        K = taus.shape[0]
+        self.n_quantiles_ = K
+        self.loss_ = MultiQuantile(taus)
+        self.lr_ = self._resolve_lr(n_samples, eval_set)
+        self._contrasts_ = _fixed_contrasts(taus)
+
+        # One TS-encoding target: every quantile shares the same y, unlike
+        # multiclass where each class gets its own one-hot column.
+        Xb, Xvb = self._prep_matrices(X, [y], cat_features, eval_set,
+                                      prep_cache, w)
+        n_bins = self.prep_.n_bins_
+        # The exact arm needs its own K-deep buffers and never touches the
+        # scalar ones; allocate exactly one of the two.
+        if self.exact_splits:
+            hist_buffers, qbuf = None, None
+            exact_hist = alloc_exact_hist(Xb.shape[0], self.depth, n_bins, K)
+        else:
+            exact_hist = None
+            hist_buffers = self._alloc_hist_buffers(Xb.shape[0], n_bins)
+            qbuf = (np.empty(n_samples, dtype=np.int64)
+                    if self.quantize_gradients else None)
+
+        yv = Fv = wv = None
+        if eval_set is not None:
+            yv = np.asarray(eval_set[1], dtype=np.float64)
+            if len(eval_set) > 2:
+                wv = _uniform_to_none(eval_set[2])
+
+        self.init_ = self.loss_.init(y, w)          # (K,), sorted
+        F = np.tile(self.init_, (n_samples, 1))     # (n, K)
+        if yv is not None:
+            Fv = np.tile(self.init_, (yv.shape[0], 1))
+
+        # --- narrowing budget -------------------------------------------
+        # `gap[k]` is a lower bound on Q_k(x) - Q_{k-1}(x) that holds for ANY
+        # input row, not just training rows: a row's gap is the initial gap
+        # plus, for each tree, the increment gap at whichever leaf it lands
+        # in, and each of those is at least the minimum over that tree's
+        # leaves. So bounding every leaf's increment gap below by -budget and
+        # then subtracting the round's realized minimum keeps the bound valid
+        # for rows the fit never saw.
+        #
+        # The floor keeps the bound comfortably above float64 accumulation
+        # error: intervals may narrow to a billionth of the global spread,
+        # which is unlimited in practice, while the guaranteed margin stays
+        # ~7 orders of magnitude above the rounding noise of summing a few
+        # hundred trees.
+        gap = np.diff(self.init_)                   # (K-1,), >= 0
+        floor = 1e-9 * max(float(self.init_[-1] - self.init_[0]), 1e-300)
+        cb = np.zeros(K)                            # cumulative budget
+
+        # Scratch reused every round: the projected gradient, the suffix-sum
+        # table `_project_pinball` indexes by PIT rank (one slot past the end
+        # so a rank of K reads zero), and a row-weight vector that is all ones
+        # when unweighted (exactly 1.0, so that path stays unchanged).
+        g_buf = np.empty(n_samples)
+        csuffix = np.zeros(K + 1)
+        w_row = np.ones(n_samples) if w is None else w
+        # Only two arms ever need the (n, K) gradient itself: "gram" measures
+        # its covariance, and the exact split search scatters all K channels.
+        need_grad = self.exact_splits or self.split_projection == "gram"
+
+        rng = np.random.default_rng(self.random_state)
+        self.trees_ = []
+        self._forest_ = None
+        self.train_history_, self.valid_history_ = [], []
+        stopper = _EarlyStopper(self.early_stopping_rounds)
+        cb_train_loss = _callbacks_need_train_loss(callbacks)
+        # `_SMALL_N` is the scalar path's fork/join break-even, in units of
+        # per-row work. The leaf refit does K quantile selections per leaf, so
+        # the same amount of work is reached at K times fewer rows -- comparing
+        # n alone would leave the parallel kernel unused on every ordinary
+        # dataset. Both branches are bit-identical, so this only moves speed.
+        small = n_samples * K <= _SMALL_N
+        t0 = time.time()
+
+        for m in range(self.n_estimators):
+            # The default arms know their direction up front, so they read the
+            # projection straight off each row's PIT rank and never build the
+            # (n, K) gradient at all -- see `tree._project_pinball`.
+            grad = None
+            if need_grad:
+                grad, _ = self.loss_.grad_hess(y, F)
+                if w is not None:
+                    grad = grad * w[:, None]
+            direction = self._split_direction(grad, m, rng)
+            if grad is not None and self.split_projection == "gram":
+                g_s = grad @ direction
+            else:
+                csuffix[:K] = np.cumsum(direction[::-1])[::-1]
+                _project_pinball(y, F, csuffix, float(direction @ taus),
+                                 w_row, g_buf)
+                g_s = g_buf
+            # Unit-norm direction + unit hessian => projected curvature is
+            # exactly 1 per row.
+            h_s = np.ones(n_samples)
+            # One MVS row selection per round, taken from the projection and
+            # reused for the leaf refit, so leaf values see exactly the rows
+            # the split search saw.
+            mw = self._mvs_row_weights(g_s, rng)
+            if mw is not None:
+                g_s, h_s = g_s * mw, h_s * mw
+            # Row weight seen by BOTH the split search and the leaf refit:
+            # sample weights times any MVS importance weight. None == uniform,
+            # which keeps the unweighted path on the fast kernels.
+            rw = w if mw is None else (mw if w is None else w * mw)
+            fmask = self._feature_mask(Xb.shape[0], rng)
+
+            if self.exact_splits:
+                tree, leaf = build_oblivious_tree_exact(
+                    Xb, grad if mw is None else grad * mw[:, None],
+                    n_bins, self.depth, self.l2_leaf_reg,
+                    feature_mask=fmask,
+                    min_child_weight=self.min_child_weight,
+                    row_weight=rw, hist_buffers=exact_hist)
+            else:
+                qseed = (int(rng.integers(1 << 63))
+                         if self.quantize_gradients else 0)
+                tree, leaf = build_oblivious_tree(
+                    Xb, g_s, h_s, n_bins, self.depth, self.l2_leaf_reg,
+                    self.lr_, feature_mask=fmask,
+                    min_child_weight=self.min_child_weight,
+                    hist_buffers=hist_buffers,
+                    quantize=self.quantize_gradients, qbuf=qbuf, qseed=qseed)
+
+            # No legal split: stop like the other boosters, keeping the best
+            # prefix exactly as the other exits do.
+            if tree.depth == 0:
+                if Fv is not None and stopper.patience:
+                    self.trees_ = self.trees_[: stopper.best_iter + 1]
+                break
+
+            # Replace the projection's scalar leaf values with the exact
+            # per-tau residual quantiles on the shared partition, sorted.
+            n_lv = tree.values.shape[0]
+            # Budget this round: the gap each channel can give away and still
+            # leave every possible row ordered. cb is its running sum, which
+            # is what turns the admissible set into plain monotonicity.
+            np.cumsum(np.maximum(gap - floor, 0.0), out=cb[1:])
+            if rw is None:
+                kern = (_leaf_quantiles_vec_serial if small
+                        else _leaf_quantiles_vec)
+                tree.values = kern(leaf, y, F, taus, cb, n_lv, self.lr_)
+            else:
+                kern = (_leaf_quantiles_vec_w_serial if small
+                        else _leaf_quantiles_vec_w)
+                tree.values = kern(leaf, y, F, rw, taus, cb, n_lv, self.lr_)
+            # Spend what this round actually took. The min runs over ALL
+            # leaves, empty ones included -- a row the fit never saw can land
+            # in a leaf no training row reached, and its increment there is
+            # zero, which the min correctly treats as "no narrowing".
+            gap += np.diff(tree.values, axis=1).min(axis=0)
+
+            _add_leaf_values(F, tree.values, leaf)
+            self.trees_.append(tree)
+            if self.verbose:
+                self.train_history_.append(self.loss_.eval(y, F, w))
+
+            if Fv is not None:
+                Fv += tree.values[tree.apply(Xvb)]
+                val = self._val_score(yv, Fv, wv)   # wv=None -> unweighted
+                self.valid_history_.append(val)
+                if stopper.step(val, m):
+                    if self.verbose:
+                        print(f"Early stop at {m} (best {stopper.best_iter})")
+                    self.trees_ = self.trees_[: stopper.best_iter + 1]
+                    break
+
+            if self.verbose and (m % max(1, self.n_estimators // 10) == 0):
+                msg = f"[{m}] train {self.train_history_[-1]:.5f}"
+                if Fv is not None:
+                    msg += f"  val {self.valid_history_[-1]:.5f}"
+                print(msg)
+
+            if callbacks:
+                tl = self.train_history_[-1] if self.train_history_ \
+                    else (self.loss_.eval(y, F, w) if cb_train_loss else None)
+                vl = self.valid_history_[-1] if self.valid_history_ else None
+                if _run_callbacks(callbacks, m, tl, vl, self):
+                    break
+        else:
+            # No break: the tree budget ran out before patience could fire.
+            if Fv is not None and stopper.patience:
+                self.trees_ = self.trees_[: stopper.best_iter + 1]
+
+        # Early stopping can discard trailing trees, and every discarded tree
+        # only ever SPENT budget, so recomputing the bound over the retained
+        # prefix is both correct and never looser than the running value.
+        self.gap_ = np.diff(self.init_) + (
+            sum(np.diff(t.values, axis=1).min(axis=0) for t in self.trees_)
+            if self.trees_ else 0.0)
+        self.gap_floor_ = floor
+        self.fit_time_ = time.time() - t0
+        self.best_iteration_ = len(self.trees_)
+        return self
+
+    def _predict_raw_impl(self, X, cat_ctx=None):
+        """Return the (n_samples, n_quantiles) matrix of quantile estimates,
+        non-decreasing along axis 1 by construction."""
+        X = as_model_array(X, bool(self.prep_.cat_features_))
+        Xb = self.prep_.transform(X, cat_ctx)       # row-major
+        if not self.trees_:
+            return np.tile(self.init_, (Xb.shape[0], 1))
+        if getattr(self, "_forest_", None) is None:
+            self._forest_ = pack_forest_vec(self.trees_, self.depth)
+        feats, thrs, depths, vals, voff, K = self._forest_
+        kernel = (_predict_forest_vec_rm_serial
+                  if Xb.shape[0] <= _SERIAL_PREDICT_N
+                  else _predict_forest_vec_rm)
+        return kernel(Xb, feats, thrs, depths, vals, voff, K, self.init_)
+
+    def staged_predict_raw(self, X):
+        """Yield the (n, K) quantile matrix after each successive tree.
+
+        Trees are accumulated in the same order as `_predict_forest_vec_rm`,
+        so the final stage equals ``predict_raw`` and every intermediate stage
+        is itself non-crossing."""
+        X = as_model_array(X, bool(self.prep_.cat_features_))
+        Xb = np.ascontiguousarray(self.prep_.transform(X).T)   # feature-major
+        F = np.tile(self.init_, (Xb.shape[1], 1))
+        for tree in self.trees_:
+            F += tree.values[tree.apply(Xb)]
+            yield F.copy()

--- a/chimeraboost/losses.py
+++ b/chimeraboost/losses.py
@@ -358,6 +358,57 @@ class MultiSoftmax:
         return _softmax(F)
 
 
+class MultiQuantile:
+    """Pinball loss on a shared tau grid: K quantile channels at once.
+
+    Raw scores are an (n, K) matrix, column k holding the estimate of the
+    `taus[k]` conditional quantile. Nothing here couples the channels -- each
+    column is exactly the scalar `Quantile` loss at its own alpha, and a
+    one-element grid reproduces it term for term. The coupling lives in the
+    booster: one shared tree structure per round, and a leaf vector that is
+    sorted before it is committed.
+
+    `taus` must be ascending, unique and strictly inside (0, 1); the estimator
+    validates that before constructing this.
+    """
+
+    name = "MultiQuantile"
+    is_classification = False
+    adjusts_leaves = True
+
+    def __init__(self, taus):
+        self.taus = np.ascontiguousarray(taus, dtype=np.float64)
+        self.K = self.taus.size
+
+    def init(self, y, sample_weight=None):
+        """Global (weighted) quantile at each level -- a (K,) starting vector."""
+        q = np.array([_weighted_quantile(y, sample_weight, a)
+                      for a in self.taus])
+        # Quantiles of one sample are already monotone in alpha, so this sort
+        # is a no-op. It is here so the non-crossing guarantee rests on an
+        # enforced invariant rather than on that argument staying true.
+        q.sort()
+        return q
+
+    def grad_hess(self, y, F):
+        """(n, K) pinball gradient; hessian is 1 everywhere.
+
+        Sign convention matches the scalar `Quantile`: -alpha where the target
+        sits at or above the current estimate, 1-alpha below."""
+        grad = np.where(y[:, None] >= F, -self.taus, 1.0 - self.taus)
+        return grad, np.ones_like(F)
+
+    def eval(self, y, F, sample_weight=None):
+        """Mean pinball loss across the grid -- the CRPS convention used by
+        `chimeraboost.quantile_metrics.crps`, and the early-stopping metric."""
+        r = y[:, None] - F
+        pinball = np.maximum(self.taus * r, (self.taus - 1.0) * r)
+        return float(np.average(pinball.mean(axis=1), weights=sample_weight))
+
+    def transform(self, F):
+        return F
+
+
 LOSSES = {"RMSE": RMSE, "Logloss": Logloss, "MAE": MAE, "Quantile": Quantile,
           "Huber": Huber, "Poisson": Poisson, "Gamma": Gamma,
           "Tweedie": Tweedie}

--- a/chimeraboost/quantile_api.py
+++ b/chimeraboost/quantile_api.py
@@ -1,0 +1,446 @@
+"""The multi-quantile estimator (benchmarks/QUANTILE_PLAN.md).
+
+Kept out of ``sklearn_api`` because it shares that module's input-validation
+helpers but almost none of its fit machinery: no loss family, no linear
+leaves, no cross features, no bagging, no full-data refit. It reuses the
+validation helpers by importing them, in the same flat, module-function style
+`sklearn_api` already uses.
+"""
+
+import numpy as np
+from sklearn.base import BaseEstimator
+
+from . import quantile_metrics
+from .booster import MultiQuantileBoosting
+from .preprocessing import as_model_array
+from .sklearn_api import (_auto_cat_combinations, _check_eval_set,
+                          _check_predict_input, _make_eval_split,
+                          _resolve_cat_features, _resolve_cat_feature_names,
+                          _validate_fit_input, _validate_hyperparams)
+
+
+# 0.05 ... 0.95 in steps of 0.05: nineteen levels, symmetric about the median,
+# so the 90%, 80%, ... central intervals are adjacent column pairs.
+DEFAULT_QUANTILES = np.round(np.arange(0.05, 0.9501, 0.05), 10)
+
+
+def _resolve_quantiles(quantiles):
+    """Validate and normalize the tau grid."""
+    q = DEFAULT_QUANTILES if quantiles is None else np.asarray(
+        quantiles, dtype=np.float64).ravel()
+    if q.size == 0:
+        raise ValueError("quantiles must contain at least one level.")
+    if not np.all(np.isfinite(q)):
+        raise ValueError(f"quantiles must all be finite; got {q!r}.")
+    if np.any(q <= 0.0) or np.any(q >= 1.0):
+        raise ValueError(
+            f"quantiles must lie strictly inside (0, 1); got {q!r}.")
+    if q.size > 1 and np.any(np.diff(q) <= 0.0):
+        raise ValueError(
+            "quantiles must be strictly ascending and unique; got "
+            f"{q!r}. The column order of predict() is the order given here, "
+            "so sort them first.")
+    return np.ascontiguousarray(q)
+
+
+def _auto_min_child_weight(taus):
+    """Leaf-size floor implied by the most extreme level on the grid.
+
+    A leaf estimating the 5% quantile from fewer than 20 rows is estimating it
+    from under one expected observation in that tail, which is noise. Scaling
+    with the grid keeps that honest for a user who asks for 0.01. It also
+    lands on 20 for the default grid, which happens to match LightGBM's
+    ``min_data_in_leaf`` -- convenient when comparing the two.
+    """
+    edge = min(float(taus[0]), 1.0 - float(taus[-1]))
+    return float(np.ceil(1.0 / max(edge, 1e-9)))
+
+
+def _median_index(taus):
+    """``(i, w)`` such that ``Q[:, i] + w * (Q[:, i+1] - Q[:, i])`` is the
+    predicted median, for a grid that may or may not contain 0.5 exactly."""
+    K = taus.shape[0]
+    if K == 1:
+        return 0, 0.0
+    j = int(np.searchsorted(taus, 0.5))
+    if j < K and abs(taus[j] - 0.5) < 1e-12:
+        return j, 0.0
+    if j == 0:
+        return 0, 0.0
+    if j >= K:
+        return K - 1, 0.0
+    lo, hi = taus[j - 1], taus[j]
+    return j - 1, float((0.5 - lo) / (hi - lo))
+
+
+def _centre(Q, mi, mw):
+    """Per-row predicted median from `_median_index`."""
+    if mw == 0.0:
+        return Q[:, mi]
+    return Q[:, mi] + mw * (Q[:, mi + 1] - Q[:, mi])
+
+
+def _cqr_scales(Q, y, taus, mi, mw):
+    """Conformalized quantile regression as a per-level SCALE about the median.
+
+    For each symmetric pair the conformity score is how far out the point sat
+    in units of the predicted half-interval,
+
+        E_i = max((c_i - y_i) / (c_i - q_lo,i), (y_i - c_i) / (q_hi,i - c_i))
+
+    with c the predicted median, and the calibrated factor is that score's
+    ``ceil((n+1)(1-alpha))``-th order statistic -- the standard conformal rank
+    (Romano, Patterson & Candes 2019), which gives distribution-free marginal
+    coverage on exchangeable data. Prediction then returns
+    ``c + s * (q - c)``.
+
+    Why scaling rather than the usual additive widening. An additive
+    correction that SHRINKS an interval is a non-monotone offset vector, and
+    the only way to apply one safely is out of the fit's narrowing budget --
+    which the fit has already spent. Scaling about the median has no such
+    problem: multiplying a monotone, sign-correct deviation by a non-negative
+    factor cannot reorder anything, for any row, spent budget or not. Since a
+    shrunk-fit quantile model is systematically OVER-dispersed -- every round's
+    step is shrunk by the learning rate, so the grid never fully contracts --
+    shrinking is the correction that is actually needed, and the additive form
+    cannot deliver it.
+
+    Two constraints are enforced:
+
+    * Outer intervals get a factor at least as large as the ones nested inside
+      them, which is what keeps the rescaled grid ordered.
+    * The rank must exist: ``ceil((n+1)(1-alpha)) <= n`` needs
+      ``n >= (1-alpha)/alpha``. Below that the interval is vacuous, and this
+      raises rather than quietly returning an uncalibrated model.
+    """
+    K = taus.shape[0]
+    s = np.ones(K)
+    n = y.shape[0]
+    c = _centre(Q, mi, mw)
+    # Relative floor for the half-widths: a row whose predicted interval has
+    # collapsed to a point would otherwise divide by zero.
+    eps = 1e-9 * max(float(np.mean(Q[:, -1] - Q[:, 0])), 1e-12)
+    pairs = []
+    for k in range(K // 2):
+        j = K - 1 - k
+        if abs((taus[k] + taus[j]) - 1.0) > 1e-9:
+            continue                       # not a symmetric pair
+        alpha = 1.0 - (taus[j] - taus[k])
+        need = int(np.ceil((1.0 - alpha) / max(alpha, 1e-12)))
+        if n < need:
+            raise ValueError(
+                f"conformalize=True needs at least {need} calibration rows to "
+                f"certify the {taus[k]:g}-{taus[j]:g} interval (nominal "
+                f"coverage {1 - alpha:.0%}), but the calibration fold holds "
+                f"only {n}. Raise calibration_fraction, supply more data, or "
+                "drop the extreme levels from `quantiles`.")
+        E = np.maximum((c - y) / np.maximum(c - Q[:, k], eps),
+                       (y - c) / np.maximum(Q[:, j] - c, eps))
+        rank = int(np.ceil((n + 1) * (1.0 - alpha)))
+        pairs.append([k, j, max(0.0, float(np.sort(E)[min(rank, n) - 1]))])
+    # Outer factor >= inner factor. The deviations from the median already
+    # grow outward, so a non-increasing factor toward the centre keeps their
+    # product monotone -- and calibration naturally lands this way, since an
+    # over-dispersed model needs the most shrinking near the median.
+    for i in range(len(pairs) - 2, -1, -1):
+        pairs[i][2] = max(pairs[i][2], pairs[i + 1][2])
+    for k, j, sp in pairs:
+        s[k] = s[j] = sp
+    return s
+
+
+class ChimeraBoostQuantileRegressor(BaseEstimator):
+    """Gradient boosting for a whole predictive distribution at once.
+
+    One booster, one tree structure per round, and a K-vector in every leaf --
+    one entry per level in ``quantiles``. Against fitting one quantile
+    regressor per level this is roughly K times less split-search work, and
+    the predictions cannot cross: the 30% quantile is never returned above the
+    70%. The guarantee is structural rather than repaired afterwards, so it
+    holds at every intermediate stage of ``staged_predict`` too.
+
+    Deliberately NOT a ``RegressorMixin``: ``predict`` returns a matrix, so the
+    inherited ``score`` (which assumes one number per row) would be wrong.
+    ``score`` here is negative CRPS -- higher is better, as sklearn requires.
+
+    Parameters
+    ----------
+    quantiles : array-like or None
+        Ascending, unique levels strictly inside (0, 1). Default
+        0.05, 0.10, ... 0.95. Column k of ``predict`` is level k.
+    split_projection : {"rotate", "sum", "gram"}
+        How the K gradient columns collapse into the single vector the tree
+        grower accepts. ``"rotate"`` cycles a location and a spread contrast,
+        two rounds of the former per round of the latter, and is the default
+        because it measured best; ``"sum"`` is the literal channel sum, which
+        is blind to spread entirely; ``"gram"`` picks the strongest contrast
+        each round and measured no better than cycling. See
+        `booster._fixed_contrasts`.
+    exact_splits : bool
+        Score splits on the exact summed-across-level gain instead of a
+        projection. More faithful, and costs K histogram channels per feature
+        instead of one -- a reference arm, not a working default.
+    conformalize : bool
+        Calibrate the intervals by conformalized quantile regression. Carves
+        ``calibration_fraction`` of the rows off BEFORE the early-stopping
+        split, so that fold influences neither the fit nor the stopping point.
+        Raises if the fold is too small to certify the requested levels.
+    calibration_fraction : float
+        Share of training rows reserved for conformalization. Ignored unless
+        ``conformalize=True``.
+
+    Other parameters carry their usual ChimeraBoost meaning. ``depth``
+    defaults to 4 (deep leaves overfit tail quantiles) and
+    ``min_child_weight`` to a floor implied by the most extreme level on the
+    grid.
+
+    Attributes
+    ----------
+    quantiles_ : ndarray of shape (n_quantiles,)
+        The resolved grid.
+    conformal_scale_ : ndarray of shape (n_quantiles,)
+        Per-level conformal scale about the predicted median; all ones unless
+        ``conformalize=True``.
+    """
+
+    def __init__(self, quantiles=None, n_estimators=2000, learning_rate=None,
+                 depth=None, l2_leaf_reg=1.0, max_bins=128, subsample=1.0,
+                 colsample=None, cat_smoothing=1.0, cat_n_permutations=4,
+                 early_stopping_rounds=None, min_child_weight=None,
+                 thread_count=None, random_state=None, verbose=False,
+                 cat_features=None, cat_combinations=None,
+                 quantize_gradients=True, early_stopping=True,
+                 validation_fraction=0.2, split_projection="rotate",
+                 exact_splits=False, conformalize=False,
+                 calibration_fraction=0.2):
+        self.quantiles = quantiles
+        self.n_estimators = n_estimators
+        self.learning_rate = learning_rate
+        self.depth = depth
+        self.l2_leaf_reg = l2_leaf_reg
+        self.max_bins = max_bins
+        self.subsample = subsample
+        self.colsample = colsample
+        self.cat_smoothing = cat_smoothing
+        self.cat_n_permutations = cat_n_permutations
+        self.early_stopping_rounds = early_stopping_rounds
+        self.min_child_weight = min_child_weight
+        self.thread_count = thread_count
+        self.random_state = random_state
+        self.verbose = verbose
+        self.cat_features = cat_features
+        self.cat_combinations = cat_combinations
+        self.quantize_gradients = quantize_gradients
+        self.early_stopping = early_stopping
+        self.validation_fraction = validation_fraction
+        self.split_projection = split_projection
+        self.exact_splits = exact_splits
+        self.conformalize = conformalize
+        self.calibration_fraction = calibration_fraction
+
+    def __sklearn_is_fitted__(self):
+        return hasattr(self, "model_")
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.input_tags.allow_nan = True   # NaN routed to a missing bin
+        tags.input_tags.sparse = False
+        return tags
+
+    def fit(self, X, y, cat_features=None, eval_set=None, groups=None,
+            sample_weight=None, callbacks=None):
+        """Fit the model. Arguments carry the same meaning as
+        `ChimeraBoostRegressor.fit`."""
+        cat_features = _resolve_cat_features(self, cat_features)
+        cat_features = _resolve_cat_feature_names(cat_features, X)
+        _validate_hyperparams(self)
+        if self.split_projection not in ("rotate", "sum", "gram"):
+            raise ValueError(
+                'split_projection must be "rotate", "sum" or "gram"; got '
+                f"{self.split_projection!r}.")
+        if not 0.0 < self.calibration_fraction < 1.0:
+            raise ValueError("calibration_fraction must be in (0, 1); got "
+                             f"{self.calibration_fraction!r}.")
+        y = _validate_fit_input(self, X, y, cat_features, sample_weight,
+                                classification=False)
+        if eval_set is not None:
+            _check_eval_set(eval_set, self.n_features_in_)
+        taus = _resolve_quantiles(self.quantiles)
+        self.quantiles_ = taus
+        self._median_idx_ = _median_index(taus)
+        self.conformal_scale_ = np.ones(taus.shape[0])
+
+        X = as_model_array(X, bool(cat_features))
+        y = np.asarray(y, dtype=np.float64)
+        if sample_weight is not None:
+            sample_weight = np.asarray(sample_weight, dtype=np.float64)
+
+        # 1. Calibration fold FIRST, so it sees neither the fit nor the
+        #    stopping decision. Carved before anything else touches y.
+        cal = None
+        if self.conformalize:
+            split = _make_eval_split(X, y, self.calibration_fraction,
+                                     self.random_state, groups=groups)
+            if split is None:
+                raise ValueError(
+                    "conformalize=True could not carve a calibration fold from "
+                    f"{len(y)} rows at calibration_fraction="
+                    f"{self.calibration_fraction}. Supply more rows or lower "
+                    "the fraction.")
+            keep, cal_idx = split
+            cal = (X[cal_idx], y[cal_idx])
+            X, y = X[keep], y[keep]
+            if sample_weight is not None:
+                sample_weight = sample_weight[keep]
+            if groups is not None:
+                groups = np.asarray(groups)[keep]
+
+        # 2. Early-stopping split out of whatever remains.
+        es_active = bool(self.early_stopping)
+        if es_active and eval_set is None:
+            split = _make_eval_split(X, y, self.validation_fraction,
+                                     self.random_state, groups=groups)
+            if split is None:
+                es_active = False           # too small to hold anything out
+            else:
+                tr, va = split
+                sw_val = None if sample_weight is None else sample_weight[va]
+                eval_set = (X[va], y[va], sw_val)
+                X, y = X[tr], y[tr]
+                if sample_weight is not None:
+                    sample_weight = sample_weight[tr]
+        es_rounds = self.early_stopping_rounds
+        if not es_active:
+            es_rounds = None
+        elif eval_set is not None and es_rounds is None:
+            es_rounds = 50
+
+        depth = 4 if self.depth is None else self.depth
+        mcw = (_auto_min_child_weight(taus) if self.min_child_weight is None
+               else self.min_child_weight)
+        cat_combos = self.cat_combinations
+        if cat_combos is None:
+            cat_combos = _auto_cat_combinations(
+                cat_features, self.n_features_in_, len(y))
+
+        self.model_ = MultiQuantileBoosting(
+            quantiles=taus, split_projection=self.split_projection,
+            exact_splits=self.exact_splits,
+            n_estimators=self.n_estimators, learning_rate=self.learning_rate,
+            depth=depth, l2_leaf_reg=self.l2_leaf_reg, max_bins=self.max_bins,
+            subsample=self.subsample,
+            colsample=1.0 if self.colsample is None else self.colsample,
+            cat_smoothing=self.cat_smoothing,
+            cat_n_permutations=self.cat_n_permutations,
+            early_stopping_rounds=es_rounds, min_child_weight=mcw,
+            thread_count=self.thread_count, random_state=self.random_state,
+            verbose=self.verbose, cat_combinations=cat_combos,
+            quantize_gradients=self.quantize_gradients)
+        self.model_.fit(X, y, cat_features=cat_features, eval_set=eval_set,
+                        sample_weight=sample_weight, callbacks=callbacks)
+
+        # 3. Conformalize on the pristine fold.
+        if cal is not None:
+            mi, mw = self._median_idx_
+            self.conformal_scale_ = _cqr_scales(
+                self.model_.predict_raw(cal[0]), cal[1], taus, mi, mw)
+        return self
+
+    def _conformalize(self, Q):
+        """Apply the calibrated scale about each row's predicted median. A
+        no-op (all factors 1) unless ``conformalize=True``."""
+        if np.all(self.conformal_scale_ == 1.0):
+            return Q
+        mi, mw = self._median_idx_
+        c = _centre(Q, mi, mw)[:, None]
+        return c + self.conformal_scale_[None, :] * (Q - c)
+
+    def predict(self, X, kind="quantiles", alpha=None):
+        """Predict the conditional distribution.
+
+        ``kind="quantiles"`` (default) returns (n_samples, n_quantiles),
+        column k being level ``quantiles_[k]``, non-decreasing along axis 1.
+
+        ``kind="interval"`` returns (n_samples, 2): the central ``1 - alpha``
+        interval, read off the ``alpha/2`` and ``1 - alpha/2`` levels, which
+        must both be on the grid. No interpolation -- an interval the model
+        was not fitted for is an error, not a guess.
+
+        ``kind="mean"`` returns (n_samples,), the integral of the quantile
+        function over tau: trapezoid across the grid plus flat extension of
+        the edge levels out to 0 and 1. The flat extension is the honest
+        reading of a finite grid, assuming nothing about tails the model never
+        estimated.
+        """
+        Xv = _check_predict_input(self, X)
+        Q = self._conformalize(
+            self.model_.predict_raw(X if Xv is None else Xv))
+        if kind == "quantiles":
+            return Q
+        if kind == "interval":
+            if alpha is None:
+                raise ValueError(
+                    'predict(kind="interval") needs alpha, the miscoverage: '
+                    "alpha=0.1 for a 90% interval.")
+            if not 0.0 < alpha < 1.0:
+                raise ValueError(f"alpha must be in (0, 1); got {alpha!r}.")
+            lo, hi = alpha / 2.0, 1.0 - alpha / 2.0
+            taus = self.quantiles_
+            i = int(np.argmin(np.abs(taus - lo)))
+            j = int(np.argmin(np.abs(taus - hi)))
+            if abs(taus[i] - lo) > 1e-9 or abs(taus[j] - hi) > 1e-9:
+                raise ValueError(
+                    f"alpha={alpha} needs levels {lo:g} and {hi:g}, which are "
+                    "not on the fitted grid "
+                    f"{np.array2string(taus, precision=4)}. Refit with those "
+                    "levels in `quantiles`.")
+            return np.column_stack([Q[:, i], Q[:, j]])
+        if kind == "mean":
+            return self._mean_from_quantiles(Q)
+        raise ValueError(
+            f'kind must be "quantiles", "interval" or "mean"; got {kind!r}.')
+
+    def _mean_from_quantiles(self, Q):
+        """Integral of the quantile function over [0, 1]: trapezoid across the
+        grid, plus a rectangle for the flat extension below the first level and
+        another above the last."""
+        taus = self.quantiles_
+        trapz = getattr(np, "trapezoid", None) or np.trapz
+        inner = trapz(Q, x=taus, axis=1) if taus.shape[0] > 1 else 0.0
+        return inner + taus[0] * Q[:, 0] + (1.0 - taus[-1]) * Q[:, -1]
+
+    def staged_predict(self, X):
+        """Yield the (n, K) quantile matrix after each successive tree. The
+        conformal rescaling, being a post-fit transform, is applied at every
+        stage so the last one equals ``predict``."""
+        Xv = _check_predict_input(self, X)
+        X = X if Xv is None else Xv
+        for staged in self.model_.staged_predict_raw(X):
+            yield self._conformalize(staged)
+
+    def score(self, X, y, sample_weight=None):
+        """Negative CRPS (mean pinball loss over the grid). Higher is better,
+        per the sklearn convention."""
+        return -quantile_metrics.crps(y, self.predict(X), self.quantiles_,
+                                      sample_weight)
+
+    def report(self, X, y, sample_weight=None):
+        """`quantile_metrics.quantile_report` on this model's predictions:
+        CRPS, per-level pinball, and coverage plus width for every symmetric
+        interval."""
+        return quantile_metrics.quantile_report(y, self.predict(X),
+                                                self.quantiles_, sample_weight)
+
+    @property
+    def best_iteration_(self):
+        return self.model_.best_iteration_
+
+    @property
+    def validation_history_(self):
+        """Per-round validation CRPS from ``fit`` (empty without a validation
+        set)."""
+        return list(self.model_.valid_history_)
+
+    @property
+    def feature_importances_(self):
+        return self.model_.feature_importances_

--- a/chimeraboost/quantile_metrics.py
+++ b/chimeraboost/quantile_metrics.py
@@ -1,0 +1,137 @@
+"""Scoring for a predicted quantile grid.
+
+Everything here takes ``Q`` of shape (n_samples, n_quantiles) -- the matrix
+`ChimeraBoostQuantileRegressor.predict` returns -- alongside the ``taus`` it
+was fitted on. Nothing here is used during fitting; these are for judging a
+fitted model.
+
+The three questions worth asking of a predictive distribution, and the
+function that answers each:
+
+  * Is each quantile in the right place?      `pinball_loss` (per level)
+  * Is the distribution as a whole right?     `crps`
+  * Do the intervals hold what they claim?    `interval_coverage` (plus width,
+    because a wide enough interval covers everything and says nothing)
+"""
+
+import numpy as np
+
+
+def _check(y, Q, taus):
+    y = np.asarray(y, dtype=np.float64).ravel()
+    Q = np.asarray(Q, dtype=np.float64)
+    taus = np.asarray(taus, dtype=np.float64).ravel()
+    if Q.ndim != 2:
+        raise ValueError(f"Q must be 2-D (n_samples, n_quantiles); got shape "
+                         f"{Q.shape}.")
+    if Q.shape[0] != y.shape[0]:
+        raise ValueError(f"Q has {Q.shape[0]} rows but y has {y.shape[0]}.")
+    if Q.shape[1] != taus.shape[0]:
+        raise ValueError(f"Q has {Q.shape[1]} columns but taus has "
+                         f"{taus.shape[0]} entries.")
+    return y, Q, taus
+
+
+def pinball_loss(y, Q, taus, sample_weight=None, average=False):
+    """Pinball (quantile) loss, one value per level.
+
+    ``average=True`` collapses to the mean over levels. Returns a ``(K,)``
+    array otherwise -- the per-level breakdown is usually the interesting
+    part, since a model can be excellent at the median and useless in the
+    tails."""
+    y, Q, taus = _check(y, Q, taus)
+    r = y[:, None] - Q
+    loss = np.maximum(taus * r, (taus - 1.0) * r)
+    per_level = np.average(loss, axis=0, weights=sample_weight)
+    return float(per_level.mean()) if average else per_level
+
+
+def crps(y, Q, taus, sample_weight=None):
+    """Continuous ranked probability score, approximated as the mean pinball
+    loss across the grid.
+
+    Convention note: CRPS is exactly ``2 * integral of pinball over tau``, so
+    this returns half the textbook CRPS. The factor is constant, so rankings
+    and relative comparisons are unaffected; it is the same convention the
+    booster's early-stopping metric uses, which keeps the two numbers directly
+    comparable. Grid resolution bounds the accuracy -- a 19-point grid
+    approximates the integral, it does not evaluate it."""
+    return pinball_loss(y, Q, taus, sample_weight, average=True)
+
+
+def interval_coverage(y, Q, taus, sample_weight=None):
+    """Empirical coverage and mean width of every symmetric (lo, hi) pair.
+
+    Pairs the k-th level with the (K-1-k)-th and keeps those whose nominal
+    levels are symmetric about the median, so a grid like 0.05...0.95 yields
+    the 90%, 80%, ... intervals. Returns a list of dicts with keys
+    ``lo``, ``hi``, ``nominal``, ``coverage``, ``width``.
+
+    Coverage alone is not a score: an interval from minus to plus infinity
+    covers everything. Read the two together."""
+    y, Q, taus = _check(y, Q, taus)
+    K = taus.shape[0]
+    out = []
+    for k in range(K // 2):
+        j = K - 1 - k
+        nominal = taus[j] - taus[k]
+        if abs((taus[k] + taus[j]) - 1.0) > 1e-9:
+            continue                      # not a symmetric pair; skip
+        inside = ((y >= Q[:, k]) & (y <= Q[:, j])).astype(np.float64)
+        out.append({
+            "lo": float(taus[k]),
+            "hi": float(taus[j]),
+            "nominal": float(nominal),
+            "coverage": float(np.average(inside, weights=sample_weight)),
+            "width": float(np.average(Q[:, j] - Q[:, k],
+                                      weights=sample_weight)),
+        })
+    return out
+
+
+def crossing_rate(Q):
+    """Fraction of adjacent quantile pairs that come out in the wrong order.
+
+    Zero by construction for `ChimeraBoostQuantileRegressor` -- that is the
+    point of the vector leaf, and this function exists to prove it rather than
+    to fix anything. Independently fitted per-level models are not zero."""
+    Q = np.asarray(Q, dtype=np.float64)
+    if Q.shape[1] < 2:
+        return 0.0
+    d = np.diff(Q, axis=1)
+    return float((d < 0).sum()) / float(d.size)
+
+
+def quantile_report(y, Q, taus, sample_weight=None):
+    """Everything above in one dict: ``crps``, ``pinball`` (per level),
+    ``taus``, ``intervals``, ``crossing_rate``."""
+    y, Q, taus = _check(y, Q, taus)
+    return {
+        "crps": crps(y, Q, taus, sample_weight),
+        "pinball": pinball_loss(y, Q, taus, sample_weight),
+        "taus": taus,
+        "intervals": interval_coverage(y, Q, taus, sample_weight),
+        "crossing_rate": crossing_rate(Q),
+    }
+
+
+def format_report(report, title=None):
+    """Render `quantile_report` as a fixed-width text table."""
+    lines = []
+    if title:
+        lines.append(title)
+    lines.append(f"CRPS (mean pinball over the grid): {report['crps']:.6f}")
+    lines.append(f"crossing rate: {report['crossing_rate']:.6f}")
+    lines.append("")
+    lines.append(f"{'tau':>8s}{'pinball':>12s}")
+    for t, p in zip(report["taus"], report["pinball"]):
+        lines.append(f"{t:8.2f}{p:12.6f}")
+    if report["intervals"]:
+        lines.append("")
+        lines.append(f"{'interval':>10s}{'nominal':>10s}{'coverage':>10s}"
+                     f"{'width':>10s}")
+        for iv in report["intervals"]:
+            lines.append(f"{iv['lo']:.2f}-{iv['hi']:.2f}".rjust(10)
+                         + f"{iv['nominal']:10.2f}{iv['coverage']:10.4f}"
+                           f"{iv['width']:10.4f}")
+    return "\n".join(lines)

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -137,7 +137,12 @@ def _validate_hyperparams(estimator):
     """
     p = estimator.get_params()
 
+    # Estimators expose different parameter sets (the quantile head has no
+    # loss/alpha family, no bagging, no linear leaves), so every check below
+    # is a no-op for a parameter this estimator does not have.
     def _pos_int(name, lo=1, allow_none=False):
+        if name not in p:
+            return
         v = p[name]
         if v is None and allow_none:
             return
@@ -146,6 +151,8 @@ def _validate_hyperparams(estimator):
             raise ValueError(f"{name} must be an integer >= {lo}; got {v!r}.")
 
     def _in_range(name, lo, hi, *, lo_incl=True, hi_incl=True, allow_none=False):
+        if name not in p:
+            return
         v = p[name]
         if v is None and allow_none:
             return
@@ -167,7 +174,7 @@ def _validate_hyperparams(estimator):
     # depth: a depth-d tree allocates 2**d leaves in the histogram buffer, so an
     # unbounded depth OOMs. 16 matches CatBoost's documented maximum. None is the
     # regressor's loss-adaptive default, resolved at fit.
-    v = p["depth"]
+    v = p.get("depth")
     if v is not None and not (isinstance(v, (int, np.integer))
                               and not isinstance(v, bool) and 1 <= v <= 16):
         raise ValueError(f"depth must be an integer in [1, 16] or None; got {v!r}.")

--- a/chimeraboost/tree.py
+++ b/chimeraboost/tree.py
@@ -785,6 +785,384 @@ def _leaf_values_vec(leaf, grad, hess, coupling, n_leaves, l2, lr):
     return values
 
 
+# ---------------------------------------------------------------------------
+# Multi-quantile vector leaves (benchmarks/QUANTILE_PLAN.md).
+#
+# The quantile head's leaf value is not a Newton step but the exact empirical
+# quantile of the leaf's residuals, one per tau -- the same override the
+# scalar MAE/Quantile path applies in `booster._correct_leaves`, widened to K
+# channels and with the committed vector projected onto the admissible set so
+# predictions can never cross (see `_project_leaf_row`).
+# ---------------------------------------------------------------------------
+
+
+@njit(cache=True, parallel=True)
+def _project_pinball(y, F, csuffix, cdot, w, out):
+    """Projected pinball gradient ``(grad @ c)`` without ever forming grad.
+
+    Row i's gradient is ``1{y_i < F_ik} - tau_k``, and F_i is non-decreasing,
+    so the set of channels the target falls below is a SUFFIX ``{r_i ... K-1}``
+    where r_i is the row's PIT rank. The projection onto c is then
+
+        g_i = csuffix[r_i] - dot(c, taus)
+
+    with ``csuffix[r] = sum(c[r:])`` precomputed once. One binary search per
+    row instead of a K-element dot product, and no (n, K) temporary: this is
+    the whole reason a K-level head can cost about what a 1-level one costs
+    per round outside the leaf refit.
+
+    ``w`` is a per-row weight array (ones when unweighted -- multiplying by
+    exactly 1.0 is bit-exact, so the unweighted path is unchanged).
+    """
+    n, K = F.shape
+    for i in prange(n):
+        yi = y[i]
+        lo = 0
+        hi = K
+        while lo < hi:                 # first k with F[i, k] > y_i
+            mid = (lo + hi) >> 1
+            if F[i, mid] > yi:
+                hi = mid
+            else:
+                lo = mid + 1
+        out[i] = (csuffix[lo] - cdot) * w[i]
+
+
+@njit(cache=True, parallel=True)
+def _add_leaf_values(F, values, leaf):
+    """``F += values[leaf]`` in place, without materializing the (n, K) gather
+    that fancy indexing would allocate every round."""
+    n, K = F.shape
+    for i in prange(n):
+        l = leaf[i]
+        for k in range(K):
+            F[i, k] += values[l, k]
+
+
+@njit(cache=True)
+def _lerp_np(a, b, t):
+    """NumPy's `_lerp` (numpy/lib/function_base.py), branch included.
+
+    The obvious ``a + (b - a) * t`` disagrees with `np.quantile` on roughly 7%
+    of random inputs; reproducing the ``t >= 0.5`` branch makes the leaf
+    quantile bit-identical to the scalar path's `np.quantile` call, which is
+    what lets tests/test_quantile_head.py assert exact equality."""
+    diff = b - a
+    out = a + diff * t
+    if t >= 0.5:
+        out = b - diff * (1.0 - t)
+    return out
+
+
+@njit(cache=True)
+def _select_kth(buf, lo, hi, k):
+    """Quickselect: reorder ``buf[lo:hi]`` so ``buf[k]`` is its (k-lo)-th
+    smallest element, everything left of k no greater, everything right no
+    smaller. Median-of-three pivot. O(m) expected, versus O(m log m) for a
+    full sort -- and the leaf refit runs this K times per leaf per round, so
+    the difference is the head's dominant per-round cost."""
+    left = lo
+    right = hi - 1
+    while left < right:
+        mid = (left + right) // 2
+        x = buf[left]
+        y = buf[mid]
+        z = buf[right]
+        if x > y:
+            x, y = y, x
+        if y > z:
+            y = z
+        if x > y:
+            y = x
+        pivot = y
+        i = left
+        j = right
+        while i <= j:
+            while buf[i] < pivot:
+                i += 1
+            while buf[j] > pivot:
+                j -= 1
+            if i <= j:
+                buf[i], buf[j] = buf[j], buf[i]
+                i += 1
+                j -= 1
+        if k <= j:
+            right = j
+        elif k >= i:
+            left = i
+        else:
+            return
+
+
+@njit(cache=True)
+def _quantile_slice(buf, lo, hi, alpha):
+    """The ``alpha`` quantile of ``buf[lo:hi]``, matching `np.quantile`'s
+    default ('linear') method bit for bit. Reorders the slice in place."""
+    m = hi - lo
+    if m <= 0:
+        return 0.0
+    if m == 1:
+        return buf[lo]
+    pos = alpha * (m - 1)
+    j = int(np.floor(pos))
+    if j >= m - 1:          # alpha == 1.0: the maximum, nothing to interpolate
+        _select_kth(buf, lo, hi, hi - 1)
+        return buf[hi - 1]
+    frac = pos - j
+    _select_kth(buf, lo, hi, lo + j)
+    a = buf[lo + j]
+    if frac == 0.0:
+        return a
+    # The slice is partitioned around lo+j, so the next order statistic is the
+    # smallest element of the tail -- no second quickselect needed.
+    b = buf[lo + j + 1]
+    for t in range(lo + j + 2, hi):
+        if buf[t] < b:
+            b = buf[t]
+    return _lerp_np(a, b, frac)
+
+
+@njit(cache=True)
+def _sort_pairs(buf, wbuf, lo, hi, wlo):
+    """Sort ``buf[lo:hi]`` ascending, carrying ``wbuf`` along. Insertion sort:
+    only the weighted path uses it, and leaves are small."""
+    for i in range(1, hi - lo):
+        v = buf[lo + i]
+        wv = wbuf[wlo + i]
+        j = i - 1
+        while j >= 0 and buf[lo + j] > v:
+            buf[lo + j + 1] = buf[lo + j]
+            wbuf[wlo + j + 1] = wbuf[wlo + j]
+            j -= 1
+        buf[lo + j + 1] = v
+        wbuf[wlo + j + 1] = wv
+
+
+@njit(cache=True)
+def _weighted_quantile_slice(buf, wbuf, lo, hi, alpha, wlo):
+    """Nearest-rank weighted quantile of ``buf[lo:hi]``, reproducing
+    `losses._weighted_quantile`: sort by value, walk the cumulative weight,
+    take the first element whose running total reaches ``alpha`` of the whole.
+    Reorders both slices in place."""
+    m = hi - lo
+    if m <= 0:
+        return 0.0
+    _sort_pairs(buf, wbuf, lo, hi, wlo)
+    total = 0.0
+    for i in range(m):
+        total += wbuf[wlo + i]
+    target = total * alpha
+    run = 0.0
+    for i in range(m):
+        run += wbuf[wlo + i]
+        if run >= target:       # np.searchsorted(..., side='left')
+            return buf[lo + i]
+    return buf[hi - 1]
+
+
+@njit(cache=True)
+def _project_leaf_row(values, l, K, cb):
+    """Project one leaf's K-vector onto the set of increments that cannot make
+    any prediction cross, in place. This is what makes the non-crossing
+    guarantee structural -- there is no predict-time repair anywhere.
+
+    The naive rule ("commit only non-decreasing increments") is sound but far
+    too strong: a sum of non-decreasing vectors is non-decreasing, so the
+    predicted interval could then never be NARROWER than the global one, and
+    the low-noise half of heteroscedastic data becomes inexpressible. Worse,
+    forcing it by sorting can reverse a narrowing update into a widening one,
+    which is self-reinforcing and diverges.
+
+    So instead each channel carries a narrowing budget ``b_k`` -- the gap the
+    model can still give away at channel k and stay ordered for EVERY possible
+    input row (see `booster.MultiQuantileBoosting` for how the budget is
+    maintained). The admissible set is ``{v : v_k - v_{k-1} >= -b_k}``, and
+    the substitution ``u_k = v_k + sum(b_1..b_k)`` turns it into plain
+    monotonicity, so the projection is ordinary isotonic regression on u.
+    ``cb`` is that cumulative budget, ``cb[0] = 0``.
+
+    Pool-adjacent-violators, not a sort: PAVA is the closest admissible vector
+    in least squares and averages violators, where a sort permutes them and
+    can invert the sign of a contrast. With ``cb == 0`` this reduces exactly
+    to enforcing non-decreasing increments.
+    """
+    bval = np.empty(K)
+    bcnt = np.empty(K, dtype=np.int64)
+    for k in range(K):
+        values[l, k] += cb[k]
+    pos = 0
+    for k in range(K):
+        val = values[l, k]
+        cnt = 1
+        while pos > 0 and bval[pos - 1] > val:
+            pos -= 1
+            tot = bcnt[pos] + cnt
+            val = (bval[pos] * bcnt[pos] + val * cnt) / tot
+            cnt = tot
+        bval[pos] = val
+        bcnt[pos] = cnt
+        pos += 1
+    idx = 0
+    for j in range(pos):
+        for _ in range(bcnt[j]):
+            values[l, idx] = bval[j] - cb[idx]
+            idx += 1
+
+
+@njit(cache=True)
+def _leaf_row_index(leaf, n_leaves):
+    """Group rows by leaf into contiguous, disjoint slices.
+
+    Returns ``(off, rows)`` where leaf l owns ``rows[off[l]:off[l+1]]``, rows
+    listed in ascending order within each leaf (the same grouping
+    `booster._correct_leaves` gets from a stable argsort). Disjointness is what
+    makes the `prange` over leaves race-free: each leaf writes only its own
+    slice of the shared scratch buffer."""
+    n = leaf.shape[0]
+    off = np.zeros(n_leaves + 1, dtype=np.int64)
+    for i in range(n):
+        off[leaf[i] + 1] += 1
+    for l in range(n_leaves):
+        off[l + 1] += off[l]
+    fill = off.copy()
+    rows = np.empty(n, dtype=np.int64)
+    for i in range(n):
+        l = leaf[i]
+        rows[fill[l]] = i
+        fill[l] += 1
+    return off, rows
+
+
+@njit(cache=True, parallel=True)
+def _leaf_quantiles_vec(leaf, y, F, taus, cb, n_leaves, lr):
+    """Per-leaf, per-tau empirical quantile of the residuals ``y - F[:, k]``,
+    scaled by the learning rate and projected onto the non-crossing set.
+
+    The (n_leaves, K) analogue of `booster._correct_leaves`: the tree structure
+    was chosen by the projected gradient, this sets the step. Column k is
+    bit-identical to what the scalar quantile path computes for the same
+    partition at ``alpha = taus[k]`` -- the oracle test in
+    tests/test_quantile_head.py.
+
+    `lr` multiplies from the outside, matching `_correct_leaves`; the
+    projection runs on the scaled value, so the budget it respects is the one
+    actually committed. ``cb`` is the cumulative narrowing budget
+    (`_project_leaf_row`)."""
+    n = leaf.shape[0]
+    K = taus.shape[0]
+    off, rows = _leaf_row_index(leaf, n_leaves)
+    values = np.zeros((n_leaves, K))
+    # One scratch run per (leaf, channel). Costs an (n, K) buffer -- the same
+    # footprint as the score matrix itself -- and buys load balance: a real
+    # oblivious tree's leaves are badly uneven, so a prange over leaves alone
+    # leaves most threads idle waiting on the biggest one. Leaf l owns
+    # buf[off[l]*K : off[l+1]*K], so the runs stay disjoint.
+    buf = np.empty(n * K, dtype=np.float64)
+    for t in prange(n_leaves * K):
+        l = t // K
+        k = t - l * K
+        lo = off[l]
+        m = off[l + 1] - lo
+        if m > 0:
+            # Forward strided scan of one F column, contiguous write. The
+            # leaf's rows are ascending so the prefetcher tracks it. Gathering
+            # channel-major in one pass was measured SLOWER -- it trades these
+            # reads for a transposing write that costs more than it saves.
+            st = lo * K + k * m
+            for j in range(m):
+                i = rows[lo + j]
+                buf[st + j] = y[i] - F[i, k]
+            values[l, k] = lr * _quantile_slice(buf, st, st + m, taus[k])
+    for l in range(n_leaves):
+        _project_leaf_row(values, l, K, cb)
+    return values
+
+
+@njit(cache=True)
+def _leaf_quantiles_vec_serial(leaf, y, F, taus, cb, n_leaves, lr):
+    """Serial twin of `_leaf_quantiles_vec` for small n, where the parallel
+    fork/join costs more than the pass. Every write is to a disjoint slice, so
+    the two are bit-identical; the booster dispatches on `_SMALL_N`."""
+    n = leaf.shape[0]
+    K = taus.shape[0]
+    off, rows = _leaf_row_index(leaf, n_leaves)
+    values = np.zeros((n_leaves, K))
+    buf = np.empty(n, dtype=np.float64)
+    for l in range(n_leaves):
+        lo = off[l]
+        hi = off[l + 1]
+        if hi > lo:
+            # One forward strided scan of F per channel. The leaf's rows are
+            # ascending, so the prefetcher tracks it, and the leaf's slice of F
+            # stays resident across the K passes. Gathering channel-major
+            # instead was measured SLOWER: it trades these reads for a
+            # transposing write, which costs more than it saves.
+            for k in range(K):
+                for j in range(lo, hi):
+                    i = rows[j]
+                    buf[j] = y[i] - F[i, k]
+                values[l, k] = lr * _quantile_slice(buf, lo, hi, taus[k])
+        _project_leaf_row(values, l, K, cb)
+    return values
+
+
+@njit(cache=True, parallel=True)
+def _leaf_quantiles_vec_w(leaf, y, F, w, taus, cb, n_leaves, lr):
+    """Weighted `_leaf_quantiles_vec`. Reproduces `losses._weighted_quantile`
+    (nearest rank on cumulative weight), which is the rule the scalar weighted
+    quantile path already uses. Rows carrying zero weight -- MVS drops, or a
+    user's zero sample weights -- contribute nothing, so the leaf value sees
+    exactly the rows the split search saw."""
+    n = leaf.shape[0]
+    K = taus.shape[0]
+    off, rows = _leaf_row_index(leaf, n_leaves)
+    values = np.zeros((n_leaves, K))
+    # Per-(leaf, channel) runs, as in the unweighted twin. The weights need
+    # their own copy per run because the paired sort reorders them.
+    buf = np.empty(n * K, dtype=np.float64)
+    wbuf = np.empty(n * K, dtype=np.float64)
+    for t in prange(n_leaves * K):
+        l = t // K
+        k = t - l * K
+        lo = off[l]
+        m = off[l + 1] - lo
+        if m > 0:
+            st = lo * K + k * m
+            for j in range(m):
+                i = rows[lo + j]
+                buf[st + j] = y[i] - F[i, k]
+                wbuf[st + j] = w[i]
+            values[l, k] = lr * _weighted_quantile_slice(
+                buf, wbuf, st, st + m, taus[k], st)
+    for l in range(n_leaves):
+        _project_leaf_row(values, l, K, cb)
+    return values
+
+
+@njit(cache=True)
+def _leaf_quantiles_vec_w_serial(leaf, y, F, w, taus, cb, n_leaves, lr):
+    """Serial twin of `_leaf_quantiles_vec_w` (see `_leaf_quantiles_vec_serial`)."""
+    n = leaf.shape[0]
+    K = taus.shape[0]
+    off, rows = _leaf_row_index(leaf, n_leaves)
+    values = np.zeros((n_leaves, K))
+    buf = np.empty(n, dtype=np.float64)
+    wbuf = np.empty(n, dtype=np.float64)
+    for l in range(n_leaves):
+        lo = off[l]
+        hi = off[l + 1]
+        if hi > lo:
+            for k in range(K):
+                for j in range(lo, hi):
+                    i = rows[j]
+                    buf[j] = y[i] - F[i, k]
+                    wbuf[j] = w[i]
+                values[l, k] = lr * _weighted_quantile_slice(
+                    buf, wbuf, lo, hi, taus[k], lo)
+        _project_leaf_row(values, l, K, cb)
+    return values
+
+
 @njit(cache=True)
 def _loo_leaf_step(leaf, grad, hess, n_leaves, l2, lr):
     """Leave-one-out training step for every row, fused into two passes.
@@ -1355,6 +1733,177 @@ def replay_oblivious_tree(donor, Xb, grad, hess, l2, lr, linear_leaves=False,
                          lin_feats=lin_feats, lin_coef=lin_coef,
                          centers_std=centers_std if lin_coef is not None
                          else None)
+    return tree, leaf
+
+
+@njit(cache=True, parallel=True)
+def _build_split_descend_vec(Xb, grad, rw, leaf, n_active, hist, histw,
+                             feat_mask, n_bins_per_feature, l2,
+                             min_child_weight, min_gain):
+    """EXACT multi-channel split search: the K-deep twin of
+    `_build_split_descend`, used only by ``exact_splits=True``.
+
+    Scores the true summed-across-channel gain. Because the multi-quantile
+    hessian is 1 in every channel, every channel shares one weight total per
+    node, and the summed gain collapses to a norm:
+
+        sum_k [Gl_k²/(Hl+l2) + Gr_k²/(Hr+l2) - Gt_k²/(Ht+l2)]
+          = ‖Gl‖²/(Hl+l2) + ‖Gr‖²/(Hr+l2) - ‖Gt‖²/(Ht+l2)
+
+    which is basis-free -- the identity that makes the default path's single
+    projection an honest rank-1 truncation of this quantity rather than a
+    different algorithm. Costs K histogram channels per feature instead of
+    one, which is exactly why it is the reference arm and not the default.
+
+    Simplified relative to the scalar kernel: no occupancy list and no
+    small-n path (level d always scans leaves 0..n_active-1). Both are speed
+    optimizations, and this kernel is not on the fast path.
+    """
+    n_features, n_samples = Xb.shape
+    max_bins = hist.shape[2]
+    K = grad.shape[1]
+    feat_gain = np.full(n_features, -np.inf)
+    feat_thr = np.zeros(n_features, dtype=np.int64)
+
+    for f in prange(n_features):
+        if feat_mask[f] == 0:
+            continue
+        nb = n_bins_per_feature[f]
+        for l in range(n_active):
+            for b in range(nb):
+                histw[f, l, b] = 0.0
+                for k in range(K):
+                    hist[f, l, b, k] = 0.0
+        Xf = Xb[f]
+        for i in range(n_samples):
+            l = leaf[i]
+            b = Xf[i]
+            histw[f, l, b] += rw[i]
+            for k in range(K):
+                hist[f, l, b, k] += grad[i, k]
+
+        gain = np.zeros(max_bins)
+        legal = np.ones(max_bins, dtype=np.uint8)
+        gt = np.empty(K)
+        gl = np.empty(K)
+        for l in range(n_active):
+            ht = 0.0
+            for k in range(K):
+                gt[k] = 0.0
+            for b in range(nb):
+                ht += histw[f, l, b]
+                for k in range(K):
+                    gt[k] += hist[f, l, b, k]
+            if ht <= 0.0:
+                continue
+            sq = 0.0
+            for k in range(K):
+                sq += gt[k] * gt[k]
+            par = sq / (ht + l2)
+            hl = 0.0
+            for k in range(K):
+                gl[k] = 0.0
+            for t in range(nb - 1):
+                hl += histw[f, l, t]
+                for k in range(K):
+                    gl[k] += hist[f, l, t, k]
+                hr = ht - hl
+                if (hl > 0.0 and hl < min_child_weight) or \
+                   (hr > 0.0 and hr < min_child_weight):
+                    legal[t] = 0
+                else:
+                    sl = 0.0
+                    sr = 0.0
+                    for k in range(K):
+                        gr = gt[k] - gl[k]
+                        sl += gl[k] * gl[k]
+                        sr += gr * gr
+                    gain[t] += sl / (hl + l2) + sr / (hr + l2) - par
+
+        best_g = -np.inf
+        best_t = -1
+        for t in range(nb - 1):
+            if legal[t] and gain[t] > best_g:
+                best_g = gain[t]
+                best_t = t
+        feat_gain[f] = best_g
+        feat_thr[f] = best_t
+
+    best_f = 0
+    best_gain = -np.inf
+    for f in range(n_features):
+        if feat_gain[f] > best_gain:
+            best_gain = feat_gain[f]
+            best_f = f
+    best_t = feat_thr[best_f]
+
+    if best_t >= 0 and best_gain > min_gain:
+        Xf = Xb[best_f]
+        for i in prange(n_samples):
+            leaf[i] = (leaf[i] << 1) + (1 if Xf[i] > best_t else 0)
+    return best_f, best_t, best_gain
+
+
+def alloc_exact_hist(n_features, max_depth, n_bins_per_feature, K):
+    """Buffers for `build_oblivious_tree_exact`, allocated once per fit.
+
+    Sized (n_features, 2**max_depth, max_bins, K) plus a shared weight
+    histogram. This is K times the default path's footprint -- at depth 6, 50
+    features, 128 bins and K=19 it is roughly 62 MB -- which is the honest
+    price of the exact gain and another reason it is not the default."""
+    max_bins = n_features and int(n_bins_per_feature.max())
+    max_leaves = 1 << max_depth
+    return (np.zeros((n_features, max_leaves, max_bins, K)),
+            np.zeros((n_features, max_leaves, max_bins)))
+
+
+def build_oblivious_tree_exact(Xb, grad, n_bins_per_feature, max_depth, l2,
+                               min_gain=1e-8, feature_mask=None,
+                               min_child_weight=1.0, row_weight=None,
+                               hist_buffers=None):
+    """Grow one oblivious tree on the EXACT summed-across-channel gain.
+
+    The reference arm for the multi-quantile head's split search (see
+    `_build_split_descend_vec`). Returns ``(tree, train_leaf)`` like
+    `build_oblivious_tree`, but leaf values are left as zeros: the quantile
+    booster overwrites them with the exact per-tau residual quantiles either
+    way, so computing a Newton step here would be wasted work.
+
+    ``row_weight`` is the per-row weight (sample weights times any MVS
+    importance weight); None means uniform. It plays the hessian's role, one
+    total shared by every channel.
+    """
+    n_features, n_samples = Xb.shape
+    if feature_mask is None:
+        feature_mask = np.ones(n_features, dtype=np.int64)
+    K = grad.shape[1]
+    if hist_buffers is None:
+        hist, histw = alloc_exact_hist(n_features, max_depth,
+                                       n_bins_per_feature, K)
+    else:
+        hist, histw = hist_buffers
+    rw = np.ones(n_samples) if row_weight is None else row_weight
+    splits_feat = []
+    splits_thr = []
+    splits_gain = []
+    leaf = np.zeros(n_samples, dtype=np.int64)
+    n_active = 1
+    for d in range(max_depth):
+        f, t, gain = _build_split_descend_vec(
+            Xb, grad, rw, leaf, n_active, hist, histw, feature_mask,
+            n_bins_per_feature, l2, min_child_weight, min_gain)
+        if gain <= min_gain or t < 0:
+            break
+        splits_feat.append(f)
+        splits_thr.append(t)
+        splits_gain.append(gain)
+        n_active <<= 1
+
+    sf = np.array(splits_feat, dtype=np.int64)
+    st = np.array(splits_thr, dtype=np.int64)
+    values = np.zeros(1 << len(splits_feat))
+    tree = ObliviousTree(sf, st, values,
+                         np.array(splits_gain, dtype=np.float64))
     return tree, leaf
 
 

--- a/chimeraboost/warmup.py
+++ b/chimeraboost/warmup.py
@@ -28,6 +28,7 @@ import time
 import numpy as np
 
 from .sklearn_api import ChimeraBoostClassifier, ChimeraBoostRegressor
+from .quantile_api import ChimeraBoostQuantileRegressor
 
 # Set once the cold-compile notice has been considered, so it prints at most
 # once per process. warmup() arms it up front -- its own fits are the compile.
@@ -151,6 +152,35 @@ def warmup(verbose=False, background=False, shap=False):
     mc.predict_proba(X[:8, :3])
     mc.predict_proba(X[:1, :3])   # vector-leaf serial twin
     _log("multiclass")
+
+    # Multi-quantile head: the leaf-quantile kernels (quickselect + the
+    # non-crossing projection) and the vector forest predictors. A short grid
+    # keeps the compile cheap -- the kernels are generic in K, so the number
+    # of levels does not change what gets compiled.
+    yq = X[:320, 0] + 0.5 * rng.standard_normal(320)
+    qr = ChimeraBoostQuantileRegressor(quantiles=[0.1, 0.5, 0.9],
+                                       n_estimators=2, random_state=0,
+                                       early_stopping=False)
+    qr.fit(X[:320, :3], yq)
+    qr.predict(X[:8, :3])
+    qr.predict(X[:1, :3])      # serial twin
+    # The parallel leaf-quantile kernel only runs above tree._SMALL_N rows,
+    # and the weighted twins only on a weighted or subsampled fit -- both too
+    # big or too narrow to reach through a warmup fit, so compile them
+    # directly with the dtypes the real call uses (same treatment as the gdiff
+    # kernel below).
+    from .tree import (_leaf_quantiles_vec, _leaf_quantiles_vec_w,
+                       _leaf_quantiles_vec_w_serial)
+    _wl = np.arange(8, dtype=np.int64) % 2
+    _wy = rng.standard_normal(8)
+    _wF = np.zeros((8, 3))
+    _wt = np.array([0.1, 0.5, 0.9])
+    _wcb = np.zeros(3)
+    _ww = np.ones(8)
+    _leaf_quantiles_vec(_wl, _wy, _wF, _wt, _wcb, 2, 0.1)
+    _leaf_quantiles_vec_w(_wl, _wy, _wF, _ww, _wt, _wcb, 2, 0.1)
+    _leaf_quantiles_vec_w_serial(_wl, _wy, _wF, _ww, _wt, _wcb, 2, 0.1)
+    _log("multi-quantile")
 
     # Regression, ordered boosting on (the LOO leaf-step kernel), with a
     # categorical column and NON-uniform sample weights: the weighted

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,9 +1,13 @@
 # API reference
 
-Both estimators are scikit-learn compatible, with `fit`, then
+All three estimators are scikit-learn compatible, with `fit`, then
 `predict` / `predict_proba` methods. Parameters are documented below; for
 guidance on which ones to tweak, see [Parameters](parameters.md).
 
 ::: chimeraboost.ChimeraBoostRegressor
 
 ::: chimeraboost.ChimeraBoostClassifier
+
+::: chimeraboost.ChimeraBoostQuantileRegressor
+
+::: chimeraboost.quantile_metrics

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -57,6 +57,23 @@ mix — e.g. `cat_features=["city", "brand"]` or `cat_features=[0, 3]`.
 
 The classifier picks its loss automatically: binary logloss for 2 classes, softmax for 3+.
 
+## Quantile head (`ChimeraBoostQuantileRegressor` only)
+
+A whole grid of conditional quantiles from one booster — see
+[Predictive distributions](quantiles.md).
+
+| Parameter | Default | Effect |
+|---|---|---|
+| `quantiles` | `0.05 ... 0.95` step `0.05` | Ascending, unique levels strictly inside (0, 1). Column `k` of `predict` is level `k`. |
+| `conformalize` | `False` | Calibrate the intervals on a fold held out before the early-stopping split. Raises if that fold cannot certify the requested levels. |
+| `calibration_fraction` | `0.2` | Rows reserved for conformalization. Ignored unless `conformalize=True`. |
+| `split_projection` | `"rotate"` | How the K gradient columns collapse for the split search: `"rotate"` (measured best), `"sum"` (blind to changes in spread), `"gram"`. |
+| `exact_splits` | `False` | Score splits on the exact summed-across-level gain instead of a projection: slightly more accurate, at K histogram channels per feature. |
+
+`depth` defaults to 4 here and `min_child_weight` to a floor implied by the most extreme
+level on the grid. `loss`, `linear_leaves`, `cross_features`, `ordered_boosting`,
+`refit_full`, `n_ensembles` and `quality` do not apply.
+
 ## Validation metric (both estimators)
 
 | Parameter | Default | Effect |

--- a/docs/quantiles.md
+++ b/docs/quantiles.md
@@ -1,0 +1,104 @@
+# Predictive distributions
+
+`ChimeraBoostQuantileRegressor` estimates a whole grid of conditional
+quantiles from a single booster. One tree structure per round serves every
+level; each leaf holds a K-vector, one entry per level.
+
+```python
+from chimeraboost import ChimeraBoostQuantileRegressor
+
+model = ChimeraBoostQuantileRegressor().fit(X_train, y_train)
+
+Q = model.predict(X_test)                            # (n_samples, 19)
+lo, hi = model.predict(X_test, kind="interval", alpha=0.1).T
+mean = model.predict(X_test, kind="mean")
+```
+
+The default grid is 0.05, 0.10, ... 0.95. Pass your own with
+`quantiles=[...]` — ascending, unique, strictly inside (0, 1). Column `k` of
+`predict` is level `k`.
+
+## Predictions never cross
+
+The 30% quantile is never returned above the 70%. This is structural, not a
+repair applied afterwards: the model starts from the sorted global quantiles
+and every leaf vector is projected onto a set of increments that cannot
+reorder anything, so `np.diff(Q, axis=1) >= 0` holds exactly — including at
+every intermediate stage of `staged_predict`.
+
+Independently fitted per-level models have no such property. On the benchmark
+in `benchmarks/quantile_head.py`, 18–21% of adjacent quantile pairs come out
+reversed.
+
+Intervals can still be *narrower* than the pooled one where the data is
+quiet — that is not given up to get the guarantee.
+
+## Interval calibration
+
+Boosting under-disperses quantiles: each round's step is scaled by the
+learning rate, so the grid never fully contracts and intervals come out too
+wide. `conformalize=True` fixes it:
+
+```python
+model = ChimeraBoostQuantileRegressor(conformalize=True).fit(X, y)
+```
+
+This holds out `calibration_fraction` of the rows **before** the
+early-stopping split, so that fold influences neither the fit nor the
+stopping point, then rescales each level about the predicted median by a
+conformal factor (Romano, Patterson & Candès 2019). On exchangeable data this
+gives distribution-free marginal coverage. Measured worst error against
+nominal: 0.7 percentage points at n = 10 000.
+
+It raises rather than guessing if the calibration fold is too small to certify
+the levels you asked for — a 90% interval needs at least 9 calibration rows,
+and a 99% one needs 99.
+
+## Scoring
+
+`chimeraboost.quantile_metrics` scores a predicted grid.
+
+```python
+from chimeraboost import quantile_metrics as qm
+
+print(qm.format_report(model.report(X_test, y_test)))
+```
+
+| function | answers |
+|:--|:--|
+| `pinball_loss` | is each level in the right place? (one value per level) |
+| `crps` | is the distribution as a whole right? |
+| `interval_coverage` | do the intervals hold what they claim — coverage *and* width |
+| `crossing_rate` | fraction of adjacent pairs out of order |
+
+`crps` is the mean pinball loss over the grid. The textbook CRPS is twice
+that; the factor is constant, so comparisons are unaffected, and this
+convention matches the early-stopping metric.
+
+`predict(kind="mean")` integrates the quantile function over tau: trapezoid
+across the grid, with the edge levels extended flat to 0 and 1. That flat
+extension assumes nothing about tails the model never estimated.
+
+## What it costs
+
+The split search runs once per round instead of once per level, so the saving
+grows with how wide the data is — roughly 3.4× the fit speed of 19
+independent boosters at 5 features, 4.8× at 32, and 7.8× at 128. Accuracy is
+within 3% of per-level models on pinball loss throughout, and better on wide
+data.
+
+## Tuning
+
+Defaults are set for the head, not inherited: `depth` is 4 (deep leaves
+overfit tail quantiles) and `min_child_weight` follows the most extreme level
+on the grid, so a leaf estimating the 5% quantile keeps at least ~20 rows.
+
+`split_projection` chooses how the K gradient columns collapse into the single
+vector the tree grower accepts. Leave it alone unless you are exploring:
+`"rotate"` measured best, `"sum"` is blind to changes in spread, and `"gram"`
+measured no better than `"rotate"`. `exact_splits=True` scores the exact
+summed-across-level gain — slightly more accurate, at K histogram channels per
+feature.
+
+`chimeraboost/benchmarks/QUANTILE_PLAN.md` records why each of those defaults
+is what it is.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
   - Getting started: getting-started.md
   - User guide:
       - Recipes: recipes.md
+      - Predictive distributions: quantiles.md
       - How it works: concepts.md
       - SHAP explanations: shap.md
       - Deployment: deployment.md

--- a/tests/test_quantile_head.py
+++ b/tests/test_quantile_head.py
@@ -1,0 +1,526 @@
+"""Shared-tree multi-quantile head (benchmarks/QUANTILE_PLAN.md): kernel
+oracles, the non-crossing guarantee, conformal coverage, and path sanity."""
+
+import pickle
+
+import numpy as np
+import pytest
+
+from chimeraboost import ChimeraBoostQuantileRegressor, ChimeraBoostRegressor
+from chimeraboost import quantile_metrics as qm
+from chimeraboost.booster import MultiQuantileBoosting, _fixed_contrasts
+from chimeraboost.losses import MultiQuantile, _weighted_quantile
+from chimeraboost.quantile_api import _cqr_scales, _median_index
+from chimeraboost.tree import (_leaf_quantiles_vec, _leaf_quantiles_vec_serial,
+                               _leaf_quantiles_vec_w,
+                               _leaf_quantiles_vec_w_serial,
+                               _project_leaf_row)
+
+TAUS = np.round(np.arange(0.05, 0.951, 0.05), 10)
+
+
+def _heteroscedastic(n=4000, p=8, seed=0, narrow=True):
+    """Centre driven by one column, spread by another. When `narrow`, half the
+    rows have a conditional spread far TIGHTER than the pooled spread -- the
+    case a monotone-increment-only construction cannot represent at all."""
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((n, p))
+    mu = 2.0 * X[:, 0]
+    sd = (0.1 if narrow else 1.0) + 2.0 * (X[:, 1] > 0)
+    y = mu + sd * rng.standard_normal(n)
+    return X, y
+
+
+def _pinball(y, Q, taus=TAUS):
+    r = np.asarray(y)[:, None] - Q
+    return float(np.maximum(taus * r, (taus - 1.0) * r).mean())
+
+
+# --------------------------------------------------------------------------
+# Kernel oracles
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("n,n_leaves", [(1000, 16), (37, 8), (9, 4)])
+def test_leaf_quantiles_match_numpy_exactly(n, n_leaves):
+    """The registered bit-exact equivalence: with the projection inactive,
+    column k of the leaf kernel IS `np.quantile` at taus[k] on that leaf's
+    residuals. Not a tolerance question -- any diff is a correctness bug.
+
+    F is constant across channels here, which makes the per-leaf residual
+    quantiles monotone in tau on their own, so the projection is the identity
+    and the raw quantile arithmetic is what gets compared."""
+    rng = np.random.default_rng(n)
+    y = rng.standard_normal(n) * 3.0
+    F = np.repeat(rng.standard_normal((n, 1)), TAUS.size, axis=1)
+    leaf = rng.integers(0, n_leaves, size=n)
+    cb = np.zeros(TAUS.size)
+    lr = 0.1
+
+    got = _leaf_quantiles_vec(leaf, y, F, TAUS, cb, n_leaves, lr)
+    ref = np.zeros((n_leaves, TAUS.size))
+    for l in range(n_leaves):
+        m = leaf == l
+        if not m.any():
+            continue
+        for k in range(TAUS.size):
+            ref[l, k] = lr * float(np.quantile(y[m] - F[m, k], TAUS[k]))
+    np.testing.assert_array_equal(got, ref)
+
+
+@pytest.mark.parametrize("n,n_leaves", [(1000, 16), (37, 8)])
+def test_leaf_quantiles_weighted_match_reference(n, n_leaves):
+    """Weighted twin reproduces `losses._weighted_quantile` (nearest rank on
+    cumulative weight) exactly, which is the rule the scalar weighted quantile
+    path already uses."""
+    rng = np.random.default_rng(n + 1)
+    y = rng.standard_normal(n) * 3.0
+    F = np.repeat(rng.standard_normal((n, 1)), TAUS.size, axis=1)
+    leaf = rng.integers(0, n_leaves, size=n)
+    w = rng.uniform(0.2, 2.0, size=n)
+    cb = np.zeros(TAUS.size)
+    lr = 0.1
+
+    got = _leaf_quantiles_vec_w(leaf, y, F, w, TAUS, cb, n_leaves, lr)
+    ref = np.zeros((n_leaves, TAUS.size))
+    for l in range(n_leaves):
+        m = leaf == l
+        if not m.any():
+            continue
+        for k in range(TAUS.size):
+            ref[l, k] = lr * _weighted_quantile(y[m] - F[m, k], w[m], TAUS[k])
+    np.testing.assert_array_equal(got, ref)
+
+
+def test_leaf_quantile_serial_twin_is_bit_identical():
+    """Every parallel kernel in this repo has a serial twin for small n, and
+    the two must be equal, not close."""
+    rng = np.random.default_rng(7)
+    n, n_leaves = 2000, 16
+    y = rng.standard_normal(n)
+    F = np.sort(rng.standard_normal((n, TAUS.size)), axis=1)
+    leaf = rng.integers(0, n_leaves, size=n)
+    w = rng.uniform(0.5, 1.5, size=n)
+    cb = np.cumsum(np.r_[0.0, rng.uniform(0, 0.1, TAUS.size - 1)])
+
+    np.testing.assert_array_equal(
+        _leaf_quantiles_vec(leaf, y, F, TAUS, cb, n_leaves, 0.1),
+        _leaf_quantiles_vec_serial(leaf, y, F, TAUS, cb, n_leaves, 0.1))
+    np.testing.assert_array_equal(
+        _leaf_quantiles_vec_w(leaf, y, F, w, TAUS, cb, n_leaves, 0.1),
+        _leaf_quantiles_vec_w_serial(leaf, y, F, w, TAUS, cb, n_leaves, 0.1))
+
+
+def _pava_reference(u):
+    """Plain-Python pool-adjacent-violators, the readable oracle for
+    `_project_leaf_row`'s in-place version."""
+    blocks = []                       # (mean, count)
+    for v in u:
+        val, cnt = float(v), 1
+        while blocks and blocks[-1][0] > val:
+            bv, bc = blocks.pop()
+            tot = bc + cnt
+            val = (bv * bc + val * cnt) / tot
+            cnt = tot
+        blocks.append((val, cnt))
+    out = []
+    for val, cnt in blocks:
+        out.extend([val] * cnt)
+    return np.array(out)
+
+
+def test_projection_matches_pava_and_respects_the_budget():
+    """The projection is isotonic regression in shifted coordinates: it must
+    match PAVA, and its output must satisfy the narrowing constraint
+    ``v[k] - v[k-1] >= -b[k]`` that keeps predictions from crossing."""
+    rng = np.random.default_rng(11)
+    K = TAUS.size
+    for _ in range(200):
+        b = np.r_[0.0, rng.uniform(0.0, 0.5, K - 1)]
+        cb = np.cumsum(b)
+        v = rng.standard_normal(K) * 0.3
+        buf = np.ascontiguousarray(v[None, :].copy())
+        _project_leaf_row(buf, 0, K, cb)
+        got = buf[0]
+        np.testing.assert_allclose(got, _pava_reference(v + cb) - cb,
+                                   rtol=0, atol=1e-12)
+        assert np.all(np.diff(got) >= -b[1:] - 1e-12)
+
+
+def test_projection_with_zero_budget_forces_monotone_increments():
+    """With no budget the admissible set collapses to non-decreasing vectors,
+    which is the degenerate case the guarantee rests on."""
+    rng = np.random.default_rng(12)
+    K = TAUS.size
+    buf = np.ascontiguousarray(rng.standard_normal((1, K)))
+    _project_leaf_row(buf, 0, K, np.zeros(K))
+    assert np.all(np.diff(buf[0]) >= 0.0)
+
+
+# --------------------------------------------------------------------------
+# The non-crossing guarantee
+# --------------------------------------------------------------------------
+
+def test_predictions_never_cross():
+    """Zero crossings, asserted exactly. Init is sorted, every committed
+    increment is admissible, and IEEE addition is monotone, so this is
+    structural rather than a tolerance."""
+    X, y = _heteroscedastic(seed=1)
+    m = ChimeraBoostQuantileRegressor(random_state=0, n_estimators=200).fit(X, y)
+    Q = m.predict(X)
+    assert Q.shape == (len(y), TAUS.size)
+    assert np.all(np.diff(Q, axis=1) >= 0.0)
+    assert qm.crossing_rate(Q) == 0.0
+
+
+def test_no_crossing_on_every_path():
+    """Staged stages, the tiny-batch serial predict kernel, the weighted and
+    subsampled paths, and the conformalized output all inherit the guarantee."""
+    X, y = _heteroscedastic(n=2500, seed=2)
+    rng = np.random.default_rng(0)
+    m = ChimeraBoostQuantileRegressor(
+        random_state=0, n_estimators=120, subsample=0.7).fit(
+            X, y, sample_weight=rng.uniform(0.5, 1.5, size=len(y)))
+    for stage in m.staged_predict(X[:64]):
+        assert np.all(np.diff(stage, axis=1) >= 0.0)
+    for k in (1, 2, 4, 5, 64):          # straddles the serial/parallel switch
+        assert np.all(np.diff(m.predict(X[:k]), axis=1) >= 0.0)
+
+    mc = ChimeraBoostQuantileRegressor(
+        random_state=0, n_estimators=120, conformalize=True).fit(X, y)
+    assert np.all(np.diff(mc.predict(X), axis=1) >= 0.0)
+
+
+def test_narrow_regions_are_actually_narrower():
+    """The head must be able to make an interval TIGHTER than the pooled one.
+    A construction that only ever adds non-decreasing increments cannot (the
+    sum of non-decreasing vectors is non-decreasing), so this pins the
+    behaviour the narrowing budget exists to allow."""
+    X, y = _heteroscedastic(n=6000, seed=3, narrow=True)
+    m = ChimeraBoostQuantileRegressor(random_state=0, n_estimators=400).fit(X, y)
+    Q = m.predict(X)
+    width = Q[:, -1] - Q[:, 0]              # 5%-95% width
+    tight, wide = X[:, 1] <= 0, X[:, 1] > 0
+    pooled = float(np.quantile(y, 0.95) - np.quantile(y, 0.05))
+    assert width[tight].mean() < 0.5 * pooled, (
+        f"tight-region width {width[tight].mean():.3f} should be far below the "
+        f"pooled width {pooled:.3f}")
+    assert width[tight].mean() < width[wide].mean()
+
+
+def test_staged_final_equals_predict():
+    X, y = _heteroscedastic(n=1200, seed=4)
+    m = ChimeraBoostQuantileRegressor(random_state=0, n_estimators=60).fit(X, y)
+    stages = list(m.staged_predict(X[:50]))
+    assert len(stages) == m.best_iteration_
+    np.testing.assert_array_equal(stages[-1], m.predict(X[:50]))
+
+
+# --------------------------------------------------------------------------
+# Accuracy
+# --------------------------------------------------------------------------
+
+def test_matches_scalar_quantile_regressor():
+    """Per level, one shared tree structure must stay close to the library's
+    own single-quantile regressors -- the in-repo stand-in for the LightGBM
+    comparison, so the suite needs no optional dependency.
+
+    Close, not better: K per-level models get K structures specialized to
+    their own level, and the whole point of this head is to give that up for a
+    K-fold cut in split-search work. The band below is what that trade costs
+    on ordinary heteroscedastic data; benchmarks/quantile_head.py measures it
+    against LightGBM properly."""
+    X, y = _heteroscedastic(n=4000, seed=5, narrow=False)
+    Xt, yt, Xv, yv = X[:3000], y[:3000], X[3000:], y[3000:]
+    levels = [0.1, 0.5, 0.9]
+    m = ChimeraBoostQuantileRegressor(
+        quantiles=levels, random_state=0, n_estimators=300).fit(Xt, yt)
+    Q = m.predict(Xv)
+    for k, a in enumerate(levels):
+        s = ChimeraBoostRegressor(loss="Quantile", alpha=a, random_state=0,
+                                  n_estimators=300, depth=4).fit(Xt, yt)
+        r_s = yv - s.predict(Xv)
+        r_m = yv - Q[:, k]
+        pb_s = float(np.maximum(a * r_s, (a - 1) * r_s).mean())
+        pb_m = float(np.maximum(a * r_m, (a - 1) * r_m).mean())
+        assert pb_m < 1.10 * pb_s, (
+            f"tau={a}: shared-tree pinball {pb_m:.5f} vs per-level "
+            f"{pb_s:.5f}")
+
+
+def test_projection_arms_agree_with_exact_gain():
+    """The default's whole justification: a rank-1 projection of the gradient
+    picks structure about as good as scoring the exact summed-across-level
+    gain, which costs K histogram channels."""
+    X, y = _heteroscedastic(n=2500, seed=6)
+    Xt, yt, Xv, yv = X[:1800], y[:1800], X[1800:], y[1800:]
+    kw = dict(random_state=0, n_estimators=200, early_stopping=False)
+    rot = ChimeraBoostQuantileRegressor(**kw).fit(Xt, yt)
+    exa = ChimeraBoostQuantileRegressor(exact_splits=True, **kw).fit(Xt, yt)
+    p_rot, p_exa = _pinball(yv, rot.predict(Xv)), _pinball(yv, exa.predict(Xv))
+    assert p_rot < 1.10 * p_exa, f"rotate {p_rot:.5f} vs exact {p_exa:.5f}"
+
+
+def test_sum_projection_is_blind_to_pure_spread():
+    """The literal channel sum cancels on a symmetric grid when only the
+    spread varies, which is why it is not the default. Recorded as a test so
+    the reasoning cannot quietly stop being true."""
+    rng = np.random.default_rng(9)
+    n = 6000
+    X = rng.standard_normal((n, 6))
+    y = (0.3 + 2.7 * (X[:, 1] > 0)) * rng.standard_normal(n)   # centre is 0
+    Xt, yt, Xv, yv = X[:4000], y[:4000], X[4000:], y[4000:]
+    kw = dict(random_state=0, n_estimators=300, early_stopping=False)
+    p_sum = _pinball(yv, ChimeraBoostQuantileRegressor(
+        split_projection="sum", **kw).fit(Xt, yt).predict(Xv))
+    p_rot = _pinball(yv, ChimeraBoostQuantileRegressor(**kw).fit(Xt, yt).predict(Xv))
+    assert p_rot < p_sum
+
+
+def test_learns_the_conditional_median():
+    X, y = _heteroscedastic(n=3000, seed=8)
+    m = ChimeraBoostQuantileRegressor(random_state=0, n_estimators=300).fit(X, y)
+    med = m.predict(X)[:, TAUS.size // 2]
+    assert float(np.corrcoef(med, 2.0 * X[:, 0])[0, 1]) > 0.95
+
+
+# --------------------------------------------------------------------------
+# Conformalization
+# --------------------------------------------------------------------------
+
+def test_conformal_coverage_is_near_nominal():
+    """CQR on a fold that saw no training, no early stopping and no model
+    selection should land every interval within ~2 points of nominal at
+    n=10k.
+
+    Scored on 20k fresh rows so that test-set sampling noise (about 0.9 points
+    on a 2k set) is not what the tolerance is measuring."""
+    X, y = _heteroscedastic(n=30000, p=10, seed=10, narrow=False)
+    Xt, yt, Xv, yv = X[:10000], y[:10000], X[10000:], y[10000:]
+    m = ChimeraBoostQuantileRegressor(
+        random_state=0, n_estimators=400, conformalize=True).fit(Xt, yt)
+    for iv in qm.interval_coverage(yv, m.predict(Xv), m.quantiles_):
+        assert abs(iv["coverage"] - iv["nominal"]) < 0.02, iv
+
+
+def test_conformal_hits_nominal_exactly_on_its_own_fold():
+    """The finite-sample guarantee itself, isolated from generalization: the
+    calibrated interval covers its own calibration fold at the nominal rate,
+    by construction of the conformal rank. Any test-set shortfall is variance
+    in how well that fold represents the next one, not a broken calibration --
+    worth separating, because the two get confused."""
+    rng = np.random.default_rng(30)
+    n = 8000
+    Q = np.sort(rng.standard_normal((n, TAUS.size)) * 0.1
+                + 3.0 * np.tile(TAUS - 0.5, (n, 1)), axis=1)
+    y = rng.standard_normal(n)
+    mi, mw = _median_index(TAUS)
+    s = _cqr_scales(Q, y, TAUS, mi, mw)
+    c = Q[:, mi][:, None]
+    for iv in qm.interval_coverage(y, c + s[None, :] * (Q - c), TAUS):
+        assert iv["coverage"] >= iv["nominal"] - 1e-9, iv
+
+
+def test_conformal_scale_is_ordered_and_nonnegative():
+    X, y = _heteroscedastic(n=4000, seed=11)
+    m = ChimeraBoostQuantileRegressor(
+        random_state=0, n_estimators=150, conformalize=True).fit(X, y)
+    s = m.conformal_scale_
+    assert np.all(s >= 0.0)
+    half = TAUS.size // 2
+    # Outer intervals must carry a factor at least as large as inner ones.
+    assert np.all(np.diff(s[:half]) <= 1e-12)
+
+
+def test_conformalize_fails_loudly_when_the_fold_is_too_small():
+    X, y = _heteroscedastic(n=200, seed=12)
+    with pytest.raises(ValueError, match="calibration"):
+        ChimeraBoostQuantileRegressor(
+            quantiles=[0.001, 0.5, 0.999], conformalize=True,
+            calibration_fraction=0.02, n_estimators=10,
+            random_state=0).fit(X, y)
+
+
+def test_cqr_scales_shrink_an_overdispersed_model():
+    """A model whose intervals are twice too wide should calibrate to a factor
+    near one half."""
+    rng = np.random.default_rng(13)
+    n = 20000
+    y = rng.standard_normal(n)
+    from scipy.stats import norm
+    Q = 2.0 * np.tile(norm.ppf(TAUS), (n, 1))     # exactly 2x too wide
+    mi, mw = _median_index(TAUS)
+    s = _cqr_scales(Q, y, TAUS, mi, mw)
+    assert 0.45 < s[0] < 0.55, s
+
+
+# --------------------------------------------------------------------------
+# Plumbing
+# --------------------------------------------------------------------------
+
+def test_predict_kinds():
+    X, y = _heteroscedastic(n=1500, seed=14)
+    m = ChimeraBoostQuantileRegressor(random_state=0, n_estimators=80).fit(X, y)
+    assert m.predict(X, kind="quantiles").shape == (len(y), TAUS.size)
+    iv = m.predict(X, kind="interval", alpha=0.1)
+    assert iv.shape == (len(y), 2)
+    np.testing.assert_array_equal(iv[:, 0], m.predict(X)[:, 0])
+    np.testing.assert_array_equal(iv[:, 1], m.predict(X)[:, -1])
+    mean = m.predict(X, kind="mean")
+    assert mean.shape == (len(y),)
+    Q = m.predict(X)
+    assert np.all(mean >= Q[:, 0]) and np.all(mean <= Q[:, -1])
+
+
+def test_mean_of_a_symmetric_grid_matches_the_trapezoid_by_hand():
+    """The flat-tail extension is a documented choice, so pin the arithmetic."""
+    X, y = _heteroscedastic(n=800, seed=15)
+    m = ChimeraBoostQuantileRegressor(quantiles=[0.25, 0.5, 0.75],
+                                      random_state=0, n_estimators=40).fit(X, y)
+    Q = m.predict(X)
+    taus = m.quantiles_
+    hand = (np.trapezoid(Q, x=taus, axis=1) if hasattr(np, "trapezoid")
+            else np.trapz(Q, x=taus, axis=1)) + 0.25 * Q[:, 0] + 0.25 * Q[:, -1]
+    np.testing.assert_allclose(m.predict(X, kind="mean"), hand, rtol=0,
+                               atol=1e-12)
+
+
+def test_pickle_round_trip():
+    X, y = _heteroscedastic(n=1200, seed=16)
+    m = ChimeraBoostQuantileRegressor(random_state=0, n_estimators=60,
+                                      conformalize=True).fit(X, y)
+    m2 = pickle.loads(pickle.dumps(m))
+    np.testing.assert_array_equal(m2.predict(X), m.predict(X))
+
+
+def test_categorical_and_nan_are_handled():
+    rng = np.random.default_rng(17)
+    n = 1500
+    num = rng.standard_normal((n, 3))
+    cat = rng.integers(0, 6, size=n).astype(np.float64)
+    X = np.column_stack([num, cat])
+    y = num[:, 0] + cat * 0.4 + rng.standard_normal(n) * 0.5
+    X[::50, 0] = np.nan
+    m = ChimeraBoostQuantileRegressor(random_state=0, n_estimators=80).fit(
+        X, y, cat_features=[3])
+    Q = m.predict(X)
+    assert np.isfinite(Q).all()
+    assert np.all(np.diff(Q, axis=1) >= 0.0)
+
+
+def test_reuses_the_shared_validation_helpers():
+    X, y = _heteroscedastic(n=600, seed=18)
+    m = ChimeraBoostQuantileRegressor(random_state=0, n_estimators=30)
+    with pytest.raises(Exception):
+        m.predict(X)                       # not fitted
+    m.fit(X, y)
+    with pytest.raises(ValueError):
+        m.predict(X[:, :3])                # wrong feature count
+    with pytest.raises(ValueError):
+        ChimeraBoostQuantileRegressor(depth=99).fit(X, y)
+    with pytest.raises(ValueError):
+        ChimeraBoostQuantileRegressor(n_estimators=30).fit(
+            X, y, sample_weight=np.full(len(y), -1.0))
+
+
+@pytest.mark.parametrize("bad", [[0.5, 0.1], [0.0, 0.5], [0.5, 1.0],
+                                 [0.3, 0.3], []])
+def test_quantile_grid_validation(bad):
+    X, y = _heteroscedastic(n=300, seed=19)
+    with pytest.raises(ValueError):
+        ChimeraBoostQuantileRegressor(quantiles=bad, n_estimators=10).fit(X, y)
+
+
+def test_single_quantile_grid_reduces_cleanly():
+    """K=1 has no spread or skew contrast and no interval; it must still fit."""
+    X, y = _heteroscedastic(n=1000, seed=20)
+    m = ChimeraBoostQuantileRegressor(quantiles=[0.5], random_state=0,
+                                      n_estimators=60).fit(X, y)
+    Q = m.predict(X)
+    assert Q.shape == (len(y), 1)
+    assert np.isfinite(m.predict(X, kind="mean")).all()
+
+
+def test_fixed_contrasts_are_orthonormal():
+    B = np.stack(_fixed_contrasts(TAUS), axis=1)
+    np.testing.assert_allclose(B.T @ B, np.eye(B.shape[1]), rtol=0, atol=1e-12)
+    # The first contrast is the plain channel sum, up to normalization.
+    np.testing.assert_allclose(B[:, 0], np.ones(TAUS.size) / np.sqrt(TAUS.size),
+                               rtol=0, atol=1e-12)
+
+
+def test_loss_reduces_to_the_scalar_quantile_gradient():
+    """A one-level grid must reproduce `losses.Quantile` term for term."""
+    from chimeraboost.losses import Quantile
+    rng = np.random.default_rng(21)
+    y = rng.standard_normal(500)
+    raw = rng.standard_normal(500)
+    mq = MultiQuantile(np.array([0.3]))
+    sq = Quantile(0.3)
+    g_m, h_m = mq.grad_hess(y, raw[:, None])
+    g_s, h_s = sq.grad_hess(y, raw)
+    np.testing.assert_array_equal(g_m[:, 0], g_s)
+    np.testing.assert_array_equal(h_m[:, 0], h_s)
+    np.testing.assert_allclose(mq.eval(y, raw[:, None]), sq.eval(y, raw),
+                               rtol=0, atol=1e-12)
+
+
+def test_booster_gap_bound_stays_positive():
+    """The narrowing budget is a lower bound on the gap for ANY row; if it
+    ever went negative the guarantee would be void."""
+    X, y = _heteroscedastic(n=3000, seed=22)
+    b = MultiQuantileBoosting(quantiles=TAUS, n_estimators=200, depth=4,
+                              random_state=0, min_child_weight=20.0)
+    b.fit(X, y)
+    assert np.all(b.gap_ >= 0.0)
+
+
+# --------------------------------------------------------------------------
+# Metrics
+# --------------------------------------------------------------------------
+
+def test_pinball_and_crps():
+    y = np.array([0.0, 1.0])
+    Q = np.array([[-1.0, 0.0, 1.0], [-1.0, 0.0, 1.0]])
+    taus = np.array([0.25, 0.5, 0.75])
+    per = qm.pinball_loss(y, Q, taus)
+    # row 0: r = 0-(-1)=1 -> .25*1 ; 0-0=0 -> 0 ; 0-1=-1 -> .25*1
+    # row 1: r = 2 -> .5 ; 1 -> .5 ; 0 -> 0
+    np.testing.assert_allclose(per, [(0.25 + 0.5) / 2, (0.0 + 0.5) / 2,
+                                     (0.25 + 0.0) / 2])
+    np.testing.assert_allclose(qm.crps(y, Q, taus), per.mean())
+
+
+def test_interval_coverage_and_width():
+    y = np.array([0.0, 5.0])
+    Q = np.array([[-1.0, 0.0, 1.0], [-1.0, 0.0, 1.0]])
+    taus = np.array([0.1, 0.5, 0.9])
+    iv = qm.interval_coverage(y, Q, taus)
+    assert len(iv) == 1
+    assert iv[0]["nominal"] == pytest.approx(0.8)
+    assert iv[0]["coverage"] == pytest.approx(0.5)
+    assert iv[0]["width"] == pytest.approx(2.0)
+
+
+def test_crossing_rate_detects_crossings():
+    assert qm.crossing_rate(np.array([[0.0, 1.0, 2.0]])) == 0.0
+    assert qm.crossing_rate(np.array([[0.0, 2.0, 1.0]])) == pytest.approx(0.5)
+
+
+def test_report_and_score():
+    X, y = _heteroscedastic(n=1000, seed=23)
+    m = ChimeraBoostQuantileRegressor(random_state=0, n_estimators=60).fit(X, y)
+    rep = m.report(X, y)
+    assert set(rep) == {"crps", "pinball", "taus", "intervals", "crossing_rate"}
+    assert rep["crossing_rate"] == 0.0
+    assert m.score(X, y) == pytest.approx(-rep["crps"])
+    assert isinstance(qm.format_report(rep, "t"), str)
+
+
+def test_metric_shape_errors():
+    y = np.zeros(3)
+    with pytest.raises(ValueError):
+        qm.pinball_loss(y, np.zeros((3, 2)), np.array([0.5]))
+    with pytest.raises(ValueError):
+        qm.pinball_loss(y, np.zeros((2, 2)), np.array([0.25, 0.75]))
+    with pytest.raises(ValueError):
+        qm.pinball_loss(y, np.zeros(3), np.array([0.5]))

--- a/tests/test_warmup.py
+++ b/tests/test_warmup.py
@@ -40,11 +40,22 @@ NOT_WARMED = {
     # warmup(shap=True), ~3.7 s of compile most callers never need.
     "chimeraboost.tree._shap_forest_linear",
     "chimeraboost.tree._predict_forest_linear",
-    # Called only from inside _linear_leaf_fit, never from Python, so its own
-    # dispatcher records a signature when that kernel is *compiled* but not
-    # when it is loaded from a warm cache. Warming it is not possible and
-    # asserting on it would make this test depend on cache state.
+    # Exact multi-quantile split search: opt-in via exact_splits=True, a
+    # reference arm costing K histogram channels per feature. Same reasoning
+    # as SHAP -- most callers never pay for it.
+    "chimeraboost.tree._build_split_descend_vec",
+    # Called only from inside another njit kernel, never from Python, so the
+    # dispatcher records a signature when that caller is *compiled* but not
+    # when it is loaded from a warm cache. Warming these is not possible and
+    # asserting on them would make this test depend on cache state.
     "chimeraboost.tree._solve_small",
+    "chimeraboost.tree._leaf_row_index",
+    "chimeraboost.tree._lerp_np",
+    "chimeraboost.tree._project_leaf_row",
+    "chimeraboost.tree._quantile_slice",
+    "chimeraboost.tree._select_kth",
+    "chimeraboost.tree._sort_pairs",
+    "chimeraboost.tree._weighted_quantile_slice",
 }
 
 # warmup(shap=True) additionally covers these.


### PR DESCRIPTION
`ChimeraBoostQuantileRegressor`: one booster, an arbitrary τ-grid, a K-vector in every leaf. Replaces "fit K independent quantile boosters" for estimating a whole predictive distribution.

```python
m = ChimeraBoostQuantileRegressor().fit(X, y)
Q     = m.predict(X_test)                              # (n, 19)
lo,hi = m.predict(X_test, kind="interval", alpha=0.1).T
mean  = m.predict(X_test, kind="mean")
```

## Acceptance

Against K = 19 LightGBM 4.6.0 quantile boosters sharing one Dataset, 300 rounds, depth 4, 3 seeds, n = 20 000.

| criterion | target | measured | |
|:--|:--|:--|:--|
| pinball vs K LightGBM boosters | match within noise | ratio 1.029 (5 features) → 0.996 (128) | **PASS** |
| fit wall clock | ≥ K/2 = 9.5× | 3.4× (5 features) → 7.8× (128) | **MISS** |
| crossing rate, no predict-time patch | exactly 0 | 0.0000 everywhere; LightGBM 0.18–0.21 | **PASS** |
| CQR coverage at n = 10k | within 2 points | worst 0.73 points | **PASS** |

**On the speed miss.** The saving is concentrated in the split search, which runs once per round instead of K times, so the speedup grows with data width and is still climbing at 128 features. It does not reach 9.5× in the tested range because the leaf refit is irreducibly K quantile selections per leaf — about 90% of a round at ordinary widths — while a single LightGBM quantile round is very cheap. Three optimizations are already in those numbers (PIT-rank projection, a K-aware parallel-dispatch threshold, refit parallelized over leaf×channel pairs); one was tried and reverted for being slower. All recorded in `benchmarks/QUANTILE_PLAN.md`.

## Two places the obvious design was wrong

**The spec's non-crossing construction diverges.** "Sort each leaf vector, so monotone init + monotone increments ⇒ never cross" is sound as stated but far too strong: a sum of non-decreasing vectors is non-decreasing, so the predicted interval can never be *narrower* than the pooled one, and the low-noise half of heteroscedastic data becomes inexpressible. Worse, sorting reverses a narrowing update into a widening one, which is self-reinforcing — measured pinball 2.9e7 against an oracle of 0.35.

The fix keeps the guarantee and drops the over-constraint. Each channel carries a **narrowing budget**: a lower bound on the gap that holds for *any* input row, not just training rows, spent down as rounds actually narrow. The admissible set becomes plain monotonicity under a shift, so the projection is isotonic regression — pool-adjacent-violators, which averages violators, where a sort permutes them and can flip a contrast's sign.

**Additive conformal correction cannot shrink.** A quantile model fitted with shrinkage is systematically over-dispersed (measured raw coverage 0.844 at nominal 0.70), so calibration needs to *shrink*. An additive offset vector that shrinks is non-monotone, and applying one safely costs narrowing budget the fit has already spent — it projected away to exactly zero. The correction is a per-level **scale about the predicted median** instead, which cannot reorder anything for any row.

## The split search, named

Pinball loss has hessian 1 in every channel, so the exact summed-across-τ gain collapses to `‖G_L‖²/(n_L+λ) + ‖G_R‖²/(n_R+λ) − ‖G_P‖²/(n_P+λ)`, which by Parseval equals the sum of projected gains over **any** orthonormal basis. Projecting onto one direction is therefore the rank-1 truncation of the exact gain, not a different algorithm. `exact_splits=True` computes the full form as the reference arm.

A second structural fact makes it cheap: a row's entire gradient is determined by its PIT rank, so the projection is a suffix sum reached by one binary search per row — the fit never builds an (n, K) gradient at all.

Ablation (excess pinball over the oracle, ×1000, 3 seeds):

| arm | location | scale | mixed | extreme | TOTAL |
|:--|--:|--:|--:|--:|--:|
| rotate (default) | 13.161 | 21.082 | 30.541 | 55.735 | **120.520** |
| sum | 13.056 | 17.222 | 43.150 | 72.966 | 146.394 |
| gram | 12.715 | 17.573 | 43.264 | 72.996 | 146.548 |
| exact | 15.651 | 20.705 | 28.039 | 48.404 | 112.799 |

The literal channel sum is dead: on a symmetric grid the τ and 1−τ pushes are equal and opposite, so a correctly-centred but too-narrow region sums to exactly zero. Measuring the direction adaptively rather than cycling ("gram") did not pay — raw gradient energy is dominated by Bernoulli noise peaking at the median, and whitening by the Brownian-bridge null is ill-conditioned. Both kept as options, documented as measured-worse.

## Scope

New: `chimeraboost/quantile_api.py`, `quantile_metrics.py`, `benchmarks/quantile_head.py`, `benchmarks/QUANTILE_PLAN.md`, `docs/quantiles.md`, `tests/test_quantile_head.py` (40 tests). Existing estimators' defaults are untouched — 706 tests pass, goldens unmoved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
