### PR TITLE
Binner: fit borders in parallel across features (bit-identical)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to ChimeraBoost are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+### Changed
+- **Numeric binning fits its borders in parallel across features.** Every
+  column's borders were already computed independently; wide-enough fits
+  (200k+ cells) now farm the columns out to a thread pool running the same
+  per-column code, sized by the numba thread count so `thread_count` and
+  bagged-worker budgets are honored. Bit-identical — every border, bin
+  center and downstream model is exactly unchanged (84/84 identity-snapshot
+  arrays). Measured at 200k rows x 30 features on 12 threads: dense borders
+  4.3x faster, zero-inflated 3.2x, sample-weighted 5.5x; a 50k x 200 matrix
+  2.7x. Small fits keep the serial loop.
+
 ## [0.26.0] - 2026-07-30
 ### Added
 - **`ChimeraBoostQuantileRegressor`: a whole predictive distribution from one

--- a/chimeraboost/binning.py
+++ b/chimeraboost/binning.py
@@ -11,8 +11,10 @@ Bin layout per feature:
 The histogram width for a feature is therefore (n_borders + 2).
 """
 
+from concurrent.futures import ThreadPoolExecutor
+
 import numpy as np
-from numba import njit, prange
+from numba import get_num_threads, njit, prange
 
 BIN_DTYPE = np.uint16
 # uint16 max is 65535; we reserve one slot for NaN, so the cap is 65534.
@@ -267,6 +269,27 @@ def _feature_borders(col, max_bins, weights=None):
     return _greedy_borders(uniq, wmass, max_bins)
 
 
+# Matrices with fewer cells than this fit their borders serially: below the
+# crossover the thread-pool spawn/join costs more than the whole pass.
+#
+# Measured 2026-07-30 (12 threads, 128 bins, dense unweighted, best of 5):
+#
+#      shape      cells    serial   parallel
+#    5000x10      50000    1.79ms     3.09ms   serial 1.7x
+#    5000x30     150000    5.31ms     7.92ms   serial 1.5x
+#   20000x10     200000    3.64ms     3.39ms   parallel 1.08x
+#   50000x10     500000    7.43ms     3.84ms   parallel 1.9x
+#  100000x30    3000000   40.24ms    12.23ms   parallel 3.3x
+#  200000x30    6000000   96.0 ms    22.3 ms   parallel 4.3x
+#
+# Zero-inflated columns gain 3.2x at 200k x 30 and the weighted path 5.5x
+# (its argsort/cumsum/interp all release the GIL). 200k cells is the first
+# size parallel wins; the penalty for being wrong near the boundary is a few
+# ms either way. Both dispatch arms run identical per-column code, so the
+# constant only affects speed, never borders.
+_PARALLEL_FIT_MIN_CELLS = 200_000
+
+
 class Binner:
     """Learns per-feature borders and maps a float matrix to bins."""
 
@@ -333,10 +356,25 @@ class Binner:
         n_features = X.shape[1]
         w = None if sample_weight is None else np.asarray(
             sample_weight, dtype=np.float64)
-        self.borders_ = [
-            _feature_borders(X[:, f], self._max_bins_for(f), w)
-            for f in range(n_features)
-        ]
+        # Every column's borders are independent (the invariant
+        # from_base_with_cross splices on), so wide-enough fits farm the
+        # columns out to a thread pool running the *same* per-column code --
+        # numpy's sort/partition/argsort release the GIL, and nothing here
+        # accumulates across features, so the borders are bit-identical to
+        # the serial loop regardless of scheduling. Pool width follows
+        # numba's thread count: fit already runs inside _thread_limit, so
+        # thread_count=1 and bagged-worker budget shares are honored.
+        n_threads = min(get_num_threads(), n_features)
+        if n_threads > 1 and X.size >= _PARALLEL_FIT_MIN_CELLS:
+            with ThreadPoolExecutor(max_workers=n_threads) as ex:
+                self.borders_ = list(ex.map(
+                    lambda f: _feature_borders(X[:, f], self._max_bins_for(f), w),
+                    range(n_features)))
+        else:
+            self.borders_ = [
+                _feature_borders(X[:, f], self._max_bins_for(f), w)
+                for f in range(n_features)
+            ]
         # +1 for the searchsorted upper bucket, +1 for the NaN bucket.
         self.n_bins_ = np.array(
             [len(b) + 2 for b in self.borders_], dtype=np.int64

--- a/tests/test_binner_parallel_fit.py
+++ b/tests/test_binner_parallel_fit.py
@@ -1,0 +1,80 @@
+"""The thread-pool Binner.fit must be bit-identical to the serial loop.
+
+Same convention as the _bin_matrix / _bin_matrix_serial twins: both dispatch
+arms run the identical per-column arithmetic, so every fitted artifact must
+match np.array_equal-exactly, across column pathologies, weights, and bin
+budgets. The parallel/serial choice is forced through _PARALLEL_FIT_MIN_CELLS.
+"""
+
+import numpy as np
+import pytest
+
+import chimeraboost.binning as B
+
+
+def _pathological_matrix(seed, n=800):
+    """One column of every shape the binner special-cases."""
+    rng = np.random.default_rng(seed)
+    cols = [
+        rng.standard_normal(n),                      # dense continuous
+        np.where(rng.random(n) < 0.7, 0.0,
+                 rng.standard_normal(n)),            # zero-inflated (greedy path)
+        np.where(rng.random(n) < 0.1, np.nan,
+                 rng.standard_normal(n)),            # NaN-laced
+        rng.integers(0, 5, n).astype(np.float64),    # few uniques
+        np.full(n, 3.25),                            # constant
+        np.full(n, np.nan),                          # all missing
+        np.round(rng.standard_normal(n), 1),         # heavy ties
+    ]
+    return np.column_stack(cols)
+
+
+def _fit_forced(X, w, max_bins, force_parallel, monkeypatch):
+    monkeypatch.setattr(
+        B, "_PARALLEL_FIT_MIN_CELLS", 0 if force_parallel else 1 << 60)
+    return B.Binner(max_bins).fit(X, w)
+
+
+@pytest.mark.parametrize("max_bins", [2, 8, 16, 128])
+@pytest.mark.parametrize("weighted", [False, True])
+def test_parallel_fit_bit_identical(max_bins, weighted, monkeypatch):
+    for seed in range(5):
+        X = _pathological_matrix(seed)
+        w = None
+        if weighted:
+            w = np.random.default_rng(seed + 100).random(X.shape[0]) + 0.25
+            w[:: 7] = 0.0  # exercise the zero-weight drop
+        ser = _fit_forced(X, w, max_bins, False, monkeypatch)
+        par = _fit_forced(X, w, max_bins, True, monkeypatch)
+        assert len(ser.borders_) == len(par.borders_)
+        for a, b in zip(ser.borders_, par.borders_):
+            assert np.array_equal(a, b)
+        assert np.array_equal(ser.n_bins_, par.n_bins_)
+        for a, b in zip(ser.bin_centers_, par.bin_centers_):
+            assert np.array_equal(a, b, equal_nan=True)  # NaN bin center
+        assert np.array_equal(ser._borders_flat, par._borders_flat)
+        assert np.array_equal(ser._offsets, par._offsets)
+
+
+def test_parallel_fit_per_feature_budgets(monkeypatch):
+    # The cat-aware per-feature max_bins array must keep feature->budget
+    # alignment under the pool (order comes from ex.map, not thread finish).
+    X = _pathological_matrix(0)
+    budgets = np.array([4, 8, 16, 32, 64, 128, 6], dtype=np.int64)
+    ser = _fit_forced(X, None, budgets, False, monkeypatch)
+    par = _fit_forced(X, None, budgets, True, monkeypatch)
+    for a, b in zip(ser.borders_, par.borders_):
+        assert np.array_equal(a, b)
+    assert np.array_equal(ser.n_bins_, par.n_bins_)
+
+
+def test_parallel_fit_propagates_errors(monkeypatch):
+    # A failure inside a pooled column must surface, not vanish in a thread.
+    monkeypatch.setattr(B, "_PARALLEL_FIT_MIN_CELLS", 0)
+
+    def boom(col, max_bins, weights=None):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(B, "_feature_borders", boom)
+    with pytest.raises(RuntimeError, match="boom"):
+        B.Binner(16).fit(np.random.default_rng(0).standard_normal((64, 4)))


### PR DESCRIPTION
## What

`Binner.fit` farms wide-enough matrices (>= 200k cells) out to a `ThreadPoolExecutor` over columns, running the **verbatim** per-column border code. Small fits keep the serial loop (crossover measured, table in the code comment). Pool width follows numba's thread count, so `thread_count=1` and bagged-worker budget shares are honored automatically — fit already runs inside `_thread_limit`.

## Why it is bit-identical

Every column's borders are computed independently (the invariant `from_base_with_cross` already splices on): no cross-feature accumulation, row order and `np.add.at` order untouched, assembly (`n_bins_`, `bin_centers_`, `_build_flat_borders`) sequential in feature order. Only which OS thread runs a column changes. numpy's sort/partition/argsort release the GIL, which is where the speedup comes from.

## Gate (bit-identical protocol, per PRs #55/#56)

- `identity_snapshot.py` save at base / check on branch: **84/84 arrays exactly equal** (six configs cover the weighted path).
- Full suite: 833 passed, 1 skipped; golden panel green with **no** `golden_metrics.json` change.
- New `tests/test_binner_parallel_fit.py`: forced-parallel vs forced-serial fits `np.array_equal` across dense / zero-inflated / NaN-laced / few-unique / constant / all-NaN / heavy-tie columns, weighted (with zero-weight rows) and unweighted, `max_bins` 2-128, per-feature budget arrays, and error propagation out of the pool.
- No decision-tier benchmark needed: identity passing is the gate.

## Measured (200k x 30, 12 threads, 128 bins, best of 5)

| case | serial | parallel | speedup |
|---|---|---|---|
| dense | 96.0 ms | 22.3 ms | 4.3x |
| zero-inflated | 91.4 ms | 28.8 ms | 3.2x |
| dense, weighted | 664.8 ms | 119.8 ms | 5.5x |
| zero-inflated, weighted | 721.0 ms | 131.6 ms | 5.5x |
| dense 50k x 200 | 151.0 ms | 56.1 ms | 2.7x |

The weighted path gains most because its stable argsort / cumsum / interp all release the GIL. Honest framing: binning is 2-9% of a bagged fit, so this is a setup-time win that matters on single-estimator fits (the default mode) on wide or high-cardinality data, not a headline number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)