### PR TITLE
Numba greedy-border sweep and group-level bag member draws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,23 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
   bit-identical, so predictions are unchanged. `warmup()` now derives its
   parallel-batch row count from the threshold rather than hardcoding it, so a
   future change cannot silently leave the parallel kernel uncompiled.
+- **Binning is up to ~4x faster on zero-inflated columns and ~3x faster on
+  dense ones.** The greedy border pass walked every distinct value in a Python
+  loop; it is now a numba kernel, its per-value mass is read off the sort's run
+  lengths instead of a `searchsorted` + `np.add.at` pass, and the quantile
+  probe partitions the already-sorted copy in place. Borders are bit-identical
+  throughout (pinned against transcriptions of the old code). 200k x 30
+  zero-inflated: 1.34 s -> 0.33 s; dense: 0.29 s -> 0.10 s.
+- **Bagged members draw whole groups when `groups` is passed.** The
+  group-disjoint out-of-bag eval set introduced above was correct but dead in
+  practice: a typical 80% row draw touches essentially every group, so it came
+  back empty and every grouped member fell back to its auto-split. Drawing
+  `max_samples` of the *groups* (a cluster bootstrap at 1.0) always holds at
+  least one group out, so members early-stop on groups they never saw and no
+  longer carve a validation slice out of their own sample. Held-out-group
+  strength is unchanged on a 24-config synthetic panel (11W-13L, median
+  +0.05%) with ~20% faster bagged fits. `groups=None` draws are byte-identical
+  to before.
 
 ### Added
 - **`ChimeraBoostQuantileRegressor`: a whole predictive distribution from one

--- a/chimeraboost/binning.py
+++ b/chimeraboost/binning.py
@@ -116,6 +116,41 @@ def _weighted_quantiles(values, weights, qs):
     return np.interp(qs, pos, v)
 
 
