### PR TITLE
Record P15: leaf spread smoothing, falsified at tier 1

### DIFF
--- a/benchmarks/LEAFTUNE_PLAN.md
+++ b/benchmarks/LEAFTUNE_PLAN.md
@@ -374,6 +374,94 @@ Reusable facts from this pass:
   `mae`, `mae_w_sub`, `quantile` and `quantile_w` share the same leaf kernels at
   K=1 and are untouched, which is what licenses skipping a `--decide` run.
 
+## P15 — spread smoothing, pre-registered 2026-07-31 (branch `quantile-spread-smoothing`)
+
+Written **before** anything was measured. This is the follow-up P14 called for:
+attack the in-sample bias in the leaf values rather than re-capping the width.
+
+**The defect.** A leaf's value at level tau is the empirical tau-quantile of the
+residuals of the rows *in that leaf*, measured on those same rows. That is
+optimistically tight, and the smaller the leaf the tighter it is: an m-row leaf
+cannot resolve a 0.95 quantile at all once m is small, so the estimate collapses
+toward the middle of the leaf's residuals. Nothing damps it, so the band narrows
+with every round and coverage decays monotonically (P14 result table).
+
+**Change.** Per round, after the leaf refit and **before** the values enter `F`,
+shrink each leaf's *spread* toward the pooled band by an amount that depends on
+how much data the leaf actually has. With `v_l` the leaf's K-vector, `p` the
+pooled band (the same quantile computation over all rows, one leaf), `c(.)` the
+interpolated tau=0.5 point of a vector, and `n_l` the leaf's row mass:
+
+```
+lambda_l = k0 / (n_l + k0)
+v'_l[k]  = c(v_l) + (1 - lambda_l) * (v_l[k] - c(v_l)) + lambda_l * (p[k] - c(p))
+```
+
+Four properties, each chosen against a recorded failure:
+
+- **Convex, never a floor.** The band stays free to be *narrower* than pooled,
+  which trap 1 in `QUANTILE_PLAN.md` says any pooled-band mechanism must
+  preserve — a sum of clipped-to-monotone vectors can never narrow, and that is
+  what diverged in PR #48. Nothing is sorted and `F` is never touched.
+- **Location-preserving**, so it is exactly the identity at K=1 (the deviations
+  from the centre are all zero). The scalar MAE/Quantile paths share these leaf
+  kernels at K=1; this keeps them provably unreachable.
+- **Adaptive, not a knob.** P11 established that no knob on this head moved
+  coverage. `lambda_l` is a function of leaf mass, so small leaves — precisely
+  the ones whose tail quantiles are unresolvable — shrink hardest, while a leaf
+  with plenty of rows keeps its own spread.
+- **The blend is NumPy on `tree.values` in the booster**, not a kernel change,
+  so the four leaf kernels and their bit-exact oracles are untouched and no new
+  warmup entry is owed.
+
+`k0` is argued, not tuned: `_auto_min_child_weight(taus)` = ceil(1 / min(tau_0,
+1 - tau_K)), the constant this head already uses for "rows needed before the
+extreme channel means anything" (20 on the default grid). A leaf sitting at the
+minimum admissible mass gets lambda = 1/2. The probe sweeps k0 at half and twice
+that value as **diagnosis of the mechanism's shape**, not to pick a default.
+
+**Arms** (`probe_quantile_band.py --tag p15`, same 3 datasets, seeds 0-2, K3 and
+K19 grids as P14): `head` (the shipped PR #62 head, unchanged), `head+sm` at the
+argued k0, `head+sm-half` and `head+sm2` for the sweep, `head+sm+CQR`, and the
+`offset` baseline. Freeze section gains a `head+sm` row.
+
+**Bars.** Ship gates, judged at the argued default `head+sm`, all required for
+the default to flip on:
+
+1. **Coverage** without `conformalize` inside [0.75, 0.88] at nominal 0.80 on
+   3 of 3 (fix: 0.758 / 0.719 / 0.725 — P14's failed bar 1).
+2. **The decay is dead**: freeze-section coverage at round 3000 is no more than
+   1 pp below its round-300 value on 3 of 3, and width at 3000 still differs
+   from round 50 by more than 1% (the P14 freeze stays dead — this must not be
+   bought by re-freezing the band).
+3. **No pinball give-back**: within 2% of the shipped PR #62 head on every
+   dataset, both grids. This is the "compare against what users have" gate that
+   P14's status entry established as the right shipping question.
+4. **Crossing rate exactly 0.0** in every arm, every path, every staged stage.
+5. **The conformal ledger is restored**: worst conformalized coverage error
+   ≤ 2 pp (fix: 2.65 pp, FAIL).
+6. **Unchanged obligations**: the identity snapshot moves only the two `mq3`
+   families and every scalar family is byte-identical (which again licenses
+   skipping `--decide`); the full suite green, including
+   `test_narrow_regions_are_actually_narrower` (tight/wide ratio < 0.35 — the
+   test that bounds how hard this may pull toward a global band).
+
+**Research target, not a gate.** Pinball beats or matches the rigid offset on
+3 of 3, currently −34.3% / −3.0% / −5.9%. Per the P14 status entry this is an
+open research target for the head and never a gate on improvements to it; bars 1
+and 3 of P14 remain recorded as FAILED. Report the movement either way.
+
+**Kill clause.** If any ship gate fails at every probed k0, mechanism A is
+falsified for this defect. Record the negative here and **remove the parameter**
+— no dead knobs. The fallback, which would need its own pre-registration, is
+mechanism B: fit the leaf residual quantiles out-of-sample on a dedicated third
+fold. B was not built first because it needs a fold that is neither the
+calibration nor the early-stopping fold (reusing the ES fold would let stopping
+score rows that set the leaf values), it cuts rows-per-leaf on a head whose
+remaining deficit P14 diagnosed as *variance*, and it breaks the recorded
+invariant that leaf values see exactly the rows the split search saw
+(`booster.py`, the MVS row-selection comment).
+
 ## Where to go instead
 
 The two untested axes are **re-purposing, not tuning**, and neither is a search

--- a/benchmarks/LEAFTUNE_PLAN.md
+++ b/benchmarks/LEAFTUNE_PLAN.md
@@ -462,6 +462,114 @@ remaining deficit P14 diagnosed as *variance*, and it breaks the recorded
 invariant that leaf values see exactly the rows the split search saw
 (`booster.py`, the MVS row-selection comment).
 
+### Result: FALSIFIED at tier 1. Kill clause honoured, parameter removed.
+
+**Sweep widened before measuring** (recorded because it changes the
+pre-registration): the plan above swept k0 at half and twice the argued 20.
+Before running anything, that was judged too narrow to be diagnostic. With 16
+leaves over 20 000 rows a leaf holds ~1250 rows, so `lambda = k0 / (n_l + k0)`
+is ~0.016 at k0 = 20 — if the optimism is driven by the split *selection*
+rather than by within-leaf sample size, a sweep spanning a factor of four could
+not tell a wrong shape from a too-small constant. The sweep was therefore
+widened to four orders of magnitude, k0 in {20, 100, 500, 2000, 10 000,
+100 000}, up to lambda ~0.99 (the fully-pooled limit). No measurement had been
+taken at that point.
+
+Mechanism screen, synthetic heteroscedastic data (8 features, conditional
+spread 0.2 against 2.0, 4000 train / 4000 test, 300 rounds, 3 seeds, grid
+(0.1, 0.5, 0.9), nominal coverage 0.80):
+
+| k0 | lambda at a 250-row leaf | test coverage | **train coverage** | width |
+|--:|--:|--:|--:|--:|
+| 0 (off) | 0.00 | 0.7555 | 0.8004 | 2.697 |
+| 20 | 0.07 | 0.7586 | 0.8013 | 2.685 |
+| 100 | 0.29 | 0.7674 | 0.8021 | 2.707 |
+| 500 | 0.67 | 0.7702 | 0.8029 | 2.703 |
+| 2 000 | 0.89 | 0.7772 | 0.8023 | 2.581 |
+| 10 000 | 0.98 | 0.7888 | 0.8037 | 2.333 |
+| 100 000 | 1.00 | 0.7882 | 0.8019 | 3.055 |
+
+**The train-coverage column is the whole finding.** It sits at nominal 0.80 at
+every k0, including fully pooled, while test coverage never gets there. The
+deficit is entirely the gap between in-sample and out-of-sample residuals — and
+the pooled band is computed from *in-sample* residuals too, so it carries the
+same bias. Shrinking toward a target that shares the error cannot remove it.
+The mechanism only ever redistributes spread *between* leaves; it has no route
+to the common component, which is all of it. A homoscedastic control moved even
+less (0.7576 to 0.7690 across the same sweep), as expected when there is no
+between-leaf variation to redistribute.
+
+What the residual gain at extreme k0 costs, same data:
+
+| k0 | test coverage | pinball | tight/wide width ratio (true 0.10) |
+|--:|--:|--:|--:|
+| 0 (off) | 0.7555 | 0.28507 | 0.129 |
+| 20 | 0.7586 | 0.28454 | 0.127 |
+| 500 | 0.7702 | 0.28592 | 0.137 |
+| 2 000 | 0.7772 | 0.28733 | 0.166 |
+| 10 000 | 0.7888 | 0.30820 | **0.420** |
+| 100 000 | 0.7882 | 0.33404 | **0.906** |
+
+The three points of coverage available are bought by pooling the band across
+leaves — the ratio walks from 0.129 (near the true 0.10) to 0.906 (a flat
+global band), which is the head ceasing to be conditional at all. That breaks
+ship gate 6 (`test_narrow_regions_are_actually_narrower`, ratio < 0.35) at the
+same k0 where gate 3 breaks too (pinball +8.1% at k0 = 10 000, +17.2% at
+100 000, against a 2% allowance). Coverage never reaches the gate-1 window on
+this data even in the fully-pooled limit. **Every k0 that helps coverage fails
+two other gates; no k0 passes all six.** Killed per the clause; the
+`spread_smoothing` parameter is removed rather than left in as a dead knob.
+
+Cost of the negative: three short screens, no `--decide` run, no probe run. The
+tier-1 screen did its job — the story did not show up, so nothing downstream
+was spent on it.
+
+**Generalizable.** A shrinkage estimator can only correct the part of the error
+that *varies across* the units being shrunk. Diagnose which component you have
+before designing the correction: here, printing in-sample alongside
+out-of-sample coverage answered it in one table and would have falsified the
+design on paper. In-sample-vs-out-of-sample gaps need an out-of-sample estimate;
+there is no arrangement of in-sample quantities that fixes them.
+
+Note what this implies about the *product* question, as distinct from the
+research one: a uniform in-sample/out-of-sample gap is exactly what a global
+multiplicative correction from a held-out fold repairs, and that is
+`conformalize=True`, already shipped and already documented as the route to a
+coverage guarantee. The remaining open item for the raw grid is pinball against
+the rigid offset, which is a sharpness question, not a calibration one.
+
+## P16 — out-of-sample leaf quantiles (pre-registration DRAFT, not started)
+
+The fallback P15 named, now with P15's evidence behind it: the defect is that
+leaf values are residual quantiles of the rows that chose the split, so the
+only fix is to estimate them on rows that did not. Structure from one set of
+rows, leaf values from another — "honest" trees in the Athey-Imbens sense,
+applied to the leaf quantile rather than the leaf mean.
+
+Not started, and it needs a real pre-registration before it is. The three
+things that pre-registration has to answer, all of them recorded costs rather
+than open questions:
+
+1. **Which rows.** Neither existing fold is available: the calibration fold
+   must stay pristine for conformalization, and using the early-stopping fold
+   would let stopping score the rows that set the leaf values. So it needs a
+   third split, or a per-round row partition (cheaper, and closer to what the
+   MVS draw already does).
+2. **Variance.** P14 diagnosed the head's remaining deficit as variance, not
+   bias. Halving the rows per leaf to buy honesty makes that worse; the K = 19
+   grid, whose extreme channels are the noisiest, is where this will show
+   first. Whether the bias removed exceeds the variance added is the whole
+   experiment, and it is genuinely uncertain.
+3. **A recorded invariant breaks.** `booster.py` states that leaf values see
+   exactly the rows the split search saw (the MVS row-selection comment). This
+   mechanism contradicts it deliberately, so the comment changes with the code
+   and the reason lands in the same commit.
+
+Bars would carry over from P15 unchanged (coverage window, no pinball
+give-back against the shipped head, crossing zero, the conformal ledger, the
+identity-snapshot scope), with the rigid-offset comparison still a research
+target and not a gate.
+
 ## Where to go instead
 
 The two untested axes are **re-purposing, not tuning**, and neither is a search


### PR DESCRIPTION
Documentation only. No library change — `chimeraboost/` and `tests/` are
byte-identical to `main`. This exists so a negative result does not evaporate.

## What was tried

The follow-up PR #62 called for: stop the quantile band over-narrowing by
shrinking each leaf's interval spread toward the pooled band, with the shrink
weight set by the leaf's own row mass.

Pre-registered first (commit 1), measured second, killed third (commit 2).

## Why it cannot work

The leaf values are residual quantiles measured on the same rows that chose the
split, so they run optimistically tight. The pooled band is computed from those
same in-sample residuals, so it carries the same bias — shrinking toward a
target that shares your error cannot remove it.

Measured directly, on synthetic heteroscedastic data, three seeds, nominal 80%:

| pseudo-mass | test coverage | **train coverage** | pinball | tight/wide ratio |
|--:|--:|--:|--:|--:|
| off | 0.7555 | 0.8004 | 0.28507 | 0.129 |
| 20 (argued default) | 0.7586 | 0.8013 | 0.28454 | 0.127 |
| 2 000 | 0.7772 | 0.8023 | 0.28733 | 0.166 |
| 10 000 | 0.7888 | 0.8037 | 0.30820 | 0.420 |
| 100 000 | 0.7882 | 0.8019 | 0.33404 | 0.906 |

Train coverage sits at nominal at *every* setting, including fully pooled,
while test coverage never arrives. The whole defect is the in-sample versus
out-of-sample gap, which this mechanism has no purchase on. The three points of
coverage available at extreme settings are bought by flattening the band across
leaves — the width ratio between quiet and noisy regions walks from 0.129 (true
value 0.10) to 0.906, i.e. the head stops being conditional — at 8% to 17%
worse pinball. Every setting that helps coverage breaks two other ship gates.

The sweep was widened from the registered ±2x to four orders of magnitude
*before* any measurement, and that is recorded in the plan file, so "the
constant was too small" is not left as an unfalsifiable escape hatch.

## Outcome

Killed per the pre-registered clause; the `spread_smoothing` parameter was
removed rather than left in as a dead knob. Cost: three short screens, no
decision-tier run and no probe run — the tier-1 screen did its job.

Also records P16 (out-of-sample leaf values, the surviving half of the original
follow-up) as a draft, with the three costs its own pre-registration has to
answer.

## Generalizable

A shrinkage estimator only corrects the component of the error that *varies
across* the units being shrunk. Diagnose which component you have before
designing the correction: printing in-sample coverage beside out-of-sample
coverage answers it in one table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)