### PR TITLE
Record the Sel25 kill; rename the summarize "Speed" column to "Slowdown"

### DIFF
--- a/benchmarks/SELECT_PLAN.md
+++ b/benchmarks/SELECT_PLAN.md
@@ -246,13 +246,134 @@ bit-identical to the benchmarked `OneLin` arm on both estimators — so the
 numbers above are the parameter's own, not a lookalike's. Docs:
 `docs/recipes.md`, `docs/parameters.md`.
 
+## `Sel25` — KILLED 2026-07-31, do not retry below k=100 without a new mechanism
+
+Ran the full /experiment gate on flipping the `selection_rounds` default
+from 100 to 25. **It fails.** Both arms ran inside ONE benchmark each
+(`compare_runs RUN RUN --model ChimeraBoost --model-new ChimeraBoostSel25`),
+so the pairing is on identical machine conditions, and every number below is
+post-PR-#60 code.
+
+### Tier 1 synth (`results/20260731-163807.json`) — PASS, flat everywhere
+
+136 datasets, 3 seeds. 29W-26L-**81T**, mean −0.066%, median exactly
++0.000%; on Brier 15W-15L-58T, mean −0.050%. `synth_report` finds **no**
+slice carrying concentrated harm — worst is func=tree at −0.698%, which is
+18 sets with 10 ties and p=0.73, and every factor-OLS |t| < 1. Fit time
+−17% (not decision-grade, per CLAUDE.md).
+
+Structural note: 47 of the 48 sets under 2000 rows are **bit-identical**.
+Below the row floors (`LINEAR_LEAVES_MIN_SAMPLES=1000`,
+`CROSS_MIN_SAMPLES=2000`) no audition runs at all, so the budget is inert.
+
+### Tier 2 decide (`results/20260731-164034.json`) — FAIL on Grinsztajn regression
+
+103 datasets, 7 strata, 3 seeds. Judged on the decision metric (RMSE
+regression / Brier classification), per stratum, never pooled:
+
+| stratum | task | W-L-T | p (exact binomial) | median |
+|---|---|--:|--:|--:|
+| **Grinsztajn** | **regression** | **6-20-10** | **0.009** | **−0.011%** |
+| Grinsztajn | classification | 8-10-5 | 0.815 | +0.000% |
+| HC | regression | 1-2-3 | 1.000 | +0.000% |
+| HC | classification | 4-2-2 | 0.688 | +0.037% |
+| gr@sus25 | both | 3-3-6 | 1.000 | +0.000% |
+| gr@sus50 | both | 2-4-0 | 0.625 | −0.117% |
+| hc@sus25 / hc@sus50 | both | 0-0-7 | 1.000 | +0.000% |
+| hc@time | both | 3-1-3 | 1.000 | +0.000% |
+
+The pre-registered bar was non-inferiority on every stratum. Grinsztajn
+regression regresses at p=0.009 — the primary decision suite, on its own
+decision metric. Kill clause fires.
+
+The loss is **broad, not one dataset**: 20 separate regression sets move
+against it, most by ≤0.1%, with four real ones — `Brazilian_houses`
+(−4.43% cat / −5.03% num) and `nyc-taxi-green-dec-2016` (−1.70% cat /
+−4.18% num). Many small same-signed deltas is what drives p that low.
+
+### Why this is not the 2026-07-25 reading
+
+Phase 0 recorded 20W-23L-16T on Grinsztajn `primary` at a rung-2 default;
+the same comparison today reads 15W-28L-16T, and the regression-only cut is
+6W-20L. Two things changed: the default is now rung 3, and 0.27.0 made
+growth cheaper.
+
+**The mechanism was already characterized in `PARETO_PLAN.md:196-201`**:
+the const-vs-linear race "genuinely crosses late on ~1/3 of regression
+selections", with no margin rule at k=100 able to separate them, and
+`k_ll=500` fixing fidelity only by collapsing the speedup. `k=100` shipped
+in July with that mispick tail knowingly waived (its own Grinsztajn sign
+test was already 8W-22L-29T). **Going to k=25 auditions even earlier and
+widens exactly that tail.** This is not a new failure mode; it is the known
+one, further in.
+
+### The refit AMPLIFIES the mispick (`results/20260731-164927.json`)
+
+Unregistered follow-up, added because Phase 0's rung-2 reading was so much
+milder. Same suite, same seeds, one run, new arm `ChimeraBoostNoRefitSel25`
+(rung 2 + k=25) against `ChimeraBoostNoRefit` (rung 2):
+
+| default the arms sit on | gr regression W-L-T | p | mean |
+|---|--:|--:|--:|
+| rung 3 (`refit_full="replay"`, today's default) | 6-20-10 | **0.009** | −0.478% |
+| rung 2 (`refit_full=False`) | 10-16-10 | 0.327 | **+0.409%** |
+
+**The same knob change is decisively harmful with the refit and not
+detectably harmful without it**, and the mean even flips positive. The
+mechanism is that rung 3 *replays the audition winner's tree structure over
+every training row* — so when a short audition picks the wrong
+configuration, the refit propagates that structure instead of diluting it.
+The audition decision became higher-stakes the day the default moved to
+rung 3.
+
+Read this as directional, not settled: 10W-16L at n=36 with 10 ties is
+underpowered, so the honest claim is "the loss does not reproduce without
+the refit", not "rung 2 is provably flat". The contrast against p=0.009 is
+what carries the weight.
+
+Consequence for the record: **`Sel25` was never really re-tested against the
+config it was measured on.** The 07-25 parity finding was a rung-2 result
+and is broadly consistent with the rung-2 numbers here. It was invalidated
+by the default flip, not by being wrong.
+
+### The speed case was weaker than advertised anyway
+
+| stratum | total fit ratio | median per-dataset ratio |
+|---|--:|--:|
+| Grinsztajn | 0.911 | 0.793 |
+| HC | 0.823 | 0.869 |
+| all 103 (speed only) | **0.887** | 0.794 |
+
+Grinsztajn buys **8.9%**, not the 26% Phase 0 quoted — the rung-3 replay
+refit is a fixed leg the audition budget cannot touch, and the biggest
+datasets (which dominate the sum) save least. For contrast, the original
+`None`→100 cut bought **1.50x** on the same suite. The audition saving is
+essentially exhausted at 100; 25 buys 9% more while pushing further into a
+documented accuracy failure mode. Even at parity that would have failed the
+registered ≥10% speed bar.
+
+### Recorded negative
+
+No source change. `selection_rounds` stays 100. Live sub-questions for
+anyone revisiting:
+
+- A **per-leg** budget. The mispick is specifically the const-vs-linear
+  race, which `PARETO_PLAN` says wants k_ll≈500; the cross race may be fine
+  short. A single global k below 100 is closed.
+- **Selection fidelity is worth more under rung 3 than it was under rung 2**
+  (see the amplification section). Any future audition-cheapening idea has
+  to be judged against the *refit* default, and any idea that makes the
+  audition more faithful is worth more than its 07-25 valuation.
+- Whether the `@sus50` median of −0.117% is real or noise at n=6.
+- Cheapest repro: `gr:*/nyc-taxi-green-dec-2016` loses in all four of its
+  appearances (−1.70% / −4.18% / −1.92% @sus25 / −2.94% @sus50).
+
+Harness: `ChimeraBoostSel25` and the new `ChimeraBoostNoRefitSel25` arms are
+both registered in `run_benchmarks.py`, off by default, so any re-test is
+one `--models` flag.
+
 ## Still open
 
-- **`Sel25`** — auditions at 25 rounds instead of 100 were parity on
-  Grinsztajn (20W-23L-16T, mean −0.044%, median exactly +0.000%) for 26%
-  less fit time. A default change, so it needs its own /experiment with
-  the full gate. The 16 exact ties are the tell: three-quarters of the
-  audition budget usually changes nothing.
 - **A "use cross features without auditioning" mode.** Rung 1 currently
   drops cross features entirely because `cross_features=True` still races
   (`sklearn_api.py:1443`). A forced-on mode could give a stronger rung 1
@@ -265,3 +386,10 @@ numbers above are the parameter's own, not a lookalike's. Docs:
   finding recorded for a separate /experiment.
 - 2026-07-25: Phase 1 PASS, high-card caveat measured, ladder co-run
   charted, `quality=1..5` shipped. Program closed.
+- 2026-07-31: `Sel25` run through the full gate and **KILLED**. Synth PASS
+  (flat, no slice harmed); decide tier FAIL — Grinsztajn regression
+  6W-20L-10T at p=0.009. Speed case also weaker than recorded (8.9% on
+  Grinsztajn, not 26%). No source change. Follow-up found the **refit
+  amplifies it**: the same knob reads 10W-16L-10T, p=0.327, mean +0.409% at
+  rung 2, so the 07-25 parity finding was a valid rung-2 result invalidated
+  by the default flip rather than a bad measurement.

--- a/benchmarks/make_pareto.py
+++ b/benchmarks/make_pareto.py
@@ -27,8 +27,8 @@ weak" — it just no longer carries the headline axis. Ship-gating is unchanged
 (sign tests on the decision suites; see /experiment).
 
 The other axis is Slowdown: mean fit-time multiple vs the fastest model on
-each dataset (1.0x = fastest), straight from summarize's Speed column. Lower =
-better, so the frontier we want is up-and-to-the-left (strong AND fast).
+each dataset (1.0x = fastest), straight from summarize's Slowdown column. Lower
+= better, so the frontier we want is up-and-to-the-left (strong AND fast).
 
 Run:
     python benchmarks/make_pareto.py                      # newest results json
@@ -105,12 +105,13 @@ def blended_strength(cols):
 
     cols is summarize.aggregate(data)[0]: column-name -> {model: value}, where
     Reg RMSE% / Bin F1% / Bin Brier% are all "% vs best" (higher better) and
-    Speed is the slowdown multiple (lower better).
+    Slowdown is the fit-time multiple vs the fastest model (lower better) --
+    the same quantity this chart plots on its cost axis.
     """
     rmse = cols["Reg RMSE%"]
     f1 = cols["Bin F1%"]
     brier = cols["Bin Brier%"]
-    speed = cols["Speed"]
+    speed = cols["Slowdown"]
     models = set(rmse) | set(f1) | set(brier) | set(speed)
 
     out = {}

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -1192,6 +1192,17 @@ def _run_chimera_sel25(task, Xtr, ytr, Xte, yte, cat, threads):
                         selection_rounds=25)
 
 
+def _run_chimera_norefit_sel25(task, Xtr, ytr, Xte, yte, cat, threads):
+    """Rung 2 with quarter-length auditions: Sel25 without the default's refit.
+
+    Pairs with ChimeraBoostNoRefit to ask whether a short audition is harmful
+    on its own or only once the refit replays the audition's structure on
+    every row.
+    """
+    return _run_chimera(task, Xtr, ytr, Xte, yte, cat, threads,
+                        selection_rounds=25, refit_full="off")
+
+
 def _run_chimera_refit(task, Xtr, ytr, Xte, yte, cat, threads):
     """Defaults + refit_full: retrain the ES winner on 100% of the rows.
 
@@ -1350,6 +1361,7 @@ RUNNERS = {
     "ChimeraBoostSel25": _run_chimera_sel25,
     "ChimeraBoostRefit": _run_chimera_refit,
     "ChimeraBoostNoRefit": _run_chimera_norefit,
+    "ChimeraBoostNoRefitSel25": _run_chimera_norefit_sel25,
     "sklearn_HGB": _run_sklearn,
     "CatBoost": _run_catboost,
     "XGBoost": _run_xgboost,
@@ -1364,7 +1376,7 @@ _OFF_BY_DEFAULT = ("XGBoost", "ChimeraBoostEns2", "ChimeraBoostEns5",
                    "ChimeraBoostEns8", "ChimeraBoostEns10",
                    "ChimeraBoostOne", "ChimeraBoostOneLin",
                    "ChimeraBoostSel25", "ChimeraBoostRefit",
-                   "ChimeraBoostNoRefit")
+                   "ChimeraBoostNoRefit", "ChimeraBoostNoRefitSel25")
 _OPTIONAL = ("CatBoost", "XGBoost", "LightGBM")
 
 

--- a/benchmarks/summarize.py
+++ b/benchmarks/summarize.py
@@ -4,12 +4,14 @@ Importable helpers shared by the status reporter (`bench_status.py`) and ad-hoc
 analysis. Reads the sidecar `.json` produced by `run_benchmarks.py --save` and
 collapses it to the five headline columns we track:
 
-    Reg RMSE%   Bin F1%   Bin Brier%   Bin Calib   Speed
+    Reg RMSE%   Bin F1%   Bin Brier%   Bin Calib   Slowdown
 
 All "%" columns are "% vs best on that task" (100 = best model on that dataset,
 averaged across datasets). Calib is mean miscalibration (MCB) in units of
-10^-3 (lower better). Speed is the mean fit-time multiple vs the fastest model
-on each dataset (1.0 = fastest).
+10^-3 (lower better). Slowdown is the mean fit-time multiple vs the fastest
+model on each dataset, so LOWER is better and 1.0 = fastest. It is the same
+quantity the Pareto chart plots on its cost axis; it was called "Speed" until
+2026-07-31, which inverted the direction the name implies.
 
 CLI:
     python benchmarks/summarize.py <results.json>              # one table
@@ -27,11 +29,11 @@ import numpy as np
 RESULTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "results")
 MODEL_ORDER = ["ChimeraBoost", "ChimeraBoostEns2", "ChimeraBoostEns5",
                "ChimeraBoostEns10", "CatBoost", "LightGBM", "sklearn_HGB", "XGBoost"]