+@njit(cache=True)
+def _greedy_border_fill(uniq, mass, heavy, target, budget):
+    """Compiled twin of the border-building sweep in `_greedy_borders`.
+
+    A straight transcription of the former Python loop: same statement order,
+    same float64 arithmetic, so the borders are bit-identical. Only the sweep
+    lives here -- the mass sums and heavy-value marking stay in numpy above,
+    because numba's reductions do not match numpy's pairwise summation
+    bit-for-bit and `target` must not move."""
+    n = uniq.size
+    borders = np.empty(budget, dtype=np.float64)
+    nb = 0
+    acc = 0.0
+    for i in range(n):
+        if nb >= budget:
+            break
+        if heavy[i]:
+            if acc > 0.0:
+                # Close the light run before the heavy value so it gets a
+                # bin of its own.
+                borders[nb] = (uniq[i - 1] + uniq[i]) / 2.0
+                nb += 1
+                acc = 0.0
+            if i < n - 1 and nb < budget:
+                borders[nb] = (uniq[i] + uniq[i + 1]) / 2.0
+                nb += 1
+        else:
+            acc += mass[i]
+            if acc >= target and i < n - 1:
+                borders[nb] = (uniq[i] + uniq[i + 1]) / 2.0
+                nb += 1
+                acc = 0.0
+    return borders[:nb].copy()
+
+
 def _greedy_borders(uniq, mass, max_bins):
     """Borders over distinct values when even-mass quantiles have collapsed.
 
@@ -160,26 +195,13 @@ def _greedy_borders(uniq, mass, max_bins):
     light_bins = max(1, max_bins // 16,
                      int(round((max_bins - n_heavy) * (light_total / total))))
     target = light_total / light_bins
-    budget = max_bins - 1
-    borders = []
-    acc = 0.0
-    for i in range(uniq.size):
-        if len(borders) >= budget:
-            break
-        if heavy[i]:
-            if acc > 0.0:
-                # Close the light run before the heavy value so it gets a
-                # bin of its own.
-                borders.append((uniq[i - 1] + uniq[i]) / 2.0)
-                acc = 0.0
-            if i < uniq.size - 1 and len(borders) < budget:
-                borders.append((uniq[i] + uniq[i + 1]) / 2.0)
-        else:
-            acc += mass[i]
-            if acc >= target and i < uniq.size - 1:
-                borders.append((uniq[i] + uniq[i + 1]) / 2.0)
-                acc = 0.0
-    return np.asarray(borders, dtype=np.float64)
+    # The O(n_distinct) sweep is compiled: in pure Python it made Binner.fit
+    # ~4x slower on zero-inflated columns (1.34 s vs 0.29 s dense at 200k
+    # rows x 30 features).
+    return _greedy_border_fill(
+        np.ascontiguousarray(uniq, dtype=np.float64),
+        np.ascontiguousarray(mass, dtype=np.float64),
+        heavy, float(target), int(max_bins - 1))
 
 
 def _feature_borders(col, max_bins, weights=None):
@@ -200,16 +222,32 @@ def _feature_borders(col, max_bins, weights=None):
     if weights is None:
         if finite.size == 0:
             return np.array([], dtype=np.float64)
-        uniq = np.unique(finite)
+        # Open-coded np.unique (one sort + a run-start mask) so the greedy
+        # path below can read its per-value mass off the run lengths for
+        # free. np.unique's counts would cost every dense column a little,
+        # and the old searchsorted + np.add.at pass cost the greedy columns
+        # more than the greedy sweep itself. Counts are exact integers any
+        # way they are computed, so borders are bit-identical.
+        sv = np.sort(finite)
+        run_start = np.empty(sv.size, dtype=np.bool_)
+        run_start[0] = True
+        np.not_equal(sv[1:], sv[:-1], out=run_start[1:])
+        uniq = sv[run_start]
         if uniq.size <= max_bins:
             # Few distinct values: put a border between each pair.
             return ((uniq[:-1] + uniq[1:]) / 2.0).astype(np.float64)
         qs = np.linspace(0.0, 1.0, max_bins + 1)[1:-1]
-        borders = np.unique(np.quantile(finite, qs))
+        # Quantiles of the sorted copy, partitioned in place: identical values
+        # (quantile is order-agnostic), but skips np.quantile's internal copy
+        # and partitions near-instantly. Only sv.size is read below this line,
+        # so scrambling sv is fine.
+        borders = np.unique(np.quantile(sv, qs, overwrite_input=True))
         if borders.size == qs.size:
             return borders.astype(np.float64)
-        counts = np.zeros(uniq.size)
-        np.add.at(counts, np.searchsorted(uniq, finite), 1.0)
+        starts = np.nonzero(run_start)[0]
+        counts = np.empty(starts.size, dtype=np.float64)
+        counts[:-1] = np.diff(starts)
+        counts[-1] = sv.size - starts[-1]
         return _greedy_borders(uniq, counts, max_bins)
     # Weighted path: a zero-weight row does not exist for border purposes.
     fw = weights[finite_mask]

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -409,14 +409,60 @@ def _member_oob_eval_indices(idx, n, groups):
     ``groups`` it is further restricted to rows whose group never appears in
     the sample -- otherwise the member's stopping signal comes from rows
     correlated with its training rows, exactly the leakage the ``groups``
-    argument promises to prevent. May return an empty array (e.g. every group
-    straddles the sample); the caller then falls back to the member's own
-    auto-split, which is group-aware."""
+    argument promises to prevent. Because grouped members draw whole groups
+    (``_member_sample_indices``), the excluded-for-straddling set is normally
+    just the rare-class donor's group; before group draws existed, a typical
+    80% row draw touched essentially every group and this returned zero rows
+    on real data, silently disabling OOB early stopping. May still return an
+    empty array (e.g. a cluster bootstrap that drew every group); the caller
+    then falls back to the member's own auto-split, which is group-aware."""
     oob_mask = np.ones(n, dtype=np.bool_)
     oob_mask[idx] = False
     if groups is not None:
         oob_mask &= ~np.isin(groups, np.unique(groups[idx]))
     return np.where(oob_mask)[0]
