### PR TITLE
Fix quantile prediction intervals: replace the narrowing budget with per-row rearrangement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,53 @@
 All notable changes to ChimeraBoost are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+### Fixed
+- **`ChimeraBoostQuantileRegressor` returned prediction intervals 2x to 10x
+  wider than they should have been, and they got worse the longer you
+  trained.** The non-crossing guarantee was enforced during the fit by a global
+  "narrowing budget" charged at the worst-case leaf each round, so a single
+  aggressively narrowing leaf spent budget on behalf of every row. It ran out
+  within tens of rounds and froze the interval width from then on: on `cpu_act`
+  the width was identical at rounds 1000, 2000 and 3000, while coverage climbed
+  from 0.86 to 0.99 against a nominal 0.80 as the centre kept sharpening under
+  a band that could no longer follow.
+
+  Ordering is now imposed per row on the delivered predictions by monotone
+  rearrangement. That is exact for each row rather than a bound that has to
+  hold for every possible row at once, and it costs no accuracy — sorting a
+  crossing quantile curve never increases pinball loss at any level
+  (Chernozhukov, Fernández-Val & Galichon 2010). Predictions still cannot
+  cross, at every stage of `staged_predict`, and `crossing_rate` is still
+  exactly zero.
+
+  Measured on three Grinsztajn regression sets, 3 seeds: pinball loss improves
+  by 80%, 24% and 24%, and the band now tracks local spread instead of freezing.
+  Against 19 independent LightGBM quantile boosters the head moves from roughly
+  matching them to beating them at every width tested (pinball ratio 0.968 to
+  0.989 from 5 to 128 features), at 3.0x to 6.2x their fit speed.
+
+  One caveat worth knowing: the raw grid now errs slightly *narrow* rather than
+  very wide — a nominal 80% interval delivers about 72 to 76% coverage, because
+  leaf values are in-sample residual quantiles. Use `conformalize=True` when you
+  need the interval to carry a coverage guarantee; it lands within 2.7
+  percentage points of nominal. See `docs/quantiles.md`.
+
+### Removed
+- The `gap_` attribute on `MultiQuantileBoosting`, which reported the narrowing
+  budget's remaining margin. The budget no longer exists, and an attribute
+  whose documented guarantee is no longer true is worse than no attribute.
+  Nothing on `ChimeraBoostQuantileRegressor` exposed it.
+
+### Notes
+- Models pickled with 0.27.0 or earlier load and predict identically: their
+  stored leaf values already satisfied the old constraint, so rearranging them
+  changes nothing.
+- The scalar `MAE` and `Quantile` losses share these leaf kernels at `K = 1` and
+  are bit-identical across this change, confirmed by the identity snapshot
+  (81 of 89 arrays unchanged; the 8 that moved are the two multi-quantile
+  configurations in full).
+
 ## [0.27.0] - 2026-07-31
 ### Changed
 - **A pass of seven output-identical speedups: MAE and quantile fits about

--- a/benchmarks/LEAFTUNE_PLAN.md
+++ b/benchmarks/LEAFTUNE_PLAN.md
@@ -202,6 +202,156 @@ binary and the reciprocal rounds past the integer. The 19-level default grid
 (20), [0.25, 0.75] (4) and [0.01, 0.99] (100) are all correct. Fix is to round
 the reciprocal before `ceil`.
 
