### PR TITLE
Cleanup: dead code, unused imports, and two long-overdue dedups

### DIFF
--- a/benchmarks/fuzz_inputs.py
+++ b/benchmarks/fuzz_inputs.py
@@ -27,7 +27,6 @@ Usage:
 import argparse
 import os
 import sys
-import traceback
 
 import numpy as np
 
@@ -99,11 +98,6 @@ def base_mixed(task, n=N, seed=0):
         "n1": num[:, 1],
     })
     return X, y, ["lo", "hi"]
-
-
-def _classifier_ok(y):
-    """A classifier needs >=2 classes; squash a 1-class probe target if needed."""
-    return y
 
 
 # ---------------------------------------------------------------------------

--- a/benchmarks/probe_cross_features.py
+++ b/benchmarks/probe_cross_features.py
@@ -70,10 +70,6 @@ BINARY = [
 ALL = GAP + CONTROL + BINARY
 
 
-def _numeric_matrix(X, cols):
-    return np.column_stack([X[:, i].astype(np.float64) for i in cols])
-
-
 def _augment(Xtr, Xte, pairs, kind):
     """Append cross columns for the given (i, j) index pairs. kind in
     {diff, prod, both}. Appended at the END so cat indices stay valid."""

--- a/benchmarks/probe_pair_stability.py
+++ b/benchmarks/probe_pair_stability.py
@@ -14,7 +14,6 @@ Run:
     python benchmarks/probe_pair_stability.py [--k 100] [--seeds 3]
 """
 import argparse
-import collections
 
 import numpy as np
 from sklearn.model_selection import train_test_split

--- a/benchmarks/replay_attr.py
+++ b/benchmarks/replay_attr.py
@@ -17,7 +17,6 @@ from sklearn.model_selection import train_test_split
 
 import chimeraboost
 import chimeraboost.booster as bmod
-import chimeraboost.tree as tmod
 from chimeraboost import ChimeraBoostClassifier, ChimeraBoostRegressor
 from chimeraboost.warmup import warmup
 import run_benchmarks as rb

--- a/benchmarks/research/ideas.py
+++ b/benchmarks/research/ideas.py
@@ -132,7 +132,3 @@ def get(name):
     if name not in IDEAS:
         raise KeyError(f"unknown idea {name!r}; known: {sorted(IDEAS)}")
     return IDEAS[name]
-
-
-def implemented_ideas():
-    return [n for n, spec in IDEAS.items() if spec["implemented"]]

--- a/benchmarks/suite_weights.py
+++ b/benchmarks/suite_weights.py
@@ -268,37 +268,3 @@ def bootstrap_competitor_relative_rank_ci(scores, ours, competitors,
     return out
 
 
-def bootstrap_average_rank_ci(scores, field, weights=None, n_boot=10000, seed=0):
-    """95% CI for average_rank, resampling DATASETS (not seeds) with replacement.
-
-    Weights ride along with the resampled datasets, so the interval reflects both
-    dataset-sampling noise and the concentration the weighting introduces.
-    """
-    import numpy as np
-    ds_list = sorted(d for d, s in scores.items() if all(m in s for m in field))
-    if not ds_list:
-        return {m: (None, None) for m in field}
-    rng = np.random.default_rng(seed)
-    idx = rng.integers(0, len(ds_list), size=(n_boot, len(ds_list)))
-    draws = {m: [] for m in field}
-    for row in idx:
-        sub = {}
-        subw = {}
-        for c, i in enumerate(row):
-            d = ds_list[i]
-            key = f"{d}#{c}"          # keep duplicates distinct
-            sub[key] = scores[d]
-            subw[key] = 1.0 if weights is None else weights.get(d, 0.0)
-        r = average_rank(sub, field, subw)
-        for m in field:
-            if m in r and not math.isnan(r[m]):
-                draws[m].append(r[m])
-    out = {}
-    for m in field:
-        if draws[m]:
-            arr = np.array(draws[m])
-            out[m] = (float(np.percentile(arr, 2.5)),
-                      float(np.percentile(arr, 97.5)))
-        else:
-            out[m] = (None, None)
-    return out

--- a/chimeraboost/booster.py
+++ b/chimeraboost/booster.py
@@ -122,7 +122,7 @@ def _thread_limit(thread_count):
         numba.set_num_threads(prev)
 
 
-def _auto_learning_rate(n_samples, n_estimators, early_stopping):
+def _auto_learning_rate(n_estimators, early_stopping):
     """Default learning rate when the user did not specify one.
 
     With early stopping, 0.1 (the field-standard default) lets early stopping
@@ -289,6 +289,42 @@ class _BaseBooster:
         return -val if getattr(self.eval_metric, "greater_is_better", False) \
             else val
 
+    def _round_epilogue(self, m, F, y, w, Fv, yv, wv, stopper, callbacks,
+                        cb_train_loss, advance_fv):
+        """Per-round tail shared by the three boosters: train-history append,
+        eval-set scoring with early stopping, the progress print, and the
+        callback hook. ``advance_fv`` adds the new tree's contribution to
+        ``Fv`` in place; it runs only when there is an eval set, so callers
+        must not precompute it. Returns True when training should stop -- the
+        caller breaks, which keeps the ``for/else`` no-break truncation
+        exactly as before."""
+        if self.verbose:
+            self.train_history_.append(self.loss_.eval(y, F, w))
+
+        if Fv is not None:
+            advance_fv()
+            val = self._val_score(yv, Fv, wv)   # wv=None -> unweighted
+            self.valid_history_.append(val)
+            if stopper.step(val, m):
+                if self.verbose:
+                    print(f"Early stop at {m} (best {stopper.best_iter})")
+                self.trees_ = self.trees_[: stopper.best_iter + 1]
+                return True
+
+        if self.verbose and (m % max(1, self.n_estimators // 10) == 0):
+            msg = f"[{m}] train {self.train_history_[-1]:.5f}"
+            if Fv is not None:
+                msg += f"  val {self.valid_history_[-1]:.5f}"
+            print(msg)
+
+        if callbacks:
+            tl = self.train_history_[-1] if self.train_history_ \
+                else (self.loss_.eval(y, F, w) if cb_train_loss else None)
+            vl = self.valid_history_[-1] if self.valid_history_ else None
+            if _run_callbacks(callbacks, m, tl, vl, self):
+                return True
+        return False
+
     def predict_raw(self, X, cat_ctx=None):
         """Predict under this model's thread limit (restored on exit).
         ``cat_ctx`` (internal) shares categorical factorizations across the
@@ -380,11 +416,11 @@ class _BaseBooster:
         w = np.asarray(sample_weight, dtype=np.float64)
         return _uniform_to_none(w * (n_samples / w.sum()))
 
-    def _resolve_lr(self, n_samples, eval_set):
+    def _resolve_lr(self, eval_set):
         if self.learning_rate is not None:
             return float(self.learning_rate)
         es = self.early_stopping_rounds is not None and eval_set is not None
-        return _auto_learning_rate(n_samples, self.n_estimators, es)
+        return _auto_learning_rate(self.n_estimators, es)
 
     def _loo_update(self, tree, leaf, g, h):
         """Leave-one-out leaf step: each row's training update uses its leaf's
@@ -532,7 +568,7 @@ class GradientBoosting(_BaseBooster):
         # losses.py protocol (see losses.CustomObjective); used as-is.
         self.loss_ = (LOSSES[self.loss_name](**self.loss_kwargs)
                       if isinstance(self.loss_name, str) else self.loss_name)
-        self.lr_ = self._resolve_lr(n_samples, eval_set)
+        self.lr_ = self._resolve_lr(eval_set)
 
         donor_trees = None
         if self.replay_donor is not None:
@@ -679,31 +715,10 @@ class GradientBoosting(_BaseBooster):
                 if not adjusts_leaves:
                     self._refine_leaf_values(tree, leaf, F, y, w)
                 F += tree.values[leaf]
-            if self.verbose:
-                self.train_history_.append(self.loss_.eval(y, F, w))
-
-            if Fv is not None:
-                Fv += tree.predict(Xvb)
-                val = self._val_score(yv, Fv, wv)   # wv=None -> unweighted
-                self.valid_history_.append(val)
-                if stopper.step(val, m):
-                    if self.verbose:
-                        print(f"Early stop at {m} (best {stopper.best_iter})")
-                    self.trees_ = self.trees_[: stopper.best_iter + 1]
-                    break
-
-            if self.verbose and (m % max(1, self.n_estimators // 10) == 0):
-                msg = f"[{m}] train {self.train_history_[-1]:.5f}"
-                if Fv is not None:
-                    msg += f"  val {self.valid_history_[-1]:.5f}"
-                print(msg)
-
-            if callbacks:
-                tl = self.train_history_[-1] if self.train_history_ \
-                    else (self.loss_.eval(y, F, w) if cb_train_loss else None)
-                vl = self.valid_history_[-1] if self.valid_history_ else None
-                if _run_callbacks(callbacks, m, tl, vl, self):
-                    break
+            if self._round_epilogue(
+                    m, F, y, w, Fv, yv, wv, stopper, callbacks, cb_train_loss,
+                    lambda: np.add(Fv, tree.predict(Xvb), out=Fv)):
+                break
         else:
             # No break: the tree budget ran out before patience could fire.
             # Keep the best prefix exactly as the mid-training stop would
@@ -855,7 +870,7 @@ class MulticlassBoosting(_BaseBooster):
         w = self._normalize_weights(sample_weight, n_samples)
 
         self.loss_ = MultiSoftmax(K)
-        self.lr_ = self._resolve_lr(n_samples, eval_set)
+        self.lr_ = self._resolve_lr(eval_set)
 
         # One ordered-TS target per class (CatBoost-style per-class statistics).
         Xb, Xvb = self._prep_matrices(X, [Y[:, k] for k in range(K)],
@@ -951,31 +966,10 @@ class MulticlassBoosting(_BaseBooster):
             else:
                 F += tree.values[leaf]
             self.trees_.append(tree)
-            if self.verbose:
-                self.train_history_.append(self.loss_.eval(Y, F, w))
-
-            if Fv is not None:
-                Fv += tree.values[tree.apply(Xvb)]
-                val = self._val_score(Yv, Fv, wv)   # wv=None -> unweighted
-                self.valid_history_.append(val)
-                if stopper.step(val, m):
-                    if self.verbose:
-                        print(f"Early stop at {m} (best {stopper.best_iter})")
-                    self.trees_ = self.trees_[: stopper.best_iter + 1]
-                    break
-
-            if self.verbose and (m % max(1, self.n_estimators // 10) == 0):
-                msg = f"[{m}] train {self.train_history_[-1]:.5f}"
-                if Fv is not None:
-                    msg += f"  val {self.valid_history_[-1]:.5f}"
-                print(msg)
-
-            if callbacks:
-                tl = self.train_history_[-1] if self.train_history_ \
-                    else (self.loss_.eval(Y, F, w) if cb_train_loss else None)
-                vl = self.valid_history_[-1] if self.valid_history_ else None
-                if _run_callbacks(callbacks, m, tl, vl, self):
-                    break
+            if self._round_epilogue(
+                    m, F, Y, w, Fv, Yv, wv, stopper, callbacks, cb_train_loss,
+                    lambda: np.add(Fv, tree.values[tree.apply(Xvb)], out=Fv)):
+                break
         else:
             # No break: the tree budget ran out before patience could fire.
             # Keep the best prefix exactly as the mid-training stop would
@@ -1260,9 +1254,8 @@ class MultiQuantileBoosting(_BaseBooster):
 
         taus = self.quantiles
         K = taus.shape[0]
-        self.n_quantiles_ = K
         self.loss_ = MultiQuantile(taus)
-        self.lr_ = self._resolve_lr(n_samples, eval_set)
+        self.lr_ = self._resolve_lr(eval_set)
         self._contrasts_ = _fixed_contrasts(taus)
 
         # One TS-encoding target: every quantile shares the same y, unlike
@@ -1419,31 +1412,10 @@ class MultiQuantileBoosting(_BaseBooster):
 
             _add_leaf_values(F, tree.values, leaf)
             self.trees_.append(tree)
-            if self.verbose:
-                self.train_history_.append(self.loss_.eval(y, F, w))
-
-            if Fv is not None:
-                Fv += tree.values[tree.apply(Xvb)]
-                val = self._val_score(yv, Fv, wv)   # wv=None -> unweighted
-                self.valid_history_.append(val)
-                if stopper.step(val, m):
-                    if self.verbose:
-                        print(f"Early stop at {m} (best {stopper.best_iter})")
-                    self.trees_ = self.trees_[: stopper.best_iter + 1]
-                    break
-
-            if self.verbose and (m % max(1, self.n_estimators // 10) == 0):
-                msg = f"[{m}] train {self.train_history_[-1]:.5f}"
-                if Fv is not None:
-                    msg += f"  val {self.valid_history_[-1]:.5f}"
-                print(msg)
-
-            if callbacks:
-                tl = self.train_history_[-1] if self.train_history_ \
-                    else (self.loss_.eval(y, F, w) if cb_train_loss else None)
-                vl = self.valid_history_[-1] if self.valid_history_ else None
-                if _run_callbacks(callbacks, m, tl, vl, self):
-                    break
+            if self._round_epilogue(
+                    m, F, y, w, Fv, yv, wv, stopper, callbacks, cb_train_loss,
+                    lambda: np.add(Fv, tree.values[tree.apply(Xvb)], out=Fv)):
+                break
         else:
             # No break: the tree budget ran out before patience could fire.
             if Fv is not None and stopper.patience:
@@ -1455,7 +1427,6 @@ class MultiQuantileBoosting(_BaseBooster):
         self.gap_ = np.diff(self.init_) + (
             sum(np.diff(t.values, axis=1).min(axis=0) for t in self.trees_)
             if self.trees_ else 0.0)
-        self.gap_floor_ = floor
         self.fit_time_ = time.time() - t0
         self.best_iteration_ = len(self.trees_)
         return self

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -701,6 +701,41 @@ def _make_eval_split(X, y, validation_fraction, random_state,
     return train_idx, val_idx
 
 
+def _auto_es_split(est, X, y, sample_weight, eval_set, groups, stratify):
+    """Resolve ``early_stopping=True`` into an explicit ``eval_set`` by holding
+    out ``validation_fraction`` of the rows. Shared by the regressor
+    (``stratify=None``) and the classifier (``stratify=y``); the classifier's
+    lost-class check runs at its call site. Returns
+    ``(es_active, auto_split, X, y, sample_weight, eval_set)``; the caller
+    keeps the pre-split arrays for the optional full-data refit."""
+    es_active = bool(est.early_stopping)
+    auto_split = False
+    if es_active and eval_set is None:
+        split = _make_eval_split(
+            X, y, est.validation_fraction, est.random_state,
+            groups=groups, stratify=stratify,
+        )
+        if split is None:
+            es_active = False  # data too small to hold out a val set
+        else:
+            auto_split = True
+            train_idx, val_idx = split
+            if est.verbose and not getattr(est, "_is_bag_member", False):
+                print(f"early_stopping=True: holding out {len(val_idx)} "
+                      f"of {len(X)} rows as a validation set (pass "
+                      "eval_set to choose it, or early_stopping=False "
+                      "to train on all rows)")
+            # Carry the val rows' weights so zero-weight rows split off into
+            # the auto holdout don't score the early-stopping metric (H3).
+            sw_val = (sample_weight[val_idx]
+                      if sample_weight is not None else None)
+            eval_set = (X[val_idx], y[val_idx], sw_val)
+            X, y = X[train_idx], y[train_idx]
+            if sample_weight is not None:
+                sample_weight = sample_weight[train_idx]
+    return es_active, auto_split, X, y, sample_weight, eval_set
+
+
 def _extract_feature_names(X):
     """Return X's column names as a 1-D object array, or None.
 
@@ -1598,34 +1633,11 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                     f"loss={self.loss!r} and will have no effect.",
                     UserWarning, stacklevel=2)
 
-        es_active = bool(self.early_stopping)
         # Kept for the optional full-data refit below: the auto split
         # reassigns X/y, but the refit retrains on every row.
         X_full, y_full, sw_full = X, y, sample_weight
-        auto_split = False
-        if es_active and eval_set is None:
-            split = _make_eval_split(
-                X, y, self.validation_fraction, self.random_state,
-                groups=groups, stratify=None,
-            )
-            if split is None:
-                es_active = False  # data too small to hold out a val set
-            else:
-                auto_split = True
-                train_idx, val_idx = split
-                if self.verbose and not getattr(self, "_is_bag_member", False):
-                    print(f"early_stopping=True: holding out {len(val_idx)} "
-                          f"of {len(X)} rows as a validation set (pass "
-                          "eval_set to choose it, or early_stopping=False "
-                          "to train on all rows)")
-                # Carry the val rows' weights so zero-weight rows split off into
-                # the auto holdout don't score the early-stopping metric (H3).
-                sw_val = (sample_weight[val_idx]
-                          if sample_weight is not None else None)
-                eval_set = (X[val_idx], y[val_idx], sw_val)
-                X, y = X[train_idx], y[train_idx]
-                if sample_weight is not None:
-                    sample_weight = sample_weight[train_idx]
+        es_active, auto_split, X, y, sample_weight, eval_set = _auto_es_split(
+            self, X, y, sample_weight, eval_set, groups, stratify=None)
 
         # Mirror the classifier's inert-setting warnings: an explicit
         # linear_leaves=True shadows ordered boosting / leaf refinement once
@@ -1646,8 +1658,8 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                 UserWarning, stacklevel=2)
 
         # If early stopping is active but patience not explicitly set, use 50.
-        # 50 beats 10 on 25/34 benchmark datasets (lr=0.1 keeps improving past a
-        # 10-round plateau); see benchmarks/investigate_early_stopping.py.
+        # 50 beat 10 on 25/34 benchmark datasets when measured (lr=0.1 keeps
+        # improving past a 10-round plateau).
         es_rounds = self.early_stopping_rounds
         if es_active and es_rounds is None:
             es_rounds = 50
@@ -2295,48 +2307,27 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         if sample_weight is not None:
             sample_weight = np.asarray(sample_weight, dtype=np.float64)
 
-        es_active = bool(self.early_stopping)
         # Kept for the optional full-data refit below: the auto split
         # reassigns X/y, but the refit retrains on every row.
         X_full, y_full, sw_full = X, y, sample_weight
-        auto_split = False
-        if es_active and eval_set is None:
-            split = _make_eval_split(
-                X, y, self.validation_fraction, self.random_state,
-                groups=groups, stratify=y,  # always stratify for classification
-            )
-            if split is None:
-                es_active = False  # data too small to hold out a val set
-            else:
-                auto_split = True
-                train_idx, val_idx = split
-                if self.verbose and not getattr(self, "_is_bag_member", False):
-                    print(f"early_stopping=True: holding out {len(val_idx)} "
-                          f"of {len(X)} rows as a validation set (pass "
-                          "eval_set to choose it, or early_stopping=False "
-                          "to train on all rows)")
-                # Carry val-row weights so zero-weight holdout rows don't score
-                # the early-stopping metric (H3).
-                sw_val = (sample_weight[val_idx]
-                          if sample_weight is not None else None)
-                eval_set = (X[val_idx], y[val_idx], sw_val)
-                X, y = X[train_idx], y[train_idx]
-                if sample_weight is not None:
-                    sample_weight = sample_weight[train_idx]
-                self.classes_ = np.unique(y)
-                self.n_classes_ = self.classes_.size
-                lost = np.setdiff1d(all_classes, self.classes_)
-                if lost.size and not getattr(self, "_is_bag_member", False):
-                    # Without this, the model silently trains without the lost
-                    # class and never predicts it (its eval rows are even
-                    # remapped onto neighboring classes).
-                    raise ValueError(
-                        f"The automatic early-stopping split left class(es) "
-                        f"{lost.tolist()} entirely in the validation set, "
-                        "usually because the class is rare or (with `groups`) "
-                        "confined to a single group. Pass an explicit "
-                        "eval_set, lower validation_fraction, or set "
-                        "early_stopping=False.")
+        es_active, auto_split, X, y, sample_weight, eval_set = _auto_es_split(
+            self, X, y, sample_weight, eval_set, groups,
+            stratify=y)  # always stratify for classification
+        if auto_split:
+            self.classes_ = np.unique(y)
+            self.n_classes_ = self.classes_.size
+            lost = np.setdiff1d(all_classes, self.classes_)
+            if lost.size and not getattr(self, "_is_bag_member", False):
+                # Without this, the model silently trains without the lost
+                # class and never predicts it (its eval rows are even
+                # remapped onto neighboring classes).
+                raise ValueError(
+                    f"The automatic early-stopping split left class(es) "
+                    f"{lost.tolist()} entirely in the validation set, "
+                    "usually because the class is rare or (with `groups`) "
+                    "confined to a single group. Pass an explicit "
+                    "eval_set, lower validation_fraction, or set "
+                    "early_stopping=False.")
 
         es_rounds = self.early_stopping_rounds
         if es_active and es_rounds is None:

--- a/tests/test_audit_fixes.py
+++ b/tests/test_audit_fixes.py
@@ -338,7 +338,6 @@ def test_h3_early_stopping_metric_ignores_zero_weight_rows():
     assert m_zero.best_iteration_ > 20
     rng = np.random.default_rng(99)
     Xte = rng.normal(size=(2000, 6))
-    yte = Xte[:, 0] * 2.0 + Xte[:, 1] - 0.5 * Xte[:, 2]
     rmse = lambda a, b: float(np.sqrt(np.mean((a - b) ** 2)))
     # Predictions track the rows-removed model closely (not off by an order
     # of magnitude, as the corrupted-metric fit was).

--- a/tests/test_synth_report.py
+++ b/tests/test_synth_report.py
@@ -3,8 +3,6 @@ import json
 import os
 import sys
 
-import numpy as np
-
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "benchmarks"))
 
 import synth_report

--- a/tests/test_synthgen.py
+++ b/tests/test_synthgen.py
@@ -22,7 +22,7 @@ GOLDEN_PATH = os.path.join(os.path.dirname(__file__), "golden_synthgen.json")
 
 
 @pytest.fixture(autouse=True)
-def _flat_memory():
+def _clear_dataset_cache():
     yield
     synthgen.build_dataset.cache_clear()
 

--- a/tests/test_tree_kernels.py
+++ b/tests/test_tree_kernels.py
@@ -7,7 +7,6 @@ these tests: any diff here is a correctness bug, not a tolerance question.
 """
 
 import numpy as np
-import pytest
 
 from chimeraboost.tree import (
     _best_split,


### PR DESCRIPTION
Mechanical cleanup pass. Everything here is behavior-identical, gated by the new exact-identity snapshot harness (`benchmarks/identity_snapshot.py`, 84 arrays over 20 configs, all `np.array_equal` exact) plus the full suite (823+ green per commit).

**Dead code removed**
- `gap_floor_` and `n_quantiles_`: write-only booster attributes nobody reads (`gap_` and the sklearn-layer `quantiles_` are the real artifacts). `fit_time_` deliberately kept — sklearn-style diagnostic a user may read.
- `_auto_learning_rate`'s `n_samples` parameter: threaded through two layers, never used.
- Four benchmark helpers with zero call sites (one was a no-op stub whose docstring described behavior it didn't have), six unused imports/locals, one comment pointing at a script deleted months ago, one misnamed autouse fixture.

**Dedups**
- The ~25-line per-round tail (train history → eval scoring/early-stop → progress print → callbacks) was copy-pasted across all three boosters; now one `_BaseBooster._round_epilogue`. The eval advance is a closure invoked only when an eval set exists, and the stop flag preserves the `for/else` truncation semantics exactly.
- The auto early-stopping split block was duplicated between regressor and classifier; now one `_auto_es_split` (classifier keeps its lost-class check at the call site).

Left alone on purpose: the tree.py reference kernels (bit-equivalence oracles), the pre-0.25 pickle-compat shims (fresh; note they currently have no test coverage), and the triplicated @njit split-search loops (documented-accepted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)