+
+
+def _member_sample_indices(n, ms, seed, groups):
+    """Row indices for one bag member's training sample.
+
+    Without ``groups``: ``ms`` of the ``n`` rows drawn without replacement
+    ("subagging"), or a classic full-size with-replacement bootstrap at
+    ``ms >= 1.0`` -- byte-identical to the draws made before this helper
+    existed (same rng construction, same single call).
+
+    With ``groups``: the same recipe applied to whole groups -- ``ms`` of the
+    groups without replacement (each contributing all of its rows), or a
+    full-size cluster bootstrap of groups at ``ms >= 1.0``. Drawing rows
+    would leave essentially every group straddling the sample, which both
+    leaks group structure into the member AND empties the group-disjoint OOB
+    set `_member_oob_eval_indices` builds. At least one group is always held
+    out (the draw is capped at ``n_groups - 1``), so the OOB eval set is
+    non-empty by construction. ``ms`` counts groups, not rows, so a member's
+    row count varies with the sizes of the groups it drew. A single all-rows
+    group falls back to the row draw: there is nothing to hold out."""
+    rng = np.random.default_rng(seed)
+    if groups is not None:
+        ug = np.unique(groups)
+        if ug.size >= 2:
+            if ms >= 1.0:
+                # Cluster bootstrap: n_groups draws with replacement; a group
+                # drawn twice appears twice (duplicates are integer weights,
+                # exactly like the row bootstrap).
+                drawn = rng.integers(0, ug.size, size=ug.size)
+                order = np.argsort(groups, kind="stable")
+                sg = groups[order]
+                starts = np.searchsorted(sg, ug, side="left")
+                ends = np.searchsorted(sg, ug, side="right")
+                return np.concatenate(
+                    [order[starts[g]:ends[g]] for g in drawn])
+            m = max(1, min(ug.size - 1, int(round(ms * ug.size))))
+            drawn = rng.choice(ug.size, size=m, replace=False)
+            return np.where(np.isin(groups, ug[drawn]))[0]
+    if ms >= 1.0:
+        return rng.integers(0, n, size=n)
+    m = max(1, int(round(ms * n)))
+    return rng.choice(n, size=m, replace=False)
 
 
 def _fit_bagged(estimator, X, y, cat_features, eval_set, groups, sample_weight):