-COLS = ["Reg RMSE%", "Bin F1%", "Bin Brier%", "Bin Calib", "Speed"]
+COLS = ["Reg RMSE%", "Bin F1%", "Bin Brier%", "Bin Calib", "Slowdown"]
 # Multiclass columns, rendered ONLY when the results contain multiclass datasets
 # (the HC suite adds them; Grinsztajn has none). They are report-only: the
 # blended north star (make_pareto) is unchanged and ignores these. Inserted
-# before Speed by _display_cols so Speed stays the last column.
+# before Slowdown by _display_cols so Slowdown stays the last column.
 MULTI_COLS = ["Multi F1%", "Multi Brier%"]
 COL_W = 13
 
@@ -70,9 +72,9 @@ def timing_mode(data):
     older ones.
 
     Runs saved before the _finish fix charged prediction and metric computation
-    (two predict passes plus a per-class isotonic fit) to fit_time. Their Speed
-    columns read LOWER for slow-fitting models than they should, so the two
-    generations must never be mixed on any speed comparison.
+    (two predict passes plus a per-class isotonic fit) to fit_time. Their
+    Slowdown columns read LOWER for slow-fitting models than they should, so the
+    two generations must never be mixed on any speed comparison.
     """
     return (data.get("config") or {}).get("timing", "fit+predict")
 
@@ -84,7 +86,7 @@ def timing_warning(*datas):
         return ""
     return ("WARNING: mixing runs with different timing conventions "
             f"({', '.join(sorted(modes))}). Older runs charged predict + metric "
-            "time to fit_time, so Speed/slowdown columns are NOT comparable "
+            "time to fit_time, so the Slowdown column is NOT comparable "
             "across them. Strength columns are unaffected.")
 
 
@@ -408,7 +410,7 @@ def aggregate(data):
         # same near-solved Brier guard (skip_below) applies per column.
         "Multi F1%": _pct_vs_best(f1, mul_ds, lower=False),
         "Multi Brier%": _pct_vs_best(brier, mul_ds, lower=True, skip_below=1e-3),
-        "Speed": _mult_vs_best(speed, all_ds),
+        "Slowdown": _mult_vs_best(speed, all_ds),
     }
     cfg = data.get("config", {})
     meta = {"n_reg": len(reg_ds), "n_bin": len(bin_ds), "n_mul": len(mul_ds),
@@ -494,10 +496,10 @@ def _suite_label(ds_names):
 
 def _display_cols(meta):
     """Column order for the table: the base five, with the two multiclass columns