+## P14 — the fix, pre-registered 2026-07-31 (branch `fix-quantile-interval-width`)
+
+Written **before** the fix was measured; the base numbers below are from the
+shipped code, re-measured today with `benchmarks/probe_quantile_band.py --tag
+base` (which rebuilds P10-P13's dead harness) and they reproduce P12/P13.
+
+**Change.** Delete the training-time narrowing budget entirely and enforce
+non-crossing **per row at delivery** by monotone rearrangement — sort each
+predicted K-vector. Chernozhukov, Fernández-Val & Galichon (2010): rearranging a
+crossing quantile curve never increases pinball loss at any level, for any row.
+The guarantee moves from a worst-case bound over all leaves and rounds to an
+exact per-row operation, which is what P12 said it should be.
+
+Why this is safe here, verified in code rather than assumed:
+
+- Pinball gradients are per-channel independent (`losses.MultiQuantile.grad_hess`
+  reads only `F[:, k]` against `y`), so quantiles crossing *during training*
+  corrupt no learning signal. Only delivered predictions need ordering.
+- Training `F`/`Fv` are accumulated in place and never read back from a predict
+  path, so a delivery-time sort cannot feed back into the fit. **This is the
+  distinction that matters:** PR #48 recorded that sorting *leaf vectors during
+  training* diverged to pinball 2.9e7 against an oracle of 0.35. That failure was
+  a feedback loop — sorted values re-entered `F` and self-reinforced. Sorting
+  delivered output has no such path, and `F` must never be sorted in place.
+
+**Base measurements to beat** (K=3 grid, central interval 0.10-0.90, nominal
+coverage 0.80, 3 seeds, `results/quantile-band-base.md`):
+
+| dataset | head pinball | head coverage | head width | offset pinball | offset width |
+|---|--:|--:|--:|--:|--:|
+| Brazilian_houses | 0.02992 | 0.9976 | 0.65019 | 0.00452 | 0.02747 |
+| cpu_act | 0.74380 | 0.9821 | 12.38850 | 0.55148 | 4.74665 |
+| elevators | 0.00067 | 0.9494 | 0.00971 | 0.00048 | 0.00467 |
+
+Head loses to the rigid offset on 0 of 3 at K=3 and 0 of 3 at K=19. The freeze is
+visible directly: cpu_act width 12.912 at rounds 1000, 2000 and 3000 alike, with
+coverage climbing 0.861 → 0.987 as the centre sharpens under a fixed band.
+
+**Bars.** All five, or the change does not ship:
+
+1. **Coverage** without `conformalize` inside [0.75, 0.88] at nominal 0.80 on
+   3 of 3 (base: 0.949-0.998).
+2. **Pinball beats the shipped head** on 3 of 3.
+3. **Pinball beats or matches the rigid offset** on 3 of 3 — the ship/kill line,
+   and the comparison the shipped head fails 0 of 3. "Matches" means within 2%.
+4. **Crossing rate exactly 0.0** in every arm, every path, every staged stage.
+5. **The freeze is dead**: central-interval width at round 3000 differs from
+   round 50 by more than 1%, and coverage does not rise monotonically with
+   rounds.
+
+Plus the unchanged obligations: the bit-identity snapshot must show every array
+identical except the two `mq3` families (the shared scalar MAE/Quantile leaf
+kernels route through the same code at K=1, where the projection was the
+identity — so any scalar diff is a bug, not a consequence), and PR #48's own
+ledger in `QUANTILE_PLAN.md` must still pass (within 3% of per-level LightGBM,
+CQR worst coverage error ≤ 2 pp).
+
+**Kill clause.** If bar 3 fails, the approach is falsified and reverted; record
+the negative here. The decision suites do not score quantiles and this touches
+`MultiQuantileBoosting` only, so no `--decide` run is owed unless the identity
+snapshot moves a scalar array.
+
+### Result: the mechanism is confirmed and fixed, but bar 3 FAILS — not shipped
+
+Same probe, `--tag fix`, same seeds and splits (`results/quantile-band-fix.md`).
+The band is no longer frozen and every absolute measure improves by a lot. The
+head still does not beat the trivial baseline, so the kill clause fires.
+
+| bar | verdict | evidence |
+|---|---|---|
+| 1 coverage in [0.75, 0.88] | **FAIL** (1 of 3) | 0.758 / 0.719 / 0.725 — now *under*-covers |
+| 2 pinball beats the shipped head | **PASS** (3 of 3) | 80%, 24%, 24% better |
+| 3 pinball beats/matches the offset | **FAIL** (0 of 3) | −34.3% / −3.0% / −5.9% |
+| 4 crossing rate exactly 0 | **PASS** | every arm, every staged stage |
+| 5 freeze is dead | **PASS** | see below |
+
+K=3, nominal 0.80, 3 seeds:
+
+| dataset | pinball base → fix | offset | coverage base → fix | width base → fix |
+|---|--:|--:|--:|--:|
+| Brazilian_houses | 0.02992 → 0.00607 | 0.00452 | 0.998 → 0.758 | 0.650 → 0.049 |
+| cpu_act | 0.74380 → 0.56782 | 0.55148 | 0.982 → 0.719 | 12.389 → 4.894 |
+| elevators | 0.00067 → 0.00051 | 0.00048 | 0.949 → 0.725 | 0.0097 → 0.0044 |
+
+**The freeze is gone and its signature reversed.** cpu_act width now runs
+13.08 → 8.73 → 6.01 → 5.03 → 4.54 → 4.27 across rounds 50 → 3000, where the base
+was flat at 12.91 from round 1000 onward. Coverage now *falls* with training
+(0.815 → 0.705) instead of climbing away from nominal (0.861 → 0.987). P12's
+diagnosis is confirmed by construction: remove the worst-case-leaf charge and
+the width moves again.
+
+**Against the external reference the change is a clear win.** The PR #48 ledger
+(`benchmarks/quantile_head.py`, 3 seeds, `results/quantile-head.md`) improves
+from parity to a win at every width — pinball ratio against 19 independent
+LightGBM quantile boosters is 0.989 / 0.984 / 0.981 / 0.981 / 0.968 / 0.969 at 5
+to 128 features, so the head is now *better* than the per-level baseline it was
+only supposed to match, at 3.0x-6.2x their fit time, with crossing 0.0000
+against their 0.18-0.21.
+
+#### Why bar 3 still fails: the error flipped sign
+
+The band no longer freezes too wide; it now over-narrows. Leaf values are the
+**in-sample** residual quantiles of the rows in that leaf, which are
+optimistically tight, and with the budget gone nothing damps that. The freeze
+table shows coverage decaying monotonically with rounds on all three datasets
+and still falling at round 3000. Early stopping halts it at the *pinball*
+optimum, which on these datasets sits below nominal coverage — hence bar 1
+failing on the low side.
+
+That also trips the ledger's conformal bar: worst conformalized coverage error
+is **2.65 pp against a 2 pp target**. The sign is informative — CQR now has to
+*widen* rather than shrink, and the "outer factor at least the inner factor"
+monotonization pushes the middle intervals up, so the largest errors sit at the
+0.20-0.80 and 0.25-0.75 pairs rather than in the tails.
+
+So the head's remaining deficit is variance, not bias: it estimates a
+conditional band per leaf where the offset estimates one marginal band from the
+whole calibration fold, and on these three datasets that extra freedom does not
+pay for itself. Consistent with P7/P8, which found the rigid arm wins wherever
+the conditional spread is close to constant.
+
+#### Status: recorded, not shipped
+
+Branch `fix-quantile-interval-width`, committed and left unmerged. The kill
+clause as written says revert, and it is not overridden here — but note the
+asymmetry before acting on it: this branch is better than `main` on every
+measured axis (pinball on 3 of 3, coverage nearer nominal, LightGBM ratio,
+freeze), so reverting restores a strictly worse model. The bar it misses is
+"beat a one-line baseline", which `main` misses by 10x more.
+
+The live follow-up is a **new mechanism and needs its own pre-registration**:
+shrink each leaf's quantile step toward the pooled band, or fit leaf residual
+quantiles out-of-sample, so the band stops over-narrowing. Both address the
+in-sample bias directly rather than re-capping the width.
+
+Reusable facts from this pass:
+
+- `tree._project_pinball` read the projected pinball gradient out of a suffix
+  table by **binary-searching the row's PIT rank**, which is valid only while
+  every row of `F` is sorted. That precondition was supplied by the very budget
+  being removed. It is now an explicit per-channel scan, and
+  `test_projected_gradient_makes_no_ordering_assumption` pins it against the
+  dense definition on a deliberately crossing `F`. Any future change that
+  relaxes an ordering invariant should grep for readers of it first.
+- Bit-identity held exactly where predicted: 81 of 89 arrays unchanged, the 8
+  that moved being the two `mq3` families in full (`pred`, `n_trees`,
+  `valid_hist`, `imp` — the tree structures change, not just the output).
+  `mae`, `mae_w_sub`, `quantile` and `quantile_w` share the same leaf kernels at
+  K=1 and are untouched, which is what licenses skipping a `--decide` run.
+
 ## Where to go instead
 
 The two untested axes are **re-purposing, not tuning**, and neither is a search

--- a/benchmarks/LEAFTUNE_PLAN.md
+++ b/benchmarks/LEAFTUNE_PLAN.md
@@ -264,7 +264,7 @@ the negative here. The decision suites do not score quantiles and this touches
 `MultiQuantileBoosting` only, so no `--decide` run is owed unless the identity
 snapshot moves a scalar array.
 
-### Result: the mechanism is confirmed and fixed, but bar 3 FAILS — not shipped
+### Result: mechanism confirmed and fixed; bars 1 and 3 FAIL; shipped anyway (see Status)
 
 Same probe, `--tag fix`, same seeds and splits (`results/quantile-band-fix.md`).
 The band is no longer frozen and every absolute measure improves by a lot. The
@@ -323,14 +323,36 @@ whole calibration fold, and on these three datasets that extra freedom does not
 pay for itself. Consistent with P7/P8, which found the rigid arm wins wherever
 the conditional spread is close to constant.
 
-#### Status: recorded, not shipped
+#### Status: SHIPPED (Nathan, 2026-07-31) — bar 3 reclassified as a research target
 
-Branch `fix-quantile-interval-width`, committed and left unmerged. The kill
-clause as written says revert, and it is not overridden here — but note the
-asymmetry before acting on it: this branch is better than `main` on every
-measured axis (pinball on 3 of 3, coverage nearer nominal, LightGBM ratio,
-freeze), so reverting restores a strictly worse model. The bar it misses is
-"beat a one-line baseline", which `main` misses by 10x more.
+> "if we are winning we shouldn't kill it"
+
+The kill clause is deliberately overridden, and the reasoning is recorded here
+because overriding a pre-registered bar is exactly the move that needs an audit
+trail.
+
+Bar 3 asked the head to beat a rigid location shift. That is the right question
+for *"is a conditional quantile model worth building at all"* — the question
+P9-P13 were asking — but it is the wrong question for *"should this change
+replace what users currently have."* On the shipping question the change wins
+every comparison there is: against the shipped head (pinball better on 3 of 3,
+by 80% / 24% / 24%), against the external per-level reference (LightGBM, now
+beaten at all six widths where it previously only matched), and on the defect
+itself (the freeze is gone). The baseline it still loses to, `main` loses to by
+roughly 10x more, so honouring the kill clause would have restored a strictly
+worse model in the name of a bar neither version clears.
+
+The bar is therefore reclassified: **beating the rigid offset stays an open
+research target for the head, not a gate on individual improvements to it.**
+Bars 1 and 3 remain FAILED and are not to be quietly restated as passes.
+
+Shipped with the raw-grid under-coverage documented rather than hidden
+(`docs/quantiles.md`, CHANGELOG): a nominal 80% interval delivers about 72-76%,
+and `conformalize=True` is the supported route to a coverage guarantee. Note
+this is a *change in the direction* of the miscalibration, not its removal —
+users reading a raw interval as a guarantee were previously safe-but-useless and
+are now optimistic, which is the more dangerous failure and the reason it is
+called out in both places.
 
 The live follow-up is a **new mechanism and needs its own pre-registration**:
 shrink each leaf's quantile step toward the pooled band, or fit leaf residual

--- a/benchmarks/QUANTILE_PLAN.md
+++ b/benchmarks/QUANTILE_PLAN.md
@@ -70,31 +70,35 @@ skew was worse. `_ROTATE_PATTERN = (0, 0, 1)`.
 
 ## Why predictions cannot cross
 
-Init is the sorted global quantiles, every committed leaf vector is projected
-onto an admissible set, IEEE addition is monotone, and the packed predictor
-accumulates trees in identical order for every channel. So
-`diff(pred, axis=1) >= 0` holds exactly. Measured crossing rate: **0.0000**
-everywhere, against 0.18-0.21 for K independent LightGBM boosters.
+**Superseded 2026-07-31 — see `LEAFTUNE_PLAN.md` P12 and P14.** The mechanism
+described in this section shipped in 0.27.0 and has since been removed; the
+history is kept because two of its dead ends are still live traps.
 
-**The obvious construction does not work.** "Commit only non-decreasing
-increments" is sound but far too strong: a sum of non-decreasing vectors is
-non-decreasing, so the predicted interval could never be NARROWER than the
-pooled one, and the low-noise half of heteroscedastic data becomes
-inexpressible. Forcing it by sorting is worse still -- it reverses a narrowing
-update into a widening one, which is self-reinforcing. Measured: pinball
-2.9e7 against an oracle of 0.35, i.e. divergence.
+Today: every delivered row is sorted on the way out of the booster, so
+`diff(pred, axis=1) >= 0` holds exactly, at every `staged_predict` stage.
+Measured crossing rate **0.0000** everywhere, against 0.18-0.21 for K
+independent LightGBM boosters. Rearrangement is free in accuracy terms
+(Chernozhukov, Fernández-Val & Galichon 2010), and being per-row it is exact
+where any training-time construction has to be a bound over all rows at once.
 
-What works is a **narrowing budget**. `gap[k]` is a lower bound on
-`Q_k(x) - Q_{k-1}(x)` valid for ANY input row, not just training rows: a row's
-gap is the initial gap plus, per tree, the increment gap at whichever leaf it
-lands in, and each of those is at least the minimum over that tree's leaves.
-Each round may give away at most the currently guaranteed gap, and the
-realized minimum is subtracted afterwards. The admissible set
-`{v : v_k - v_{k-1} >= -b_k}` becomes plain monotonicity under
-`u_k = v_k + sum(b_1..b_k)`, so the projection is isotonic regression
-(pool-adjacent-violators, which averages violators -- a sort permutes them and
-can flip a contrast's sign). A floor at 1e-9 of the initial spread keeps the
-guaranteed margin far above float64 accumulation error.
+**Trap 1, still live.** "Commit only non-decreasing increments" is sound but far
+too strong: a sum of non-decreasing vectors is non-decreasing, so the predicted
+interval could never be NARROWER than the pooled one. Forcing it by sorting the
+leaf vector is worse still -- sorted values re-enter the accumulated scores and
+self-reinforce. Measured: pinball 2.9e7 against an oracle of 0.35, i.e.
+divergence. **This is why sorting is safe only at delivery**, where nothing
+feeds back into the fit.
+
+**Trap 2, the one that shipped.** The fix for trap 1 was a **narrowing budget**:
+`gap[k]` a lower bound on `Q_k(x) - Q_{k-1}(x)` valid for any input row, spent
+down each round by the realized minimum over all leaves, with the admissible set
+`{v : v_k - v_{k-1} >= -b_k}` projected by PAVA in shifted coordinates. Sound as
+a bound and ruinous in practice: charging at the worst-case leaf let one leaf
+spend on behalf of every row, so it saturated in tens of rounds and froze the
+interval width, leaving bands 2x to 10x too wide. Passing this section's own
+acceptance ledger while doing so is the cautionary part -- the ledger compared
+against per-level LightGBM and against nominal coverage, and never against a
+trivial fixed-width baseline, which would have caught it immediately.
 
 ## Conformalization
 
@@ -102,14 +106,14 @@ guaranteed margin far above float64 accumulation error.
 split, so it sees no training, no stopping decision and no model selection.
 
 The correction is a per-level **scale about the predicted median**, not the
-usual additive widening. An additive correction that shrinks an interval is a
-non-monotone offset vector, and the only way to apply one safely is out of the
-narrowing budget -- which the fit has already spent, so it projects away to
-nothing (measured: offsets of exactly 0). Scaling has no such problem, and
-shrinking is what is actually needed: a shrunk-fit quantile model is
-systematically over-dispersed, because every round's step is scaled by the
-learning rate so the grid never fully contracts. Measured raw coverage at
-nominal 0.70 was 0.844.
+usual additive widening. The scores it is applied to are already rearranged, so
+every deviation from the median is sign-correct and a non-negative factor cannot
+reorder anything; an additive correction that shrinks an interval is a
+non-monotone offset vector and has no such property. Scaling also moves in both
+directions, which matters more now than it did: the head used to be
+systematically over-dispersed (raw coverage 0.844 at nominal 0.70) and the
+factors shrank, whereas since the budget was removed the raw grid runs slightly
+narrow and they widen.
 
 Fails loudly when the fold cannot support the requested levels
 (`ceil((n+1)(1-alpha)) <= n` needs `n >= (1-alpha)/alpha`).
@@ -126,6 +130,24 @@ boosters sharing one Dataset, 300 rounds, depth 4, lr 0.1, n = 20 000,
 | fit wall clock | >= K/2 = 9.5x faster | 3.4x (5 features) rising to 7.8x (128) | **MISS** |
 | crossing rate, no predict-time patch | exactly 0 | 0.0000 at every width; LightGBM 0.18-0.21 | **PASS** |
 | CQR coverage at n=10k | within 2 points of nominal | worst 0.73 points | **PASS** |
+
+Re-measured 2026-07-31 after the budget was removed (same protocol, 3 seeds):
+
+| criterion | measured | verdict |
+|:--|:--|:--|
+| pinball vs K LightGBM boosters | ratio 0.989 (5 features) to 0.969 (128) — now a **win** at every width | **PASS** |
+| fit wall clock | 3.0x (5 features) rising to 6.2x (128) | **MISS**, unchanged in kind |
+| crossing rate | 0.0000 at every width | **PASS** |
+| CQR coverage at n=10k | worst 2.65 points, erring wide | **FAIL** |
+
+The crossing row's original wording ("no predict-time patch") no longer
+describes the implementation and is kept only as the historical target. What the
+guarantee is worth to a user is unchanged: zero crossings, at every stage.
+
+The CQR row is a real regression against its 2-point target and is recorded as
+such. Cause and follow-up in `LEAFTUNE_PLAN.md` P14 — the raw grid now runs
+narrow, so the factors widen, and the outer-at-least-inner monotonization pushes
+the middle intervals furthest.
 
 **On the speed miss.** The saving is concentrated in the split search, which
 runs once per round instead of K times, so the speedup grows with how wide the

--- a/benchmarks/probe_quantile_band.py
+++ b/benchmarks/probe_quantile_band.py
@@ -1,0 +1,264 @@
+"""Interval-width probe for the multi-quantile head (LEAFTUNE P10-P13 re-run).
+
+P12 found that the head's training-time narrowing budget saturates: the band
+freezes within tens of rounds and the delivered intervals end 2x to 10x wider
+than a calibrated band, so coverage runs far above nominal and pinball loses to
+the dumbest possible quantile model. That harness lived on a worktree that no
+longer exists; this rebuilds the parts that judge a fix.
+
+Three arms on the three P12 datasets:
+
+  head        ChimeraBoostQuantileRegressor, out of the box
+  head+CQR    the same with conformalize=True (the feature's own remedy)
+  offset      the rigid location shift: ONE squared-error fit plus the marginal
+              quantiles of held-out residuals. Identical interval width for
+              every row -- no conditional spread at all. This is the baseline
+              the shipped head lost to on 3 of 3, and beating it is the bar.
+
+Two questions, two sections:
+
+  1. Quality  -- mean pinball over the grid, coverage and width of the central
+                 interval, crossing rate. Lower pinball wins; coverage is read
+                 next to width, since a wide enough band covers everything.
+  2. Freeze   -- interval width by boosting round out to 3000. A width that is
+                 identical at round 50 and round 3000 is the saturation
+                 signature; a healthy fit keeps adapting.
+
+Run alone -- one benchmark at a time.
+    python benchmarks/probe_quantile_band.py --tag base
+    python benchmarks/probe_quantile_band.py --tag fix
+Writes: benchmarks/results/quantile-band-<tag>.md
+"""
+
+import argparse
+import os
+import sys
+import time
+
+import numpy as np
+from sklearn.model_selection import train_test_split
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(_HERE))
+sys.path.insert(0, _HERE)
+
+import chimeraboost                                            # noqa: E402
+from chimeraboost import (ChimeraBoostQuantileRegressor,       # noqa: E402
+                          ChimeraBoostRegressor)
+from chimeraboost import quantile_metrics as qm                # noqa: E402
+from chimeraboost.warmup import warmup                         # noqa: E402
+import run_benchmarks as rb                                    # noqa: E402
+
+rb._add_grinsztajn_datasets()
+
+DATASETS = [
+    "gr:reg_cat/Brazilian_houses",
+    "gr:reg_num/cpu_act",
+    "gr:reg_num/elevators",
+]
+SEEDS = (0, 1, 2)
+# K=3 puts the 0.80 central interval on the grid, which is the interval every
+# P10-P13 coverage number is quoted against. K=19 is the shipped default grid.
+GRIDS = {"K3": np.array([0.1, 0.5, 0.9]),
+         "K19": np.round(np.arange(0.05, 0.9501, 0.05), 10)}
+FREEZE_ROUNDS = (50, 100, 300, 1000, 2000, 3000)
+
+
+def _central(taus):
+    """Index pair of the widest symmetric interval on the grid, and its
+    nominal level."""
+    lo, hi = 0, taus.size - 1
+    return lo, hi, float(taus[hi] - taus[lo])
+
+
+def _metrics(y, Q, taus):
+    lo, hi, nominal = _central(taus)
+    inside = (y >= Q[:, lo]) & (y <= Q[:, hi])
+    return {
+        "pinball": qm.crps(y, Q, taus),
+        "coverage": float(inside.mean()),
+        "width": float(np.mean(Q[:, hi] - Q[:, lo])),
+        "crossing": qm.crossing_rate(Q),
+        "nominal": nominal,
+    }
+
+
+def _rigid_offset(Xtr, ytr, Xte, cat, taus, seed):
+    """One squared-error fit; the band is the marginal quantiles of residuals
+    measured on a held-out fold, added to every row's point prediction.
+
+    Held-out rather than in-sample: in-sample residuals are shrunk by the fit
+    and understate the spread, which is the fix P10 gave this arm before it
+    started winning."""
+    Xf, Xc, yf, yc = train_test_split(Xtr, ytr, test_size=0.2,
+                                      random_state=seed)
+    m = ChimeraBoostRegressor(random_state=seed).fit(Xf, yf, cat_features=cat)
+    resid = np.asarray(yc, dtype=np.float64) - m.predict(Xc)
+    return m.predict(Xte)[:, None] + np.quantile(resid, taus)[None, :]
+
+
+def run_quality(key, seed, taus):
+    """One (dataset, seed): all three arms on an identical split."""
+    X, y, cat, _ = rb.DATASETS[key](1, np.random.default_rng(0))
+    Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.25,
+                                          random_state=seed)
+    yte = np.asarray(yte, dtype=np.float64)
+    out = {}
+
+    for name, kw in (("head", {}), ("head+CQR", {"conformalize": True})):
+        t0 = time.perf_counter()
+        m = ChimeraBoostQuantileRegressor(quantiles=taus, random_state=seed)
+        m.set_params(**kw).fit(Xtr, ytr, cat_features=cat)
+        secs = time.perf_counter() - t0
+        out[name] = {**_metrics(yte, m.predict(Xte), taus), "secs": secs,
+                     "rounds": len(m.model_.trees_)}
+
+    t0 = time.perf_counter()
+    Q = _rigid_offset(Xtr, ytr, Xte, cat, taus, seed)
+    out["offset"] = {**_metrics(yte, Q, taus),
+                     "secs": time.perf_counter() - t0, "rounds": np.nan}
+    return out
+
+
+def run_freeze(key, taus, seed=0):
+    """Central-interval width by round, from ONE fit read through
+    staged_predict. Early stopping off so the round axis is the real one."""
+    X, y, cat, _ = rb.DATASETS[key](1, np.random.default_rng(0))
+    Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.25,
+                                          random_state=seed)
+    yte = np.asarray(yte, dtype=np.float64)
+    m = ChimeraBoostQuantileRegressor(
+        quantiles=taus, n_estimators=max(FREEZE_ROUNDS), random_state=seed,
+        early_stopping=False).fit(Xtr, ytr, cat_features=cat)
+    lo, hi, _ = _central(taus)
+    wanted = set(FREEZE_ROUNDS)
+    widths, covs = {}, {}
+    for i, Q in enumerate(m.staged_predict(Xte), start=1):
+        if i in wanted:
+            widths[i] = float(np.mean(Q[:, hi] - Q[:, lo]))
+            covs[i] = float(np.mean((yte >= Q[:, lo]) & (yte <= Q[:, hi])))
+    return widths, covs
+
+
+def _fmt_quality(rows, taus, grid_name, lines):
+    lo, hi, nominal = _central(taus)
+    hdr = (f"{'dataset':>26s}{'arm':>10s}{'pinball':>11s}{'coverage':>10s}"
+           f"{'width':>12s}{'crossing':>10s}{'secs':>8s}")
+    print(f"\n{'=' * len(hdr)}")
+    print(f"QUALITY, grid {grid_name} ({taus.size} levels), central interval "
+          f"{taus[lo]:.2f}-{taus[hi]:.2f}, nominal {nominal:.2f}")
+    print("=" * len(hdr))
+    print(hdr)
+    print("-" * len(hdr))
+    lines += [f"## Quality, grid {grid_name}", "",
+              f"Central interval {taus[lo]:.2f}-{taus[hi]:.2f}, nominal "
+              f"coverage {nominal:.2f}. `pinball` is the mean over the grid "
+              f"(lower is better), averaged over {len(SEEDS)} seeds.", "",
+              "| dataset | arm | pinball | coverage | width | crossing | "
+              "secs |", "|:--|:--|--:|--:|--:|--:|--:|"]
+    for key in DATASETS:
+        for arm in ("head", "head+CQR", "offset"):
+            r = rows[key][arm]
+            short = key.split("/")[-1]
+            print(f"{short:>26s}{arm:>10s}{r['pinball']:11.5f}"
+                  f"{r['coverage']:10.4f}{r['width']:12.5f}"
+                  f"{r['crossing']:10.4f}{r['secs']:8.2f}")
+            lines.append(f"| {short} | {arm} | {r['pinball']:.5f} | "
+                         f"{r['coverage']:.4f} | {r['width']:.5f} | "
+                         f"{r['crossing']:.4f} | {r['secs']:.2f} |")
+    lines.append("")
+
+    # Head vs the trivial baseline: the bar the shipped version failed 0 of 3.
+    print(f"\n{'head vs offset (pinball, + means the head is better)':>60s}")
+    lines += ["### Head against the rigid offset", "",
+              "Relative pinball, positive means the head wins. The shipped "
+              "head lost on 3 of 3.", "",
+              "| dataset | head vs offset | head+CQR vs offset |",
+              "|:--|--:|--:|"]
+    wins = 0
+    for key in DATASETS:
+        o = rows[key]["offset"]["pinball"]
+        a = (o - rows[key]["head"]["pinball"]) / o * 100
+        b = (o - rows[key]["head+CQR"]["pinball"]) / o * 100
+        wins += int(max(a, b) > 0)
+        print(f"{key.split('/')[-1]:>26s}{a:+11.2f}%{b:+11.2f}%")
+        lines.append(f"| {key.split('/')[-1]} | {a:+.2f}% | {b:+.2f}% |")
+    print(f"\nhead beats the offset on {wins} of {len(DATASETS)} datasets")
+    lines += ["", f"Head (best of plain / CQR) beats the offset on **{wins} of "
+                  f"{len(DATASETS)}** datasets.", ""]
+    return wins
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--tag", default="run", help="label for the output file")
+    ap.add_argument("--skip-freeze", action="store_true")
+    ap.add_argument("--grids", default="K3,K19")
+    args = ap.parse_args()
+
+    print(f"chimeraboost: {chimeraboost.__file__}")
+    print("warming JIT...", flush=True)
+    warmup()
+
+    lines = [f"# Quantile interval band probe ({args.tag})", "",
+             f"Datasets {', '.join(d.split('/')[-1] for d in DATASETS)}; "
+             f"seeds {list(SEEDS)}; arms head / head+CQR / rigid offset.", ""]
+    verdict = {}
+
+    for grid_name in args.grids.split(","):
+        taus = GRIDS[grid_name]
+        rows = {}
+        for key in DATASETS:
+            per_seed = [run_quality(key, s, taus) for s in SEEDS]
+            rows[key] = {
+                arm: {k: float(np.mean([p[arm][k] for p in per_seed]))
+                      for k in per_seed[0][arm]}
+                for arm in per_seed[0]}
+            print(f"  done {key} [{grid_name}]", flush=True)
+        verdict[grid_name] = _fmt_quality(rows, taus, grid_name, lines)
+
+    if not args.skip_freeze:
+        taus = GRIDS["K3"]
+        hdr = f"{'dataset':>26s}" + "".join(f"{r:>10d}" for r in FREEZE_ROUNDS)
+        print(f"\n{'=' * len(hdr)}")
+        print("FREEZE CHECK: central-interval width by round (K3, no early "
+              "stopping)")
+        print("=" * len(hdr))
+        print(hdr)
+        print("-" * len(hdr))
+        lines += ["## Freeze check", "",
+                  "Central-interval width by boosting round, early stopping "
+                  "off. Identical widths across the row are the saturation "
+                  "signature; `ratio` is the last round over round 50.", "",
+                  "| dataset | " + " | ".join(str(r) for r in FREEZE_ROUNDS)
+                  + " | ratio |",
+                  "|:--|" + "--:|" * (len(FREEZE_ROUNDS) + 1)]
+        for key in DATASETS:
+            w, c = run_freeze(key, taus)
+            ratio = w[FREEZE_ROUNDS[-1]] / w[FREEZE_ROUNDS[0]]
+            print(f"{key.split('/')[-1]:>26s}"
+                  + "".join(f"{w[r]:10.5f}" for r in FREEZE_ROUNDS)
+                  + f"   ratio {ratio:.4f}")
+            print(f"{'  coverage':>26s}"
+                  + "".join(f"{c[r]:10.4f}" for r in FREEZE_ROUNDS))
+            lines.append(f"| {key.split('/')[-1]} | "
+                         + " | ".join(f"{w[r]:.5f}" for r in FREEZE_ROUNDS)
+                         + f" | {ratio:.4f} |")
+            lines.append(f"| {key.split('/')[-1]} coverage | "
+                         + " | ".join(f"{c[r]:.4f}" for r in FREEZE_ROUNDS)
+                         + " | |")
+        lines.append("")
+
+    for grid_name, wins in verdict.items():
+        print(f"\nVERDICT {grid_name}: head beats the rigid offset on "
+              f"{wins} of {len(DATASETS)}")
+
+    out = os.path.join(_HERE, "results", f"quantile-band-{args.tag}.md")
+    os.makedirs(os.path.dirname(out), exist_ok=True)
+    with open(out, "w", encoding="utf-8") as fh:
+        fh.write("\n".join(lines) + "\n")
+    print(f"\nwrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/chimeraboost/booster.py
+++ b/chimeraboost/booster.py
@@ -767,24 +767,22 @@ class GradientBoosting(_BaseBooster):
         `losses._weighted_quantile`, `_leaf_row_index` groups rows in the
         same ascending order the argsort did (all three pinned by
         tests/test_quantile_head.py and the scalar oracle in
-        tests/test_bitident_refactors.py), and at K=1 the non-crossing
-        projection is the identity. Custom adjusts-leaves losses keep the
-        generic path below."""
+        tests/test_bitident_refactors.py). Custom adjusts-leaves losses keep
+        the generic path below."""
         n_leaves = tree.values.shape[0]
         if type(self.loss_) in (MAE, Quantile):
             alpha = 0.5 if type(self.loss_) is MAE else self.loss_.alpha
             taus = np.array([alpha])
-            cb = np.zeros(1)
             F2 = F[:, None]        # (n, 1) view of contiguous F: C-contiguous
             small = leaf.shape[0] <= _SMALL_N
             if sample_weight is None:
                 kern = (_leaf_quantiles_vec_serial if small
                         else _leaf_quantiles_vec)
-                vals = kern(leaf, y, F2, taus, cb, n_leaves, self.lr_)
+                vals = kern(leaf, y, F2, taus, n_leaves, self.lr_)
             else:
                 kern = (_leaf_quantiles_vec_w_serial if small
                         else _leaf_quantiles_vec_w)
-                vals = kern(leaf, y, F2, sample_weight, taus, cb, n_leaves,
+                vals = kern(leaf, y, F2, sample_weight, taus, n_leaves,
                             self.lr_)
             tree.values = vals[:, 0]
             return
@@ -1241,13 +1239,34 @@ class MultiQuantileBoosting(_BaseBooster):
       residuals (`tree._leaf_quantiles_vec`), not a Newton step -- the vector
       form of the override the scalar MAE/Quantile path already applies.
 
-    The starting vector is the sorted global quantiles and every committed
-    leaf vector is projected onto the non-crossing set before it is added, so
-    every partial sum is monotone in tau: predictions cannot cross, and there
-    is no predict-time repair anywhere in this class. The projection is NOT a
-    sort -- see `tree._project_leaf_row` for why sorting both diverges and
-    makes narrow intervals inexpressible, and `_fit_impl` for the narrowing
-    budget that keeps the guarantee valid for rows the fit never saw.
+    Leaf channels are independent steps and nothing constrains them against one
+    another during the fit. Ordering is imposed on DELIVERED predictions, per
+    row, by monotone rearrangement: `_predict_raw_impl` and
+    `staged_predict_raw` sort each row's K-vector before returning it, so
+    predictions cannot cross at any stage. Rearrangement is free of charge in
+    accuracy terms -- Chernozhukov, Fernandez-Val & Galichon (2010) show that
+    sorting a crossing quantile curve never increases pinball loss at any
+    level, for any row -- and it is exact per row rather than a bound that has
+    to hold for every row at once.
+
+    Two rules this class depends on, both learned the expensive way:
+
+    * **Never sort ``F`` in place, or anything that feeds back into it.** An
+      earlier design sorted each leaf vector as it was committed. Sorted values
+      then re-entered the accumulated scores and self-reinforced, and the fit
+      diverged to a measured pinball of 2.9e7 against an oracle of 0.35.
+      Sorting delivered output has no such path back into training.
+    * Nothing may assume a row of ``F`` is ordered. The pinball gradient is
+      per-channel independent (`losses.MultiQuantile.grad_hess` compares only
+      ``F[:, k]`` against ``y``), so crossing scores cost the fit nothing, but
+      code that reads a row as if it were sorted is silently wrong -- see the
+      scan in `tree._project_pinball`, which used to binary-search a PIT rank.
+
+    The predecessor to all this was a training-time "narrowing budget" charged
+    at the worst-case leaf each round. It was a valid bound and a bad one: one
+    aggressively-narrowing leaf spent budget on behalf of every row, so it
+    saturated within tens of rounds and froze the interval width, leaving bands
+    2x to 10x wider than calibrated (benchmarks/LEAFTUNE_PLAN.md, P12).
 
     Known limitation, by construction: within one round, gradient signal
     orthogonal to the chosen direction cannot drive a split. The exact leaf
@@ -1332,30 +1351,10 @@ class MultiQuantileBoosting(_BaseBooster):
         if yv is not None:
             Fv = np.tile(self.init_, (yv.shape[0], 1))
 
-        # --- narrowing budget -------------------------------------------
-        # `gap[k]` is a lower bound on Q_k(x) - Q_{k-1}(x) that holds for ANY
-        # input row, not just training rows: a row's gap is the initial gap
-        # plus, for each tree, the increment gap at whichever leaf it lands
-        # in, and each of those is at least the minimum over that tree's
-        # leaves. So bounding every leaf's increment gap below by -budget and
-        # then subtracting the round's realized minimum keeps the bound valid
-        # for rows the fit never saw.
-        #
-        # The floor keeps the bound comfortably above float64 accumulation
-        # error: intervals may narrow to a billionth of the global spread,
-        # which is unlimited in practice, while the guaranteed margin stays
-        # ~7 orders of magnitude above the rounding noise of summing a few
-        # hundred trees.
-        gap = np.diff(self.init_)                   # (K-1,), >= 0
-        floor = 1e-9 * max(float(self.init_[-1] - self.init_[0]), 1e-300)
-        cb = np.zeros(K)                            # cumulative budget
-
-        # Scratch reused every round: the projected gradient, the suffix-sum
-        # table `_project_pinball` indexes by PIT rank (one slot past the end
-        # so a rank of K reads zero), and a row-weight vector that is all ones
-        # when unweighted (exactly 1.0, so that path stays unchanged).
+        # Scratch reused every round: the projected gradient, and a row-weight
+        # vector that is all ones when unweighted (exactly 1.0, so that path
+        # stays unchanged).
         g_buf = np.empty(n_samples)
-        csuffix = np.zeros(K + 1)
         w_row = np.ones(n_samples) if w is None else w
         # Only two arms ever need the (n, K) gradient itself: "gram" measures
         # its covariance, and the exact split search scatters all K channels.
@@ -1388,8 +1387,7 @@ class MultiQuantileBoosting(_BaseBooster):
             if grad is not None and self.split_projection == "gram":
                 g_s = grad @ direction
             else:
-                csuffix[:K] = np.cumsum(direction[::-1])[::-1]
-                _project_pinball(y, F, csuffix, float(direction @ taus),
+                _project_pinball(y, F, direction, float(direction @ taus),
                                  w_row, g_buf)
                 g_s = g_buf
             # Unit-norm direction + unit hessian => projected curvature is
@@ -1439,25 +1437,19 @@ class MultiQuantileBoosting(_BaseBooster):
                 break
 
             # Replace the projection's scalar leaf values with the exact
-            # per-tau residual quantiles on the shared partition, sorted.
+            # per-tau residual quantiles on the shared partition. Each channel
+            # is its own quantile of the same residuals; they are not
+            # constrained against one another, which is what lets a leaf
+            # narrow its interval as far as its rows warrant.
             n_lv = tree.values.shape[0]
-            # Budget this round: the gap each channel can give away and still
-            # leave every possible row ordered. cb is its running sum, which
-            # is what turns the admissible set into plain monotonicity.
-            np.cumsum(np.maximum(gap - floor, 0.0), out=cb[1:])
             if rw is None:
                 kern = (_leaf_quantiles_vec_serial if small
                         else _leaf_quantiles_vec)
-                tree.values = kern(leaf, y, F, taus, cb, n_lv, self.lr_)
+                tree.values = kern(leaf, y, F, taus, n_lv, self.lr_)
             else:
                 kern = (_leaf_quantiles_vec_w_serial if small
                         else _leaf_quantiles_vec_w)
-                tree.values = kern(leaf, y, F, rw, taus, cb, n_lv, self.lr_)
-            # Spend what this round actually took. The min runs over ALL
-            # leaves, empty ones included -- a row the fit never saw can land
-            # in a leaf no training row reached, and its increment there is
-            # zero, which the min correctly treats as "no narrowing".
-            gap += np.diff(tree.values, axis=1).min(axis=0)
+                tree.values = kern(leaf, y, F, rw, taus, n_lv, self.lr_)
 
             _add_leaf_values(F, tree.values, leaf)
             self.trees_.append(tree)
@@ -1470,19 +1462,22 @@ class MultiQuantileBoosting(_BaseBooster):
             if Fv is not None and stopper.patience:
                 self.trees_ = self.trees_[: stopper.best_iter + 1]
 
-        # Early stopping can discard trailing trees, and every discarded tree
-        # only ever SPENT budget, so recomputing the bound over the retained
-        # prefix is both correct and never looser than the running value.
-        self.gap_ = np.diff(self.init_) + (
-            sum(np.diff(t.values, axis=1).min(axis=0) for t in self.trees_)
-            if self.trees_ else 0.0)
         self.fit_time_ = time.time() - t0
         self.best_iteration_ = len(self.trees_)
         return self
 
+    def _val_score(self, yv, Fv, wv):
+        """Score the eval set on REARRANGED scores, which is what a user
+        receives. Sorting can only lower the pinball loss, so stopping on the
+        raw accumulator would pick the best round for a prediction this class
+        never returns. ``np.sort`` copies -- ``Fv`` itself must stay untouched,
+        since the fit keeps adding to it."""
+        return super()._val_score(yv, np.sort(Fv, axis=1), wv)
+
     def _predict_raw_impl(self, X, cat_ctx=None):
         """Return the (n_samples, n_quantiles) matrix of quantile estimates,
-        non-decreasing along axis 1 by construction."""
+        each row sorted (see the class docstring: monotone rearrangement is
+        where the non-crossing guarantee is enforced)."""
         X = as_model_array(X, bool(self.prep_.cat_features_))
         Xb = self.prep_.transform(X, cat_ctx)       # row-major
         if not self.trees_:
@@ -1493,17 +1488,24 @@ class MultiQuantileBoosting(_BaseBooster):
         kernel = (_predict_forest_vec_rm_serial
                   if Xb.shape[0] <= _SERIAL_PREDICT_N
                   else _predict_forest_vec_rm)
-        return kernel(Xb, feats, thrs, depths, vals, voff, K, self.init_)
+        return np.sort(
+            kernel(Xb, feats, thrs, depths, vals, voff, K, self.init_), axis=1)
 
     def staged_predict_raw(self, X):
         """Yield the (n, K) quantile matrix after each successive tree.
 
         Trees are accumulated in the same order as `_predict_forest_vec_rm`,
-        so the final stage equals ``predict_raw`` and every intermediate stage
-        is itself non-crossing."""
+        so the final stage equals ``predict_raw``. Each stage is rearranged on
+        the way out and every one of them is non-crossing.
+
+        ``np.sort`` returns a copy, which is load-bearing twice over: it is the
+        per-stage copy the caller needs, and it keeps the running ``F`` in raw
+        accumulated form. Sorting ``F`` in place would feed rearranged scores
+        back into the next stage and reproduce the divergence recorded in the
+        class docstring."""
         X = as_model_array(X, bool(self.prep_.cat_features_))
         Xb = np.ascontiguousarray(self.prep_.transform(X).T)   # feature-major
         F = np.tile(self.init_, (Xb.shape[1], 1))
         for tree in self.trees_:
             F += tree.values[tree.apply(Xb)]
-            yield F.copy()
+            yield np.sort(F, axis=1)

--- a/chimeraboost/losses.py
+++ b/chimeraboost/losses.py
@@ -387,9 +387,10 @@ class MultiQuantile(_UnitHessian):
     Raw scores are an (n, K) matrix, column k holding the estimate of the
     `taus[k]` conditional quantile. Nothing here couples the channels -- each
     column is exactly the scalar `Quantile` loss at its own alpha, and a
-    one-element grid reproduces it term for term. The coupling lives in the
-    booster: one shared tree structure per round, and a leaf vector that is
-    sorted before it is committed.
+    one-element grid reproduces it term for term. Columns of ``F`` may
+    therefore cross during a fit and none of the maths below cares; the
+    coupling lives in the booster, which shares one tree structure per round
+    and rearranges each row before returning it.
 
     `taus` must be ascending, unique and strictly inside (0, 1); the estimator
     validates that before constructing this.
@@ -408,8 +409,8 @@ class MultiQuantile(_UnitHessian):
         q = np.array([_weighted_quantile(y, sample_weight, a)
                       for a in self.taus])
         # Quantiles of one sample are already monotone in alpha, so this sort
-        # is a no-op. It is here so the non-crossing guarantee rests on an
-        # enforced invariant rather than on that argument staying true.
+        # is a no-op. Kept because a starting vector that is ordered costs
+        # nothing and makes the zero-tree prediction trivially well formed.
         q.sort()
         return q
 

--- a/chimeraboost/quantile_api.py
+++ b/chimeraboost/quantile_api.py
@@ -105,16 +105,14 @@ def _cqr_scales(Q, y, taus, mi, mw):
     coverage on exchangeable data. Prediction then returns
     ``c + s * (q - c)``.
 
-    Why scaling rather than the usual additive widening. An additive
-    correction that SHRINKS an interval is a non-monotone offset vector, and
-    the only way to apply one safely is out of the fit's narrowing budget --
-    which the fit has already spent. Scaling about the median has no such
-    problem: multiplying a monotone, sign-correct deviation by a non-negative
-    factor cannot reorder anything, for any row, spent budget or not. Since a
-    shrunk-fit quantile model is systematically OVER-dispersed -- every round's
-    step is shrunk by the learning rate, so the grid never fully contracts --
-    shrinking is the correction that is actually needed, and the additive form
-    cannot deliver it.
+    Why scaling rather than the usual additive widening. The scores this is
+    applied to are already rearranged, so every deviation from the median is
+    sign-correct and ordered outward; multiplying it by a non-negative factor
+    cannot reorder anything, for any row. An additive correction has no such
+    property -- one that SHRINKS an interval is a non-monotone offset vector
+    and can reorder the grid on its own. Scaling also happens to be the
+    correction with the right degree of freedom, since a shrunk fit can be
+    over- or under-dispersed and a factor moves in both directions.
 
     Two constraints are enforced:
 
@@ -192,8 +190,11 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
     holding one entry per level in ``quantiles``. Against fitting one quantile
     regressor per level this is roughly K times less split-search work, and
     the predictions cannot cross: the 30% quantile is never returned above the
-    70%. The guarantee is structural rather than repaired afterwards, so it
-    holds at every intermediate stage of ``staged_predict`` too.
+    70%. Ordering is enforced per row by monotone rearrangement of the
+    delivered scores, which is exact for every row and holds at every
+    intermediate stage of ``staged_predict`` too. Rearrangement cannot cost
+    accuracy -- sorting a crossing quantile curve never increases pinball loss
+    at any level (Chernozhukov, Fernandez-Val & Galichon 2010).
 
     Deliberately not a ``RegressorMixin``: ``predict`` returns a matrix, so the
     inherited ``score`` (which assumes one number per row) would be wrong.

--- a/chimeraboost/quantile_metrics.py
+++ b/chimeraboost/quantile_metrics.py
@@ -92,9 +92,9 @@ def interval_coverage(y, Q, taus, sample_weight=None):
 def crossing_rate(Q):
     """Fraction of adjacent quantile pairs that come out in the wrong order.
 
-    Zero by construction for `ChimeraBoostQuantileRegressor` -- that is the
-    point of the vector leaf, and this function exists to prove it rather than
-    to fix anything. Independently fitted per-level models are not zero."""
+    Zero for `ChimeraBoostQuantileRegressor`, whose delivered rows are sorted;
+    this function exists to prove that rather than to fix anything.
+    Independently fitted per-level models are not zero."""
     Q = np.asarray(Q, dtype=np.float64)
     if Q.shape[1] < 2:
         return 0.0

--- a/chimeraboost/tree.py
+++ b/chimeraboost/tree.py
@@ -918,25 +918,32 @@ def _leaf_values_vec(leaf, grad, hess, coupling, n_leaves, l2, lr):
 # The quantile head's leaf value is not a Newton step but the exact empirical
 # quantile of the leaf's residuals, one per tau -- the same override the
 # scalar MAE/Quantile path applies in `booster._correct_leaves`, widened to K
-# channels and with the committed vector projected onto the admissible set so
-# predictions can never cross (see `_project_leaf_row`).
+# channels. The channels are not constrained against one another here; ordering
+# is imposed per row on delivered predictions (`booster.MultiQuantileBoosting`).
 # ---------------------------------------------------------------------------
 
 
 @njit(cache=True, parallel=True)
-def _project_pinball(y, F, csuffix, cdot, w, out):
+def _project_pinball(y, F, c, cdot, w, out):
     """Projected pinball gradient ``(grad @ c)`` without ever forming grad.
 
-    Row i's gradient is ``1{y_i < F_ik} - tau_k``, and F_i is non-decreasing,
-    so the set of channels the target falls below is a SUFFIX ``{r_i ... K-1}``
-    where r_i is the row's PIT rank. The projection onto c is then
+    Row i's channel-k gradient is ``1{y_i < F_ik} - tau_k``, so the projection
+    onto the direction ``c`` is
 
-        g_i = csuffix[r_i] - dot(c, taus)
+        g_i = sum over {k : F_ik > y_i} of c_k, minus dot(c, taus)
 
-    with ``csuffix[r] = sum(c[r:])`` precomputed once. One binary search per
-    row instead of a K-element dot product, and no (n, K) temporary: this is
-    the whole reason a K-level head can cost about what a 1-level one costs
-    per round outside the leaf refit.
+    which is one accumulating pass over the row instead of a K-element dot
+    product against a materialized (n, K) gradient. Not building that matrix is
+    the whole reason a K-level head can cost about what a 1-level one costs per
+    round outside the leaf refit.
+
+    An earlier version read the sum straight out of a precomputed suffix table
+    by binary-searching the row's PIT rank, which is valid only while ``F_i`` is
+    non-decreasing. Leaf vectors are no longer constrained against one another
+    (ordering is imposed per row on delivered predictions instead), so a row's
+    channels may cross during training and ``{k : F_ik > y_i}`` need not be a
+    suffix. The scan below makes no ordering assumption at all; it costs K
+    comparisons rather than log K over the same cache lines.
 
     ``w`` is a per-row weight array (ones when unweighted -- multiplying by
     exactly 1.0 is bit-exact, so the unweighted path is unchanged).
@@ -944,15 +951,11 @@ def _project_pinball(y, F, csuffix, cdot, w, out):
     n, K = F.shape
     for i in prange(n):
         yi = y[i]
-        lo = 0
-        hi = K
-        while lo < hi:                 # first k with F[i, k] > y_i
-            mid = (lo + hi) >> 1
-            if F[i, mid] > yi:
-                hi = mid
-            else:
-                lo = mid + 1
-        out[i] = (csuffix[lo] - cdot) * w[i]
+        s = 0.0
+        for k in range(K):
+            if F[i, k] > yi:
+                s += c[k]
+        out[i] = (s - cdot) * w[i]
 
 
 @njit(cache=True, parallel=True)
@@ -1088,55 +1091,6 @@ def _weighted_quantile_slice(buf, wbuf, lo, hi, alpha, wlo):
 
 
 @njit(cache=True)
-def _project_leaf_row(values, l, K, cb):
-    """Project one leaf's K-vector onto the set of increments that cannot make
-    any prediction cross, in place. This is what makes the non-crossing
-    guarantee structural -- there is no predict-time repair anywhere.
-
-    The naive rule ("commit only non-decreasing increments") is sound but far
-    too strong: a sum of non-decreasing vectors is non-decreasing, so the
-    predicted interval could then never be NARROWER than the global one, and
-    the low-noise half of heteroscedastic data becomes inexpressible. Worse,
-    forcing it by sorting can reverse a narrowing update into a widening one,
-    which is self-reinforcing and diverges.
-
-    So instead each channel carries a narrowing budget ``b_k`` -- the gap the
-    model can still give away at channel k and stay ordered for EVERY possible
-    input row (see `booster.MultiQuantileBoosting` for how the budget is
-    maintained). The admissible set is ``{v : v_k - v_{k-1} >= -b_k}``, and
-    the substitution ``u_k = v_k + sum(b_1..b_k)`` turns it into plain
-    monotonicity, so the projection is ordinary isotonic regression on u.
-    ``cb`` is that cumulative budget, ``cb[0] = 0``.
-
-    Pool-adjacent-violators, not a sort: PAVA is the closest admissible vector
-    in least squares and averages violators, where a sort permutes them and
-    can invert the sign of a contrast. With ``cb == 0`` this reduces exactly
-    to enforcing non-decreasing increments.
-    """
-    bval = np.empty(K)
-    bcnt = np.empty(K, dtype=np.int64)
-    for k in range(K):
-        values[l, k] += cb[k]
-    pos = 0
-    for k in range(K):
-        val = values[l, k]
-        cnt = 1
-        while pos > 0 and bval[pos - 1] > val:
-            pos -= 1
-            tot = bcnt[pos] + cnt
-            val = (bval[pos] * bcnt[pos] + val * cnt) / tot
-            cnt = tot
-        bval[pos] = val
-        bcnt[pos] = cnt
-        pos += 1
-    idx = 0
-    for j in range(pos):
-        for _ in range(bcnt[j]):
-            values[l, idx] = bval[j] - cb[idx]
-            idx += 1
-
-
-@njit(cache=True)
 def _leaf_row_index(leaf, n_leaves):
     """Group rows by leaf into contiguous, disjoint slices.
 
@@ -1161,9 +1115,9 @@ def _leaf_row_index(leaf, n_leaves):
 
 
 @njit(cache=True, parallel=True)
-def _leaf_quantiles_vec(leaf, y, F, taus, cb, n_leaves, lr):
+def _leaf_quantiles_vec(leaf, y, F, taus, n_leaves, lr):
     """Per-leaf, per-tau empirical quantile of the residuals ``y - F[:, k]``,
-    scaled by the learning rate and projected onto the non-crossing set.
+    scaled by the learning rate.
 
     The (n_leaves, K) analogue of `booster._correct_leaves`: the tree structure
     was chosen by the projected gradient, this sets the step. Column k is
@@ -1171,10 +1125,10 @@ def _leaf_quantiles_vec(leaf, y, F, taus, cb, n_leaves, lr):
     partition at ``alpha = taus[k]`` -- the oracle test in
     tests/test_quantile_head.py.
 
-    `lr` multiplies from the outside, matching `_correct_leaves`; the
-    projection runs on the scaled value, so the budget it respects is the one
-    actually committed. ``cb`` is the cumulative narrowing budget
-    (`_project_leaf_row`)."""
+    Each channel is an independent step and nothing constrains them against one
+    another here; ordering is imposed on delivered predictions instead, per row
+    (see `booster.MultiQuantileBoosting`). `lr` multiplies from the outside,
+    matching `_correct_leaves`."""
     n = leaf.shape[0]
     K = taus.shape[0]
     off, rows = _leaf_row_index(leaf, n_leaves)
@@ -1200,13 +1154,11 @@ def _leaf_quantiles_vec(leaf, y, F, taus, cb, n_leaves, lr):
                 i = rows[lo + j]
                 buf[st + j] = y[i] - F[i, k]
             values[l, k] = lr * _quantile_slice(buf, st, st + m, taus[k])
-    for l in range(n_leaves):
-        _project_leaf_row(values, l, K, cb)
     return values
 
 
 @njit(cache=True)
-def _leaf_quantiles_vec_serial(leaf, y, F, taus, cb, n_leaves, lr):
+def _leaf_quantiles_vec_serial(leaf, y, F, taus, n_leaves, lr):
     """Serial twin of `_leaf_quantiles_vec` for small n, where the parallel
     fork/join costs more than the pass. Every write is to a disjoint slice, so
     the two are bit-identical; the booster dispatches on `_SMALL_N`."""
@@ -1229,12 +1181,11 @@ def _leaf_quantiles_vec_serial(leaf, y, F, taus, cb, n_leaves, lr):
                     i = rows[j]
                     buf[j] = y[i] - F[i, k]
                 values[l, k] = lr * _quantile_slice(buf, lo, hi, taus[k])
-        _project_leaf_row(values, l, K, cb)
     return values
 
 
 @njit(cache=True, parallel=True)
-def _leaf_quantiles_vec_w(leaf, y, F, w, taus, cb, n_leaves, lr):
+def _leaf_quantiles_vec_w(leaf, y, F, w, taus, n_leaves, lr):
     """Weighted `_leaf_quantiles_vec`. Reproduces `losses._weighted_quantile`
     (nearest rank on cumulative weight), which is the rule the scalar weighted
     quantile path already uses. Rows carrying zero weight -- MVS drops, or a
@@ -1261,13 +1212,11 @@ def _leaf_quantiles_vec_w(leaf, y, F, w, taus, cb, n_leaves, lr):
                 wbuf[st + j] = w[i]
             values[l, k] = lr * _weighted_quantile_slice(
                 buf, wbuf, st, st + m, taus[k], st)
-    for l in range(n_leaves):
-        _project_leaf_row(values, l, K, cb)
     return values
 
 
 @njit(cache=True)
-def _leaf_quantiles_vec_w_serial(leaf, y, F, w, taus, cb, n_leaves, lr):
+def _leaf_quantiles_vec_w_serial(leaf, y, F, w, taus, n_leaves, lr):
     """Serial twin of `_leaf_quantiles_vec_w` (see `_leaf_quantiles_vec_serial`)."""
     n = leaf.shape[0]
     K = taus.shape[0]
@@ -1286,7 +1235,6 @@ def _leaf_quantiles_vec_w_serial(leaf, y, F, w, taus, cb, n_leaves, lr):
                     wbuf[j] = w[i]
                 values[l, k] = lr * _weighted_quantile_slice(
                     buf, wbuf, lo, hi, taus[k], lo)
-        _project_leaf_row(values, l, K, cb)
     return values
 
 

--- a/chimeraboost/warmup.py
+++ b/chimeraboost/warmup.py
@@ -161,10 +161,10 @@ def warmup(verbose=False, background=False, shap=False):
     mc.predict_proba(X[:1, :3])   # vector-leaf serial twin
     _log("multiclass")
 
-    # Multi-quantile head: the leaf-quantile kernels (quickselect + the
-    # non-crossing projection) and the vector forest predictors. A short grid
-    # keeps the compile cheap -- the kernels are generic in K, so the number
-    # of levels does not change what gets compiled.
+    # Multi-quantile head: the leaf-quantile kernels (quickselect) and the
+    # vector forest predictors. A short grid keeps the compile cheap -- the
+    # kernels are generic in K, so the number of levels does not change what
+    # gets compiled.
     yq = X[:320, 0] + 0.5 * rng.standard_normal(320)
     qr = ChimeraBoostQuantileRegressor(quantiles=[0.1, 0.5, 0.9],
                                        n_estimators=2, random_state=0,
@@ -183,11 +183,10 @@ def warmup(verbose=False, background=False, shap=False):
     _wy = rng.standard_normal(8)
     _wF = np.zeros((8, 3))
     _wt = np.array([0.1, 0.5, 0.9])
-    _wcb = np.zeros(3)
     _ww = np.ones(8)
-    _leaf_quantiles_vec(_wl, _wy, _wF, _wt, _wcb, 2, 0.1)
-    _leaf_quantiles_vec_w(_wl, _wy, _wF, _ww, _wt, _wcb, 2, 0.1)
-    _leaf_quantiles_vec_w_serial(_wl, _wy, _wF, _ww, _wt, _wcb, 2, 0.1)
+    _leaf_quantiles_vec(_wl, _wy, _wF, _wt, 2, 0.1)
+    _leaf_quantiles_vec_w(_wl, _wy, _wF, _ww, _wt, 2, 0.1)
+    _leaf_quantiles_vec_w_serial(_wl, _wy, _wF, _ww, _wt, 2, 0.1)
     _log("multi-quantile")
 
     # Regression, ordered boosting on (the LOO leaf-step kernel), with a

--- a/docs/quantiles.md
+++ b/docs/quantiles.md
@@ -35,34 +35,43 @@ More worked snippets are in [Recipes](recipes.md#quantile-regression).
 
 ## Predictions never cross
 
-The 30% quantile is never returned above the 70%. This is built into the model rather
-than repaired afterwards: it starts from the sorted global quantiles, and every leaf
-vector is projected onto a set of increments that cannot reorder anything. So
+The 30% quantile is never returned above the 70%. Every row is sorted on its way out, so
 `np.diff(Q, axis=1) >= 0` holds exactly, including at every intermediate stage of
-`staged_predict`.
+`staged_predict`. Sorting is not a compromise: rearranging a crossing quantile curve
+never increases pinball loss at any level, for any row (Chernozhukov, Fernández-Val &
+Galichon 2010), so the guarantee is free.
 
 Independently fitted per-level models have no such property. On the benchmark in
 `benchmarks/quantile_head.py`, 18 to 21% of adjacent quantile pairs come out reversed.
 
-Intervals can still be *narrower* than the pooled one where the data is quiet, so that
-is not given up to get the guarantee.
+The band is free to be much *narrower* than the pooled one where the data is quiet — it
+tracks the local spread rather than a global floor.
 
 ## Interval calibration
 
-Boosting under-disperses quantiles. Each round's step is scaled by the learning rate, so
-the grid never fully contracts and intervals come out too wide. `conformalize=True`
-fixes it:
+Read the intervals with this in mind: **the raw grid runs slightly narrow.** Leaf values
+are the residual quantiles of the rows in that leaf, measured on those same rows, which
+is optimistic. On the datasets in `benchmarks/probe_quantile_band.py` a nominal 80%
+interval delivers about 72 to 76% coverage. Pinball loss is what the model optimizes and
+it is good — better than one dedicated LightGBM booster per level — but a raw interval
+is not a coverage guarantee.
+
+`conformalize=True` turns it into one:
 
 ```python
 model = ChimeraBoostQuantileRegressor(conformalize=True).fit(X, y)
-print(model.conformal_scale_)      # one factor per level; below 1 means the fit was too wide
+print(model.conformal_scale_)      # one factor per level; above 1 widened the fit
 ```
 
 This holds out `calibration_fraction` of the rows **before** the early-stopping split,
 so that fold influences neither the fit nor the stopping point, then rescales each level
 about the predicted median by a conformal factor (Romano, Patterson & Candès 2019). On
-exchangeable data this gives distribution-free marginal coverage. The worst measured
-error against nominal is 0.7 percentage points at n = 10,000.
+exchangeable data this gives distribution-free marginal coverage. Measured coverage lands
+within 2.7 percentage points of nominal at n = 10,000, erring on the wide side — conformal
+prediction is conservative by construction, so over-coverage is the expected direction.
+
+Use it whenever you need the interval to mean what it says. It costs one extra held-out
+fold and no extra fitting.
 
 It raises rather than guessing when the calibration fold is too small to certify the
 levels you asked for. A 90% interval needs at least 9 calibration rows, and a 99% one
@@ -96,11 +105,12 @@ assumes nothing about tails the model never estimated.
 ## What it costs
 
 The split search runs once per round instead of once per level, so the saving grows with
-how wide the data is: roughly 3.4x the fit speed of 19 independent boosters at 5
-features, 4.8x at 32, and 7.8x at 128. Accuracy stays within 3% of per-level models on
-pinball loss throughout, and comes out better on wide data.
+how wide the data is: roughly 3.0x the fit speed of 19 independent LightGBM quantile
+boosters at 5 features, 3.6x at 32, and 6.2x at 128. Accuracy is not traded for it —
+pinball loss comes out 1 to 3% *better* than those per-level models at every width
+measured, with the margin widening on wide data.
 
-That 3% is an average over the whole grid; a single level can trade more, because every
+That is an average over the whole grid; a single level can trade more, because every
 level shares one tree structure per round. On data whose signal takes many rounds to
 resolve, the median column of the default 19-level grid has measured up to 18% worse
 than a dedicated `quantiles=[0.5]` fit, with a 3-level grid recovering most of the gap

--- a/tests/test_quantile_head.py
+++ b/tests/test_quantile_head.py
@@ -15,8 +15,7 @@ from chimeraboost.quantile_api import (DEFAULT_QUANTILES,
                                        _median_index)
 from chimeraboost.tree import (_leaf_quantiles_vec, _leaf_quantiles_vec_serial,
                                _leaf_quantiles_vec_w,
-                               _leaf_quantiles_vec_w_serial,
-                               _project_leaf_row)
+                               _leaf_quantiles_vec_w_serial)
 
 TAUS = np.round(np.arange(0.05, 0.951, 0.05), 10)
 
@@ -44,21 +43,16 @@ def _pinball(y, Q, taus=TAUS):
 
 @pytest.mark.parametrize("n,n_leaves", [(1000, 16), (37, 8), (9, 4)])
 def test_leaf_quantiles_match_numpy_exactly(n, n_leaves):
-    """The registered bit-exact equivalence: with the projection inactive,
-    column k of the leaf kernel IS `np.quantile` at taus[k] on that leaf's
-    residuals. Not a tolerance question -- any diff is a correctness bug.
-
-    F is constant across channels here, which makes the per-leaf residual
-    quantiles monotone in tau on their own, so the projection is the identity
-    and the raw quantile arithmetic is what gets compared."""
+    """The registered bit-exact equivalence: column k of the leaf kernel IS
+    `np.quantile` at taus[k] on that leaf's residuals. Not a tolerance
+    question -- any diff is a correctness bug."""
     rng = np.random.default_rng(n)
     y = rng.standard_normal(n) * 3.0
     F = np.repeat(rng.standard_normal((n, 1)), TAUS.size, axis=1)
     leaf = rng.integers(0, n_leaves, size=n)
-    cb = np.zeros(TAUS.size)
     lr = 0.1
 
-    got = _leaf_quantiles_vec(leaf, y, F, TAUS, cb, n_leaves, lr)
+    got = _leaf_quantiles_vec(leaf, y, F, TAUS, n_leaves, lr)
     ref = np.zeros((n_leaves, TAUS.size))
     for l in range(n_leaves):
         m = leaf == l
@@ -79,10 +73,9 @@ def test_leaf_quantiles_weighted_match_reference(n, n_leaves):
     F = np.repeat(rng.standard_normal((n, 1)), TAUS.size, axis=1)
     leaf = rng.integers(0, n_leaves, size=n)
     w = rng.uniform(0.2, 2.0, size=n)
-    cb = np.zeros(TAUS.size)
     lr = 0.1
 
-    got = _leaf_quantiles_vec_w(leaf, y, F, w, TAUS, cb, n_leaves, lr)
+    got = _leaf_quantiles_vec_w(leaf, y, F, w, TAUS, n_leaves, lr)
     ref = np.zeros((n_leaves, TAUS.size))
     for l in range(n_leaves):
         m = leaf == l
@@ -102,60 +95,33 @@ def test_leaf_quantile_serial_twin_is_bit_identical():
     F = np.sort(rng.standard_normal((n, TAUS.size)), axis=1)
     leaf = rng.integers(0, n_leaves, size=n)
     w = rng.uniform(0.5, 1.5, size=n)
-    cb = np.cumsum(np.r_[0.0, rng.uniform(0, 0.1, TAUS.size - 1)])
 
     np.testing.assert_array_equal(
-        _leaf_quantiles_vec(leaf, y, F, TAUS, cb, n_leaves, 0.1),
-        _leaf_quantiles_vec_serial(leaf, y, F, TAUS, cb, n_leaves, 0.1))
+        _leaf_quantiles_vec(leaf, y, F, TAUS, n_leaves, 0.1),
+        _leaf_quantiles_vec_serial(leaf, y, F, TAUS, n_leaves, 0.1))
     np.testing.assert_array_equal(
-        _leaf_quantiles_vec_w(leaf, y, F, w, TAUS, cb, n_leaves, 0.1),
-        _leaf_quantiles_vec_w_serial(leaf, y, F, w, TAUS, cb, n_leaves, 0.1))
+        _leaf_quantiles_vec_w(leaf, y, F, w, TAUS, n_leaves, 0.1),
+        _leaf_quantiles_vec_w_serial(leaf, y, F, w, TAUS, n_leaves, 0.1))
 
 
-def _pava_reference(u):
-    """Plain-Python pool-adjacent-violators, the readable oracle for
-    `_project_leaf_row`'s in-place version."""
-    blocks = []                       # (mean, count)
-    for v in u:
-        val, cnt = float(v), 1
-        while blocks and blocks[-1][0] > val:
-            bv, bc = blocks.pop()
-            tot = bc + cnt
-            val = (bv * bc + val * cnt) / tot
-            cnt = tot
-        blocks.append((val, cnt))
-    out = []
-    for val, cnt in blocks:
-        out.extend([val] * cnt)
-    return np.array(out)
-
-
-def test_projection_matches_pava_and_respects_the_budget():
-    """The projection is isotonic regression in shifted coordinates: it must
-    match PAVA, and its output must satisfy the narrowing constraint
-    ``v[k] - v[k-1] >= -b[k]`` that keeps predictions from crossing."""
-    rng = np.random.default_rng(11)
-    K = TAUS.size
-    for _ in range(200):
-        b = np.r_[0.0, rng.uniform(0.0, 0.5, K - 1)]
-        cb = np.cumsum(b)
-        v = rng.standard_normal(K) * 0.3
-        buf = np.ascontiguousarray(v[None, :].copy())
-        _project_leaf_row(buf, 0, K, cb)
-        got = buf[0]
-        np.testing.assert_allclose(got, _pava_reference(v + cb) - cb,
-                                   rtol=0, atol=1e-12)
-        assert np.all(np.diff(got) >= -b[1:] - 1e-12)
-
-
-def test_projection_with_zero_budget_forces_monotone_increments():
-    """With no budget the admissible set collapses to non-decreasing vectors,
-    which is the degenerate case the guarantee rests on."""
-    rng = np.random.default_rng(12)
-    K = TAUS.size
-    buf = np.ascontiguousarray(rng.standard_normal((1, K)))
-    _project_leaf_row(buf, 0, K, np.zeros(K))
-    assert np.all(np.diff(buf[0]) >= 0.0)
+def test_projected_gradient_makes_no_ordering_assumption():
+    """`_project_pinball` collapses the K gradient columns onto one direction
+    without building them. It once did that by binary-searching the row's PIT
+    rank, which silently returns the wrong channel set once a row of F crosses
+    -- and rows of F are free to cross now. Score a deliberately crossing F
+    against the dense definition."""
+    from chimeraboost.tree import _project_pinball
+    rng = np.random.default_rng(21)
+    n, K = 500, TAUS.size
+    y = rng.standard_normal(n)
+    F = rng.standard_normal((n, K))          # unsorted on purpose
+    assert (np.diff(F, axis=1) < 0).any(), "F must actually cross"
+    c = rng.standard_normal(K)
+    w = rng.uniform(0.5, 1.5, n)
+    out = np.empty(n)
+    _project_pinball(y, F, c, float(c @ TAUS), w, out)
+    grad = np.where(y[:, None] >= F, -TAUS, 1.0 - TAUS)
+    np.testing.assert_allclose(out, (grad @ c) * w, rtol=0, atol=1e-12)
 
 
 # --------------------------------------------------------------------------
@@ -163,9 +129,7 @@ def test_projection_with_zero_budget_forces_monotone_increments():
 # --------------------------------------------------------------------------
 
 def test_predictions_never_cross():
-    """Zero crossings, asserted exactly. Init is sorted, every committed
-    increment is admissible, and IEEE addition is monotone, so this is
-    structural rather than a tolerance."""
+    """Zero crossings, asserted exactly: every delivered row is rearranged."""
     X, y = _heteroscedastic(seed=1)
     m = ChimeraBoostQuantileRegressor(random_state=0, n_estimators=200).fit(X, y)
     Q = m.predict(X)
@@ -193,10 +157,15 @@ def test_no_crossing_on_every_path():
 
 
 def test_narrow_regions_are_actually_narrower():
-    """The head must be able to make an interval TIGHTER than the pooled one.
-    A construction that only ever adds non-decreasing increments cannot (the
-    sum of non-decreasing vectors is non-decreasing), so this pins the
-    behaviour the narrowing budget exists to allow."""
+    """The band must track the LOCAL spread, not just beat the pooled one.
+
+    The data has a 0.1 spread on one side and 2.1 on the other, so the honest
+    width ratio is about 0.05. The predecessor to today's construction spent a
+    global narrowing budget at its worst-case leaf, froze within tens of rounds
+    and delivered bands 2x to 10x too wide on real data
+    (benchmarks/LEAFTUNE_PLAN.md, P12) -- while still clearing a loose
+    "narrower than pooled" bar. Hence the ratio, which is what actually
+    failed."""
     X, y = _heteroscedastic(n=6000, seed=3, narrow=True)
     m = ChimeraBoostQuantileRegressor(random_state=0, n_estimators=400).fit(X, y)
     Q = m.predict(X)
@@ -206,7 +175,57 @@ def test_narrow_regions_are_actually_narrower():
     assert width[tight].mean() < 0.5 * pooled, (
         f"tight-region width {width[tight].mean():.3f} should be far below the "
         f"pooled width {pooled:.3f}")
-    assert width[tight].mean() < width[wide].mean()
+    ratio = width[tight].mean() / width[wide].mean()
+    assert ratio < 0.35, (
+        f"tight/wide width ratio {ratio:.3f} should approach the true spread "
+        f"ratio of ~0.05; a frozen global band sits near 1.0")
+
+
+def test_coverage_does_not_ratchet_up_with_training():
+    """The saturation signature, pinned as a regression test.
+
+    When the width is frozen but the centre keeps sharpening, empirical
+    coverage climbs AWAY from nominal as rounds accumulate -- P12 measured
+    0.817 at round 1 and 0.995 from round 50. A healthy fit does the opposite:
+    coverage settles toward nominal and the width keeps moving."""
+    X, y = _heteroscedastic(n=6000, seed=5, narrow=True)
+    Xt, yt, Xv, yv = X[:4000], y[:4000], X[4000:], y[4000:]
+    m = ChimeraBoostQuantileRegressor(
+        random_state=0, n_estimators=400, early_stopping=False).fit(Xt, yt)
+    lo, hi = 0, TAUS.size - 1               # the 0.05-0.95 band, nominal 0.90
+    seen = {}
+    for i, Q in enumerate(m.staged_predict(Xv), start=1):
+        if i in (50, 400):
+            seen[i] = (float(np.mean((yv >= Q[:, lo]) & (yv <= Q[:, hi]))),
+                       float(np.mean(Q[:, hi] - Q[:, lo])))
+    (cov50, wid50), (cov400, wid400) = seen[50], seen[400]
+
+    assert abs(wid400 - wid50) / wid50 > 0.01, (
+        f"width froze: {wid50:.5f} at round 50 vs {wid400:.5f} at 400")
+    assert cov400 <= cov50 + 0.02, (
+        f"coverage ratcheted up with training ({cov50:.3f} -> {cov400:.3f}), "
+        f"which is the frozen-band signature")
+    assert 0.84 <= cov400 <= 0.95, (
+        f"final coverage {cov400:.3f} should sit near the nominal 0.90")
+
+
+def test_rearrangement_never_increases_pinball():
+    """Sorting a crossing quantile curve cannot raise the pinball loss at any
+    level (Chernozhukov, Fernandez-Val & Galichon 2010). That is the whole
+    licence for repairing order at delivery, so check it against the model's
+    own raw accumulated scores."""
+    X, y = _heteroscedastic(n=3000, seed=6)
+    m = ChimeraBoostQuantileRegressor(
+        random_state=0, n_estimators=150, early_stopping=False).fit(X, y)
+
+    Xb = np.ascontiguousarray(m.model_.prep_.transform(X).T)
+    raw = np.tile(m.model_.init_, (X.shape[0], 1))
+    for tree in m.model_.trees_:
+        raw += tree.values[tree.apply(Xb)]
+    sorted_out = m.predict(X)
+
+    np.testing.assert_array_equal(sorted_out, np.sort(raw, axis=1))
+    assert _pinball(y, sorted_out) <= _pinball(y, raw) + 1e-12
 
 
 def test_staged_final_equals_predict():
@@ -466,14 +485,18 @@ def test_loss_reduces_to_the_scalar_quantile_gradient():
                                rtol=0, atol=1e-12)
 
 
-def test_booster_gap_bound_stays_positive():
-    """The narrowing budget is a lower bound on the gap for ANY row; if it
-    ever went negative the guarantee would be void."""
+def test_booster_keeps_no_narrowing_budget():
+    """The budget is gone and must stay gone: `gap_` was its public trace, and
+    a half-reverted state that recreates the attribute without the machinery
+    (or vice versa) would be worse than either. The raw accumulated scores are
+    free to cross -- that is the point -- while every delivered row is
+    ordered."""
     X, y = _heteroscedastic(n=3000, seed=22)
     b = MultiQuantileBoosting(quantiles=TAUS, n_estimators=200, depth=4,
                               random_state=0, min_child_weight=20.0)
     b.fit(X, y)
-    assert np.all(b.gap_ >= 0.0)
+    assert not hasattr(b, "gap_")
+    assert np.all(np.diff(b.predict_raw(X), axis=1) >= 0.0)
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_warmup.py
+++ b/tests/test_warmup.py
@@ -69,7 +69,6 @@ CACHE_DEPENDENT = {
     "chimeraboost.tree._solve_small",
     "chimeraboost.tree._leaf_row_index",
     "chimeraboost.tree._lerp_np",
-    "chimeraboost.tree._project_leaf_row",
     "chimeraboost.tree._quantile_slice",
     "chimeraboost.tree._select_kth",
     "chimeraboost.tree._sort_pairs",


### PR DESCRIPTION
## What was wrong

`ChimeraBoostQuantileRegressor` returned prediction intervals **2x to 10x wider than they should have been, and they got worse the longer you trained.**

The non-crossing guarantee was enforced during the fit by a global "narrowing budget" charged at the **worst-case leaf** each round, so one aggressively narrowing leaf spent budget on behalf of every row. At depth 4 that is 16 leaves competing to be worst, every round. It saturated within tens of rounds and froze the interval width from then on.

Measured on the shipped code (`benchmarks/probe_quantile_band.py --tag base`), `cpu_act` width by round:

| 50 | 100 | 300 | 1000 | 2000 | 3000 |
|--:|--:|--:|--:|--:|--:|
| 13.256 | 12.808 | 12.873 | 12.909 | 12.912 | 12.912 |

Coverage over the same rounds climbs 0.861 → 0.987 against a nominal 0.80: the centre keeps sharpening under a band that can no longer follow. Diagnosed in `LEAFTUNE_PLAN.md` P12; this PR is the fix.

## The change

Delete the budget. Impose ordering **per row on delivered predictions** by monotone rearrangement — sort each row on its way out of the booster.

This is exact for each row, where any training-time construction has to be a bound that holds for every possible row at once, and it costs no accuracy: sorting a crossing quantile curve never increases pinball loss at any level (Chernozhukov, Fernández-Val & Galichon 2010).

**Why sorting is safe here and was not before.** PR #48 recorded that sorting leaf vectors *during training* diverged to pinball 2.9e7 against an oracle of 0.35. That was a feedback loop — sorted values re-entered the accumulated scores and self-reinforced. Delivered output has no path back into the fit. `F` must never be sorted in place, and the class docstring now says so.

**The trap this uncovered.** `tree._project_pinball` computed the split-search gradient by binary-searching each row's PIT rank in a suffix table — valid only while that row of `F` is sorted, which is precisely what the budget used to guarantee. Nothing would have crashed; the tree structures would just have been quietly wrong. It is now an explicit per-channel scan, pinned by a new test against the dense gradient on deliberately crossing `F`.

## Results

Three Grinsztajn regression sets, 3 seeds, K=3, nominal 0.80:

| dataset | pinball base → fix | coverage base → fix | width base → fix |
|---|--:|--:|--:|
| Brazilian_houses | 0.02992 → 0.00607 | 0.998 → 0.758 | 0.650 → 0.049 |
| cpu_act | 0.74380 → 0.56782 | 0.982 → 0.719 | 12.389 → 4.894 |
| elevators | 0.00067 → 0.00051 | 0.949 → 0.725 | 0.0097 → 0.0044 |

The freeze is gone and its signature reversed — `cpu_act` width now runs 13.08 → 8.73 → 6.01 → 5.03 → 4.54 → 4.27 across rounds 50 → 3000, and coverage falls toward nominal instead of climbing away.

Against 19 independent LightGBM quantile boosters the head moves **from parity to a win at every width**: pinball ratio 0.989 / 0.984 / 0.981 / 0.981 / 0.968 / 0.969 at 5 to 128 features, at 3.0x–6.2x their fit speed, crossing 0.0000 against their 0.18–0.21.

## Honest caveats

**Two pre-registered bars FAIL and are recorded as failures, not restated as passes.**

- The head was required to beat a rigid fixed-width baseline on 3 of 3. It still loses on 3 of 3 — but by −34% / −3.0% / −5.9% instead of −562% / −35% / −40%.
- Raw coverage was required to land in [0.75, 0.88]; it reads 0.758 / 0.719 / 0.725.

**The error flipped sign.** Leaf values are *in-sample* residual quantiles, so with nothing damping them the band now over-narrows: a nominal 80% interval delivers about 72–76% where it used to deliver 95–99%. For anyone reading a raw interval as a guarantee that is the more dangerous direction, so `docs/quantiles.md` and the CHANGELOG both say so plainly and point at `conformalize=True`. The same cause moves the conformal ledger row to 2.65 pp against a 2 pp target — also recorded as a FAIL in `QUANTILE_PLAN.md`.

The kill clause was overridden deliberately (Nathan: *"if we are winning we shouldn't kill it"*), on the grounds that the baseline bar is the right question for "is a conditional quantile model worth building" and the wrong one for "should this replace what users have" — and that `main` misses that same bar by roughly 10x more. Reasoning is in `LEAFTUNE_PLAN.md` P14, since overriding a pre-registered bar is exactly what needs an audit trail. Beating the rigid offset is reclassified as an open research target, with the next mechanism named: shrink each leaf's quantile step toward the pooled band, or fit leaf residual quantiles out-of-sample.

## Verification

- **896 tests pass.** Budget tests removed; new tests cover the saturation signature (coverage must not ratchet up with rounds), width tracking local spread, rearrangement never raising pinball, the gradient's ordering-independence, and `gap_` staying gone.
- **Bit-identity: 81 of 89 arrays unchanged.** The 8 that moved are the two `mq3` families in full. `mae`, `mae_w_sub`, `quantile` and `quantile_w` share these leaf kernels at K=1 and are bit-identical — which is what licenses skipping a `--decide` run, since the decision suites do not score quantiles.
- `benchmarks/probe_quantile_band.py` is new and rebuilds the P10–P13 harness that was lost with a deleted worktree.

## Removed

`MultiQuantileBoosting.gap_` — the budget's public trace. Never exposed on the estimator, never documented. Models pickled with 0.27.0 or earlier load and predict identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