@@ -426,7 +472,10 @@ def _fit_bagged(estimator, X, y, cat_features, eval_set, groups, sample_weight):
     (``n_ensembles=None``) and its own seed, fit on its own random row sample:
     ``max_samples`` (default 0.8) of the rows drawn WITHOUT replacement
     ("subagging"; ``max_samples=1.0`` restores the classic full-size
-    with-replacement bootstrap). Because a member is the same estimator class,
+    with-replacement bootstrap). With ``groups`` the same recipe draws whole
+    groups instead of rows, so the held-out groups form each member's
+    group-disjoint OOB eval set (see ``_member_sample_indices``). Because a
+    member is the same estimator class,
     all per-model machinery â€” binary/multiclass dispatch, ``cat_features``,
     the early-stopping auto-split, temperature scaling â€” is reused unchanged,
     and ``cat_features``/``sample_weight``/``groups`` forward naturally (which
@@ -502,13 +551,12 @@ def _fit_bagged(estimator, X, y, cat_features, eval_set, groups, sample_weight):
         # 0.8n compute is more effective data AND less work — measured
         # stronger and faster on both decision suites (gr 54W-5L +0.94%,
         # Brier 23W-0L, fit 0.87x; hc Brier 8W-0L, fit 0.73x).
-        # max_samples=1.0 restores the classic full-size bootstrap.
+        # max_samples=1.0 restores the classic full-size bootstrap. With
+        # ``groups`` the draw is over whole groups instead of rows, so the
+        # held-out groups give the member a non-empty group-disjoint OOB
+        # eval set (see _member_sample_indices).
         ms = float(estimator.max_samples)
-        if ms >= 1.0:
-            idx = np.random.default_rng(seed).integers(0, n, size=n)
-        else:
-            m = max(1, int(round(ms * n)))
-            idx = np.random.default_rng(seed).choice(n, size=m, replace=False)
+        idx = _member_sample_indices(n, ms, seed, groups)
         # A rare class can be missed by the draw entirely, and a member cannot
         # fit on a single class ("Need at least 2 classes" would crash the
         # whole bag on data whose y plainly has two). Inject one row of the
@@ -1336,7 +1384,10 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         bootstrap on strength and fit time (a full-size bootstrap holds
         only ~0.63n unique rows at n rows of compute). 1.0 restores the
         classic full-size with-replacement bootstrap. Unsampled rows are
-        each member's early-stopping eval set either way.
+        each member's early-stopping eval set either way. When ``groups``
+        is passed to ``fit``, the draw is over whole groups instead of
+        rows (a cluster bootstrap at 1.0), so each member's eval set is
+        made of groups it never trained on.
     refit_full : "replay", bool, default "replay"
         After the automatic early-stopping split has chosen the tree budget
         (and model selection / calibration have used it), retrain the winning
@@ -2041,7 +2092,10 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         bootstrap on strength and fit time (a full-size bootstrap holds
         only ~0.63n unique rows at n rows of compute). 1.0 restores the
         classic full-size with-replacement bootstrap. Unsampled rows are
-        each member's early-stopping eval set either way.
+        each member's early-stopping eval set either way. When ``groups``
+        is passed to ``fit``, the draw is over whole groups instead of
+        rows (a cluster bootstrap at 1.0), so each member's eval set is
+        made of groups it never trained on.
     refit_full : "replay", bool, default "replay"
         After the automatic early-stopping split has chosen the tree budget
         (and model selection / temperature scaling have used it), retrain the

--- a/chimeraboost/warmup.py
+++ b/chimeraboost/warmup.py
@@ -215,6 +215,15 @@ def warmup(verbose=False, background=False, shap=False):
     _grouped_kahan_sum(np.zeros(4, dtype=np.int64), np.ones(4), 2)
     _log("gdiff group-sum kernel")
 
+    # The greedy-border sweep only fires when a column's quantile borders
+    # collapse (one value holding more than an even bin's share of mass) --
+    # none of the warmup fits' columns do, so compile it directly with the
+    # dtypes `_greedy_borders` passes (same treatment as the gdiff kernel).
+    from .binning import _greedy_border_fill
+    _greedy_border_fill(np.arange(4, dtype=np.float64), np.ones(4),
+                        np.zeros(4, dtype=np.bool_), 2.0, 3)
+    _log("greedy-border sweep kernel")
+
     # The fused level kernel (`_build_split_descend_q`) has one signature for
     # both its small-n and large-n branches, so the small fits above compile
     # everything on the tree-build path — no direct kernel calls needed.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -196,7 +196,8 @@ early-stopping metric stays unweighted.
 Regressors average predictions; classifiers soft-vote calibrated probabilities. Each
 member trains on `max_samples` (default 0.8) of the rows drawn without replacement,
 which beats the classic bootstrap on both accuracy and fit time, and early-stops on
-its own unsampled rows.
+its own unsampled rows. With `groups`, each member draws whole groups instead of
+rows and early-stops on the groups it never saw.
 
 ```python
 reg = ChimeraBoostRegressor(n_ensembles=8, random_state=0).fit(X_train, y_train)

--- a/tests/test_greedy_kernel_and_group_bagging.py
+++ b/tests/test_greedy_kernel_and_group_bagging.py
@@ -1,0 +1,244 @@
+"""Regression tests for the two PR #53 follow-ups.
+
+  * The `_greedy_borders` value sweep moved into a numba kernel and the
+    unweighted `_feature_borders` path open-codes np.unique -- both promised
+    bit-identical to the old pure-Python/numpy versions, pinned here against
+    in-test reference transcriptions of the old code.
+  * Bag members draw whole groups when ``groups`` is passed, so the
+    group-disjoint OOB eval set `_member_oob_eval_indices` builds is non-empty
+    by construction. Before, a typical 80% row draw touched essentially every
+    group, the OOB set came back empty, and OOB early stopping was silently
+    dead for every grouped bagged fit."""
+
+import numpy as np
+import pytest
+
+from chimeraboost import ChimeraBoostClassifier, ChimeraBoostRegressor
+from chimeraboost.binning import _feature_borders, _greedy_border_fill
+from chimeraboost.sklearn_api import (_member_oob_eval_indices,
+                                      _member_sample_indices)
+
+
+# --- greedy-border kernel: bit-identity to the retired Python loop -----------
+
+def _reference_greedy_fill(uniq, mass, heavy, target, budget):
+    """The pure-Python sweep `_greedy_border_fill` replaced, verbatim."""
+    borders = []
+    acc = 0.0
+    for i in range(uniq.size):
+        if len(borders) >= budget:
+            break
+        if heavy[i]:
+            if acc > 0.0:
+                borders.append((uniq[i - 1] + uniq[i]) / 2.0)
+                acc = 0.0
+            if i < uniq.size - 1 and len(borders) < budget:
+                borders.append((uniq[i] + uniq[i + 1]) / 2.0)
+        else:
+            acc += mass[i]
+            if acc >= target and i < uniq.size - 1:
+                borders.append((uniq[i] + uniq[i + 1]) / 2.0)
+                acc = 0.0
+    return np.asarray(borders, dtype=np.float64)
+
+
+@pytest.mark.parametrize("seed", range(20))
+def test_greedy_fill_kernel_matches_python_reference(seed):
+    rng = np.random.default_rng(seed)
+    n = int(rng.integers(3, 400))
+    uniq = np.sort(rng.normal(size=n))
+    mass = rng.uniform(0.0, 5.0, size=n)
+    mass[rng.random(n) < 0.3] *= 100.0          # some heavy hitters
+    heavy = mass >= np.sort(mass)[-max(1, n // 8)]
+    target = float(mass[~heavy].sum() / max(1, int((~heavy).sum()) // 4 or 1))
+    budget = int(rng.integers(1, 64))
+    got = _greedy_border_fill(uniq, mass, heavy, target, budget)
+    want = _reference_greedy_fill(uniq, mass, heavy, target, budget)
+    assert got.dtype == want.dtype
+    assert np.array_equal(got, want)
+
+
+def _reference_feature_borders_unweighted(col, max_bins):
+    """The np.unique + searchsorted + np.add.at path this change retired,
+    verbatim; the new open-coded sort must be bit-identical to it."""
+    finite = col[np.isfinite(col)]
+    if finite.size == 0:
+        return np.array([], dtype=np.float64)
+    uniq = np.unique(finite)
+    if uniq.size <= max_bins:
+        return ((uniq[:-1] + uniq[1:]) / 2.0).astype(np.float64)
+    qs = np.linspace(0.0, 1.0, max_bins + 1)[1:-1]
+    borders = np.unique(np.quantile(finite, qs))
+    if borders.size == qs.size:
+        return borders.astype(np.float64)
+    counts = np.zeros(uniq.size)
+    np.add.at(counts, np.searchsorted(uniq, finite), 1.0)
+    from chimeraboost.binning import _greedy_borders
+    return _greedy_borders(uniq, counts, max_bins)
+
+
+@pytest.mark.parametrize("seed", range(10))
+def test_unweighted_borders_bit_identical_to_old_path(seed):
+    rng = np.random.default_rng(seed)
+    n = int(rng.integers(50, 5000))
+    cols = [
+        rng.normal(size=n),                                   # dense
+        np.where(rng.random(n) < 0.9, 0.0, rng.normal(size=n)),   # dominated
+        rng.poisson(1.5, size=n).astype(np.float64),          # few uniques
+    ]
+    zi = rng.normal(size=n)
+    zi[rng.random(n) < 0.5] = 0.0
+    cols.append(zi)                                           # zero-inflated
+    nan_col = rng.normal(size=n)
+    nan_col[rng.random(n) < 0.1] = np.nan
+    cols.append(nan_col)
+    for col in cols:
+        for max_bins in (2, 3, 8, 15, 16, 32, 128):
+            got = _feature_borders(col, max_bins)
+            want = _reference_feature_borders_unweighted(col, max_bins)
+            assert np.array_equal(got, want), (seed, max_bins)
+
+
+# --- member sampling: rows without groups, whole groups with ----------------
+
+def test_member_row_draw_byte_identical_to_old_recipe():
+    """groups=None draws must not move: same rng construction, same single
+    call as the inline code this helper replaced."""
+    n = 1000
+    for seed in (0, 7, 12345):
+        for ms in (0.3, 0.8):
+            m = max(1, int(round(ms * n)))
+            want = np.random.default_rng(seed).choice(n, size=m, replace=False)
+            got = _member_sample_indices(n, ms, seed, None)
+            assert np.array_equal(got, want)
+        want = np.random.default_rng(seed).integers(0, n, size=n)
+        got = _member_sample_indices(n, 1.0, seed, None)
+        assert np.array_equal(got, want)
+
+
+@pytest.mark.parametrize("dtype", ["int", "str"])
+@pytest.mark.parametrize("ms", [0.2, 0.5, 0.8])
+def test_group_draw_takes_whole_groups_and_holds_some_out(dtype, ms):
+    rng = np.random.default_rng(3)
+    sizes = rng.integers(1, 30, size=25)
+    groups = np.repeat(np.arange(sizes.size), sizes)
+    if dtype == "str":
+        groups = np.array([f"g{g:03d}" for g in groups])
+    n = groups.size
+    for seed in range(10):
+        idx = _member_sample_indices(n, ms, seed, groups)
+        drawn_groups = np.unique(groups[idx])
+        # Whole groups: every row of a drawn group is in the sample.
+        in_drawn = np.isin(groups, drawn_groups)
+        assert np.array_equal(np.sort(idx), np.where(in_drawn)[0])
+        # And at least one group is held out, so the OOB set is non-empty
+        # and group-disjoint.
+        oob = _member_oob_eval_indices(idx, n, groups)
+        assert len(oob) > 0
+        assert not np.isin(groups[oob], drawn_groups).any()
+
+
+def test_group_cluster_bootstrap_at_full_size():
+    """ms=1.0 with groups: n_groups draws with replacement, a group drawn k
+    times contributes each of its rows exactly k times."""
+    groups = np.repeat(np.arange(12), 5)
+    n = groups.size
+    idx = _member_sample_indices(n, 1.0, 42, groups)
+    drawn = np.random.default_rng(42).integers(0, 12, size=12)
+    mult = np.bincount(drawn, minlength=12)
+    got_counts = np.bincount(groups[idx], minlength=12)
+    assert np.array_equal(got_counts, mult * 5)
+    # Every copy of a drawn group is complete (each row appears k times).
+    row_counts = np.bincount(idx, minlength=n)
+    assert np.array_equal(row_counts, mult[groups])
+
+
+def test_single_group_falls_back_to_row_draw():
+    """One group has nothing to hold out; the draw must equal the plain row
+    draw so tiny grouped fits keep working exactly as before."""
+    n = 100
+    groups = np.zeros(n, dtype=int)
+    for ms in (0.5, 1.0):
+        got = _member_sample_indices(n, ms, 5, groups)
+        want = _member_sample_indices(n, ms, 5, None)
+        assert np.array_equal(got, want)
+
+
+def test_tiny_group_count_still_leaves_one_out():
+    """round(0.8 * 2) == 2 would draw both groups; the n_groups-1 cap keeps
+    one out so the OOB set survives even at two groups."""
+    groups = np.repeat([0, 1], 20)
+    idx = _member_sample_indices(40, 0.8, 0, groups)
+    assert np.unique(groups[idx]).size == 1
+
+
+# --- end to end: grouped bagged fits get a live OOB eval set ----------------
+
+def _grouped_data(seed=0, n_groups=20, group_size=12):
+    """Group random-effects data: rows within a group share an offset."""
+    rng = np.random.default_rng(seed)
+    n = n_groups * group_size
+    groups = np.repeat(np.arange(n_groups), group_size)
+    X = rng.normal(size=(n, 4))
+    effect = rng.normal(size=n_groups)[groups]
+    y = X[:, 0] + effect + 0.3 * rng.normal(size=n)
+    return X, y, groups
+
+
+def test_grouped_bagged_members_get_nonempty_oob_evals(monkeypatch):
+    """The point of the change: with groups, members no longer fall back to
+    the auto-split -- the OOB set is non-empty for every member."""
+    import chimeraboost.sklearn_api as api
+    returned_sizes = []
+    real = api._member_oob_eval_indices
+
+    def spy(idx, n, groups):
+        out = real(idx, n, groups)
+        returned_sizes.append(len(out))
+        return out
+
+    monkeypatch.setattr(api, "_member_oob_eval_indices", spy)
+    X, y, groups = _grouped_data()
+    reg = ChimeraBoostRegressor(n_estimators=20, depth=3, n_ensembles=3,
+                                ensemble_n_jobs=1, random_state=0)
+    reg.fit(X, y, groups=groups)
+    assert len(returned_sizes) == 3
+    assert all(s > 0 for s in returned_sizes)
+    assert np.all(np.isfinite(reg.predict(X[:5])))
+
+
+def test_grouped_bagged_classifier_fits_and_predicts():
+    X, y, groups = _grouped_data(seed=1)
+    yc = (y > np.median(y)).astype(int)
+    clf = ChimeraBoostClassifier(n_estimators=20, depth=3, n_ensembles=3,
+                                 ensemble_n_jobs=1, random_state=0)
+    clf.fit(X, yc, groups=groups)
+    proba = clf.predict_proba(X[:7])
+    assert proba.shape == (7, 2)
+    assert np.allclose(proba.sum(axis=1), 1.0)
+
+
+def test_grouped_bagged_rare_class_guard_still_works():
+    """A group draw can miss a class entirely (the rare class lives in one
+    group); the donor patch must still rescue the member."""
+    rng = np.random.default_rng(0)
+    n = 60
+    groups = np.repeat(np.arange(6), 10)
+    X = rng.normal(size=(n, 3))
+    y = np.zeros(n, dtype=int)
+    y[groups == 0] = 1          # the rare class is exactly one group
+    clf = ChimeraBoostClassifier(n_estimators=5, depth=2, n_ensembles=5,
+                                 max_samples=0.4, ensemble_n_jobs=1,
+                                 random_state=0)
+    clf.fit(X, y, groups=groups)
+    proba = clf.predict_proba(X[:1])
+    assert proba.shape == (1, 2)
+
+
+def test_grouped_bagged_with_sample_weight():
+    X, y, groups = _grouped_data(seed=2)
+    sw = np.random.default_rng(2).uniform(0.5, 2.0, size=len(y))
+    reg = ChimeraBoostRegressor(n_estimators=15, depth=3, n_ensembles=3,
+                                ensemble_n_jobs=1, random_state=0)
+    reg.fit(X, y, groups=groups, sample_weight=sw)
+    assert np.all(np.isfinite(reg.predict(X[:5])))


### PR DESCRIPTION
The two follow-ups #53 named and deferred, each promising its own change.

## The greedy border pass is compiled: ~4x on zero-inflated columns, ~3x on dense

`_greedy_borders` walked every distinct value in a Python loop. Three changes,
each bit-identical by construction:

- The O(n_distinct) sweep is a numba kernel. The mass sums and heavy-value
  marking stay in numpy, because numba's reductions do not match numpy's
  pairwise summation bit-for-bit and the split target must not move.
- The unweighted path open-codes `np.unique` (one sort + a run-start mask), so
  the greedy path reads its per-value mass off the run lengths for free. The
  old `searchsorted` + `np.add.at` pass cost more than the greedy sweep itself.
  Counts are exact integers either way.
- The quantile collapse probe runs on the already-sorted copy with
  `overwrite_input=True`: quantile is order-agnostic, and only the array's
  size is read afterwards. This is what speeds up *dense* columns too — the
  one sort now feeds both unique and quantile.

On the #53 repro shape (200k rows x 30 features): zero-inflated `Binner.fit`
1.34 s -> 0.33 s, dense control 0.29 s -> 0.10 s.

Identity evidence: a 4,400-case fuzz (zero-inflated, heavy multi-modal,
Poisson counts, NaN mixes, weighted and unweighted, `max_bins` 2-255) against
the pre-change source came back exactly equal; the new tests pin the kernel
and the unweighted path against verbatim transcriptions of the old code; the
numerical-identity goldens pass. `warmup()` compiles the new kernel directly
(same treatment as the gdiff kernel), keeping the exact-coverage test honest.

## Bag members draw whole groups, so the group-aware OOB path is alive

The group-disjoint OOB eval set #52 added was correct but dead: with a typical
80% row draw essentially every group has a row in the sample, so the set came
back empty and every grouped member fell back to its auto-split. As #53 put
it, the real fix is sampling members by group.

`max_samples` now draws that fraction of the *groups* (each contributing all
its rows), capped at `n_groups - 1` so at least one group is always held out;
`max_samples=1.0` becomes a cluster bootstrap (n_groups draws with
replacement, a group drawn twice appears twice). A single all-rows group falls
back to the row draw. `groups=None` draws are byte-identical to before — same
rng construction, same single call — so ungrouped bagged fits do not move.

The benchmarks never pass `groups`, so the decision suites cannot see this
change either way. The honest check is a 24-config synthetic panel (group
random effects, regression + classification, varied group counts and effect
sizes), scored on held-out groups:

| | old (row draws) | new (group draws) |
|---|---|---|
| head-to-head | 13 wins | 11 wins |
| median metric delta | — | +0.05% (noise) |
| median bagged fit | 0.23 s | 0.18 s |

Flat strength is the expected reading: the old fallback (member auto-split)
was also group-aware, just wasteful — it carved a validation slice out of each
member's sample. The win is structural correctness plus ~20% faster grouped
bagged fits.

## Testing

44 new tests in `tests/test_greedy_kernel_and_group_bagging.py`. Full suite
**823 passed, 1 skipped**, goldens included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)