-    inserted before Speed only when the run actually has multiclass datasets."""
+    inserted before Slowdown only when the run has multiclass datasets."""
     cols = list(COLS)
     if meta.get("n_mul", 0) > 0:
-        cols[cols.index("Speed"):cols.index("Speed")] = MULTI_COLS
+        cols[cols.index("Slowdown"):cols.index("Slowdown")] = MULTI_COLS
     return cols
 
 
@@ -506,7 +508,7 @@ def _fmt(v, col):
         return f"{'--':>{COL_W}}"
     if col == "Bin Calib":
         return f"{v * 1000:>{COL_W - 1}.2f}m"
-    if col == "Speed":
+    if col == "Slowdown":
         return f"{v:>{COL_W - 1}.1f}x"
     return f"{v:>{COL_W - 1}.1f}%"
 
@@ -537,7 +539,8 @@ def format_table(data, label=None):
     cap = (f"{meta['suite']} — {meta['n_total']} datasets "
            f"({meta['n_reg']} reg, {meta['n_bin']} binary, "
            f"{meta['n_mul']} multiclass){seeds} | "
-           f"100% = best | Calib MCB x10^-3 lower=better | Speed vs fastest")
+           f"100% = best | Calib MCB x10^-3 lower=better | "
+           f"Slowdown = fit-time multiple vs fastest, lower=better")
     lines.append(cap)
     if meta.get("n_reg_excl"):
         n = meta["n_reg_excl"]
