### PR TITLE
Fix off-by-one in the quantile head's automatic leaf-size floor

### DIFF
--- a/chimeraboost/quantile_api.py
+++ b/chimeraboost/quantile_api.py
@@ -53,7 +53,17 @@ def _auto_min_child_weight(taus):
     ``min_data_in_leaf`` -- convenient when comparing the two.
     """
     edge = min(float(taus[0]), 1.0 - float(taus[-1]))
-    return float(np.ceil(1.0 / max(edge, 1e-9)))
+    inv = 1.0 / max(edge, 1e-9)
+    # `1.0 - taus[-1]` is not exact in binary: for a symmetric grid such as
+    # (0.1, 0.5, 0.9) it lands a couple of ulps BELOW 0.1, so the reciprocal
+    # creeps just past 10 and `ceil` rounds the floor up to 11. Snap to a whole
+    # number when we are within rounding noise of one -- genuine fractions like
+    # the 3.33 of a (0.3, 0.7) grid are far outside the tolerance and still
+    # round up, which is the intended behaviour.
+    nearest = round(inv)
+    if abs(inv - nearest) <= 1e-9 * max(1.0, abs(inv)):
+        inv = float(nearest)
+    return float(np.ceil(inv))
 
 
 def _median_index(taus):

--- a/tests/test_quantile_head.py
+++ b/tests/test_quantile_head.py
@@ -10,7 +10,9 @@ from chimeraboost import ChimeraBoostQuantileRegressor, ChimeraBoostRegressor
 from chimeraboost import quantile_metrics as qm
 from chimeraboost.booster import MultiQuantileBoosting, _fixed_contrasts
 from chimeraboost.losses import MultiQuantile, _weighted_quantile
-from chimeraboost.quantile_api import _cqr_scales, _median_index
+from chimeraboost.quantile_api import (DEFAULT_QUANTILES,
+                                       _auto_min_child_weight, _cqr_scales,
+                                       _median_index)
 from chimeraboost.tree import (_leaf_quantiles_vec, _leaf_quantiles_vec_serial,
                                _leaf_quantiles_vec_w,
                                _leaf_quantiles_vec_w_serial,
@@ -514,6 +516,33 @@ def test_report_and_score():
     assert rep["crossing_rate"] == 0.0
     assert m.score(X, y) == pytest.approx(-rep["crps"])
     assert isinstance(qm.format_report(rep, "t"), str)
+
+
+@pytest.mark.parametrize("grid, want", [
+    ([0.1, 0.5, 0.9], 10),          # 1.0 - 0.9 is a few ulps under 0.1
+    ([0.2, 0.8], 5),                # so is 1.0 - 0.8
+    ([0.05, 0.5, 0.95], 20),
+    (list(DEFAULT_QUANTILES), 20),  # matches LightGBM's min_data_in_leaf
+    ([0.25, 0.75], 4),
+    ([0.01, 0.99], 100),
+    ([0.001, 0.999], 1000),
+    ([0.3, 0.7], 4),                # 1/0.3 is GENUINELY 3.33 -- must round up
+    ([0.15, 0.85], 7),              # likewise 6.67
+])
+def test_auto_min_child_weight_is_exact_on_symmetric_grids(grid, want):
+    """The floor is 1/edge rounded up. Computing `edge` as `1.0 - taus[-1]`
+    loses a couple of ulps, which used to push the reciprocal just past a whole
+    number and cost an extra row of leaf floor -- 11 instead of 10 for the
+    (0.1, 0.5, 0.9) grid. Fractional edges must still round up."""
+    assert _auto_min_child_weight(np.asarray(grid)) == want
+
+
+def test_auto_min_child_weight_unrounded_grid_matches_rounded():
+    """A user building the default grid by arithmetic rather than by
+    `np.round` lands on 0.9500000000000001, which must not change the floor."""
+    unrounded = np.array([0.05 + 0.05 * i for i in range(19)])
+    assert (_auto_min_child_weight(unrounded)
+            == _auto_min_child_weight(DEFAULT_QUANTILES) == 20)
 
 
 def test_metric_shape_errors():


### PR DESCRIPTION
## What

`_auto_min_child_weight` derives the quantile head's leaf-size floor as `1/edge`
rounded up, where `edge` is the distance from the most extreme requested level
to 0 or 1. Computing that as `1.0 - taus[-1]` is inexact in binary: for a
symmetric grid like `(0.1, 0.5, 0.9)` it lands a couple of ulps *below* 0.1, so
the reciprocal creeps to `10.000000000000002` and `ceil` returns 11 instead of
10.

## Scope

Any symmetric grid whose upper edge loses precision was affected:

| grid | intended floor | returned |
|---|---|---|
| `[0.1, 0.5, 0.9]` | 10 | 11 |
| `[0.2, 0.8]` | 5 | 6 |
| 19-level grid built by arithmetic rather than `np.round` | 20 | 21 |

The shipped `DEFAULT_QUANTILES` grid is already rounded to 10 decimals and was
correct at 20, so **no default behaviour changes** — only explicitly supplied
grids were paying an extra row of leaf floor.

## Fix

Snap the reciprocal to a whole number when it is within rounding noise of one.
Genuine fractions are far outside the tolerance and still round up, which is the
intended behaviour: a `[0.3, 0.7]` grid stays at 4, not 3.

## Tests

716 passed, 1 skipped, numerical-identity goldens included. Adds a parametrized
regression test over nine grids (covering both the ulp cases and the genuine
fractions that must still round up) plus one asserting an unrounded 19-level
grid matches the rounded default.

## Not in scope

Found while investigating the head's interval widths. The separate and larger
finding from that work — that the non-crossing narrowing budget saturates within
about fifty rounds and freezes the interval width, leaving bands 2x to 10x wider
than calibrated — is **not** addressed here and remains parked on
`worktree-leaf-replay-tuning`.

No CHANGELOG entry: `ChimeraBoostQuantileRegressor` is itself unreleased, so
this bug never reached a user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