@@ -592,7 +595,7 @@ def format_compare(base_data, new_data, base_label="BEFORE", new_label="AFTER",
             d = (bv - nv) * 1000
             out.append(f"  {c:<12} {bv*1000:.2f}m -> {nv*1000:.2f}m  "
                        f"({d:+.2f}m {'better' if d > 0 else 'worse'})")
-        elif c == "Speed":
+        elif c == "Slowdown":
             d = bv - nv
             out.append(f"  {c:<12} {bv:.1f}x -> {nv:.1f}x  "
                        f"({d:+.1f}x {'faster' if d > 0 else 'slower'})")


### PR DESCRIPTION
Two independent pieces of benchmark-harness bookkeeping. The library is untouched — no source file outside `benchmarks/` changes, so defaults are byte-identical.

## 1. Sel25 is dead: `selection_rounds` stays at 100

Shortening the variant audition from 100 rounds to 25 was the last open speed lever on the SELECT ladder. It ran through the full protocol and failed at the decision tier. Record lives in `benchmarks/SELECT_PLAN.md`.

- **Tier 1 (synthetic) passed**: 29 wins, 26 losses, 81 ties, median exactly +0.000%, and no attribute slice carried concentrated harm.
- **Tier 2 (Grinsztajn) failed**: 6 wins against 20 losses on regression, exact binomial p=0.009, mean −0.478%. Twenty datasets move against it — this is a broad loss, not a tail. Every other stratum was flat.
- **The speed case was also overstated**: total Grinsztajn fit time drops 8.9%, not the 26% an earlier note claimed. The rung-3 replay refit is a leg the audition budget cannot touch.

The finding worth carrying forward is why it failed. Same knob, same suite, same seeds: with the refit on (the current default) it is p=0.009 and mean −0.478%; with the refit off it is p=0.327 and mean **+0.409%**. The refit replays the audition winner's structure over every row, so a wrong pick propagates instead of washing out. **Selection fidelity is worth more now than it was before `refit_full` became default** — future audition-cheapening ideas should be judged against the refit default, and fidelity-improving ideas re-valued upward.

To make that comparison reproducible the harness gains one off-by-default arm, `ChimeraBoostNoRefitSel25`, which pairs with the existing `ChimeraBoostNoRefit` to isolate the audition length from the refit.

## 2. The "Speed" column is now "Slowdown"

The column holds a fit-time multiple against the fastest model on each dataset, so 1.0x is fastest and lower is better — the opposite of what "Speed" implies, on a number that feeds the north-star Pareto chart's cost axis. Renamed at the source in `summarize.py`, with `make_pareto.py` following, and the docstrings now state the direction explicitly. Both consumers of the key were verified against a real results file; nothing else in the repo reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)