### PR TITLE
refit_members: reclaim the per-member data tax in the bagged path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to ChimeraBoost are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+### Added
+- **`refit_members` (opt-in, bagged path): each member now reclaims the rows it
+  never learned from.** A bag member trains on `max_samples` of the rows and
+  early-stops on its out-of-bag complement, so the full-data refit that helps a
+  single model never fired for it — every member's leaf values were estimated
+  from 80% of the data. With `refit_members=True` each member replays its own
+  tree structure against gradients from every row once early stopping is done.
+
+  Only the leaf values move: the splits stay exactly as each member's own
+  sample grew them, which is where a bag's diversity actually lives. Measured
+  over 10 datasets and 3 seeds, an 8-member bag improves on 10 of 10 datasets
+  (mean +1.02% on the primary metric), and the gain is largest for small bags
+  (+1.86% at 2 members) — which is what "each member is individually stronger"
+  predicts, since fewer members mean less averaging to hide weak leaf values.
+  A 5-member refit bag matches or beats a plain 8-member bag on 7 of 10.
+  Costs about 10% more fit time.
+
+  Regression and binary classification only; multiclass members would need a
+  full refit rather than a cheap structure replay, so the flag is ignored
+  there. Default `False`, and byte-identical to the previous release when off.
+
 ## [0.28.0] - 2026-07-31
 ### Fixed
 - **`ChimeraBoostQuantileRegressor` returned prediction intervals 2x to 10x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,21 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
   A 5-member refit bag matches or beats a plain 8-member bag on 7 of 10.
   Costs about 10% more fit time.
 
+  On the decision suites an 8-member bag improves in **every stratum**, with
+  perfect sweeps on the small-data ones — Grinsztajn 52W-7L (+0.500%),
+  Grinsztajn at a quarter of the rows **12W-0L** (+1.206%), at half the rows
+  **6W-0L**, high-card at a quarter of the rows 2W-0L (+1.452%). Brier moves
+  with it (Grinsztajn 20W-3L, +1.503%). Fit cost rises about 17%.
+
+  A **5-member bag with `refit_members` beats a plain 8-member bag on both
+  axes** — stronger in five of seven strata and 20% faster — so the cheapest
+  way to buy accuracy from bagging is now fewer, better members.
+
   Regression and binary classification only; multiclass members would need a
   full refit rather than a cheap structure replay, so the flag is ignored
-  there. Default `False`, and byte-identical to the previous release when off.
+  there. Default `False`, and byte-identical to the previous release when off:
+  single-model behaviour, the default configuration and the headline chart are
+  all untouched.
 
 ## [0.28.0] - 2026-07-31
 ### Fixed

--- a/benchmarks/BREAKTHROUGH_PLAN.md
+++ b/benchmarks/BREAKTHROUGH_PLAN.md
@@ -1,0 +1,233 @@
+# BREAKTHROUGH — hunting a significant Pareto move (opened 2026-08-01)
+
+Goal set by Nathan: a **significant** strength-vs-slowdown Pareto improvement.
+Not a hairline. Honest methods only — TabArena stays sealed, decisions run on
+synthetic → Grinsztajn + high-card, per-stratum sign tests.
+
+## Where we actually stand (baseline `results/20260731-142609.json`, 3 seeds)
+
+| model | Reg RMSE% | Bin Brier% | Slowdown |
+|---|---|---|---|
+| ChimeraBoost | 98.4 | 99.0 | 7.1x |
+| ChimeraBoostEns8 | 99.8 | 99.8 | 26.8x |
+| CatBoost | 95.2 | 94.4 | 15.3x |
+| LightGBM | 93.2 | 94.7 | 1.1x |
+| sklearn_HGB | 93.4 | 94.5 | 4.7x |
+
+Head-to-head (primary metric, near-solved excluded, 57 sets): we beat CatBoost
+46W-11L (80.7%), LightGBM 56W-1L (98.2%), HGB 55W-2L (96.5%). We **dominate
+CatBoost on both axes** — stronger and less than half the fit time.
+
+**Every remaining loss is noisy, low-dimensional binary classification**, gaps
+under 1.1% of Brier: bank-marketing (+1.02% vs CatBoost), credit (+0.47%),
+heloc (+0.43%), california (+0.28%), default-of-credit (+0.15%),
+Diabetes130US (+0.13%), plus electricity vs HGB (+1.07%) and road-safety vs
+HGB (+0.32%). Loss rate by suite: clf_num 16.7%, reg_num 3.5%, clf_cat 4.8%,
+reg_cat 6.7%. Not a size story (flat across size buckets), not a categorical
+story (cat suites lose LESS).
+
+Do not break: Brazilian_houses (−22% to −35% vs the field), covertype (−17% to
+−32%), sulfur, pol. Highly structured low-noise sets where ES + refit compound.
+
+---
+
+## FINDING 1 — the gap is RESOLUTION, not calibration. Calibration levers are dead. (2026-08-01)
+
+**Refuted before any code was written**, from the MCB term the harness already
+records (CORP isotonic gap = exactly what a perfect recalibration would recover).
+
+Mean miscalibration across the 23 classification sets:
+
+| model | mean MCB | mean Brier | MCB as share of Brier |
+|---|---|---|---|
+| **ChimeraBoost** | **0.002197** | 0.27089 | 1.07% |
+| CatBoost | 0.002310 | 0.27913 | 1.09% |
+| LightGBM | 0.002326 | 0.27813 | 1.02% |
+| sklearn_HGB | 0.002716 | 0.27989 | 1.19% |
+
+**We are already the best-calibrated model in the field.** And the decisive
+control: subtract each model's own MCB — i.e. perfectly recalibrate *both*
+sides — and the scoreboard does not move at all.
+
+| opponent | today | both sides perfectly recalibrated |
+|---|---|---|
+| CatBoost | 17W-6L (73.9%) | 17W-6L (73.9%) |
+| LightGBM | 22W-1L (95.7%) | 22W-1L (95.7%) |
+| sklearn_HGB | 21W-2L (91.3%) | 21W-2L (91.3%) |
+
+Every matchup keeps its sign. It is true that our MCB exceeds the deficit on 7
+of 9 losing matchups — but so does the opponent's, by the same margin, so the
+comparison is untouched. The remaining deficit lives in **resolution**
+(sharpness/structure), which no calibration map can reach.
+
+⇒ **KILLED**: the *story* that we lose because we are miscalibrated relative to
+the field. We are not. Any argument of the form "our gaps are calibration-scale,
+therefore a calibration lever closes them" is refuted by the table above.
+Script: `scratchpad/calib_headroom.py` (analysis only, no library change).
+
+### Correction (same day) — this answered the wrong question
+
+The counterfactual above recalibrates *both* sides, which is the right way to
+ask "are we relatively miscalibrated?" It is the wrong way to ask the shipping
+question, which is: **can we recover more of our own remaining 0.00220 while
+the opponents stay where they are?** Those have different answers.
+
+Our shipped map is a single scalar T minimizing validation log loss of
+`sigmoid(raw/T)` (`_fit_temperature`). That family has **no intercept**, so it
+cannot move the operating point of a skewed problem — on an 11%-positive set
+the only reachable maps fix p=0.5 at raw=0. Five of the nine losing binary
+matchups have gaps below 0.0006, i.e. under a third of our own MCB.
+
+So the reliability lane is narrowed, not closed, and the open question is
+specific: does a map *with* an intercept beat a scalar temperature
+out-of-sample? Probe: `benchmarks/probe_calibration_map.py` — compares raw /
+scalar-T(log loss) / scalar-T(Brier) / Platt / beta / isotonic, all fitted on a
+held-out calibration fold and scored on test, over the 7 losing binary sets and
+4 controls. Zero fit-time cost if it works, which makes it a pure Pareto move.
+
+### Verdict: the calibration lane is CLOSED. Nothing there, with or without an intercept.
+
+Mean improvement over the shipped scalar temperature (% of Brier, out-of-sample):
+
+| map | losing matchups | controls |
+|---|---|---|
+| Platt `sigmoid(a·raw+b)` | **−0.027%** (better on 3/7, median −0.001%) | +0.076% (2/4) |
+| beta (3-param) | −0.078% (1/7) | +0.060% (2/4) |
+| isotonic | −0.587% (0/7) | −1.813% (0/4) |
+
+Two things close this for good:
+
+1. **Adding the intercept buys nothing** — Platt is a wash, beta is worse, and
+   isotonic badly overfits the calibration fold.
+2. **The `raw` column is the real finding.** Uncalibrated probabilities score
+   essentially the same as the shipped temperature everywhere, and on
+   bank-marketing and credit they score *better*. Our temperature scaling is
+   already a near-no-op because the model comes out of the boosting loop
+   calibrated.
+
+And the mechanism argument dissolves on inspection of the suite: **every
+Grinsztajn binary set is class-balanced (the `pos%` column is 50.0% on all 11
+sets).** The intercept exists to move the operating point of a skewed problem;
+the skew is not there. The impl judge's supporting measurement used synthetic
+data at 11% positives — a real effect, in a regime our decision suites do not
+contain.
+
+⇒ **KILLED without implementation**: Platt, beta, isotonic, Brier-objective
+temperature, and the whole reliability lane. Combined with Finding 1, no
+calibration lever can move this benchmark.
+
+---
+
+## FINDING 2 — where does CatBoost's remaining edge come from?
+
+Since the features on the losing sets are numeric, CatBoost's ordered target
+statistics are irrelevant there. Its remaining distinctive default-ON machinery
+is two stochastic regularizers we have never implemented (architecture map
+degree-of-freedom #1, "no gain dithering/temperature"):
+
+- `random_strength=1` — Gaussian noise added to each split score before the
+  argmax, decaying with round index.
+- `bagging_temperature=1` — Bayesian bootstrap per-tree row weights
+  `w_i = u_i^(1/T)`, every row kept, mean weight 1.
+
+Hypothesis: our pure greedy argmax over ~p×128 noisy gain estimates suffers a
+winner's curse — the selected split is chosen partly for its noise and
+underdelivers out of sample — and this is worst exactly on low-signal data.
+
+**Probe (`probe_catboost_ablation.py`): ablate the OPPONENT.** Run CatBoost at
+defaults, without `random_strength`, without the bootstrap, and without both,
+on the 6 sets where it beats us plus 4 controls where we win comfortably.
+Using CatBoost as an oracle for its own mechanism costs one short benchmark.
+
+Pre-registered predictions:
+- **Hypothesis right**: disabling both costs CatBoost most of its edge on the
+  loss cluster while the controls move little ⇒ build the mechanism.
+- **Hypothesis wrong**: CatBoost's Brier barely moves and its edge survives
+  ⇒ **do not build it**; the edge lives elsewhere.
+
+### Verdict: HYPOTHESIS WRONG. Mechanism not built.
+
+Mean CatBoost edge over us on the 6-set loss cluster (% of our Brier, positive
+= CatBoost ahead), 3 seeds, paired identical splits:
+
+| CatBoost arm | mean edge, loss cluster | leads | mean edge, controls | leads |
+|---|---|---|---|---|
+| defaults | +0.624% | 5 of 6 | −15.31% | 0 of 4 |
+| `random_strength=0` | +0.493% | 3 of 6 | −16.51% | 0 of 4 |
+| `bootstrap_type="No"` | +0.558% | 5 of 6 | −14.82% | 0 of 4 |
+| both disabled | +0.269% | 3 of 6 | −15.61% | 0 of 4 |
+
+The controls validate the design: CatBoost is 15% behind us there regardless of
+arm (covertype −45.8%, pol −8.4%), so the probe is measuring a real, specific
+quantity and not a generic shift.
+
+Removing either regularizer alone changes essentially nothing, and the two
+ablations disagree about which one even helps. Removing both leaves CatBoost
+still ahead. Upper bound on what a perfect port could recover: 0.36% of Brier
+averaged over 6 datasets — roughly two matchup flips, about one win-rate point,
+and that assumes we reproduce CatBoost's regularizers exactly. Below the bar,
+and inside seed noise.
+
+⇒ **KILLED without implementation**: `random_strength`-style split-score
+dithering and Bayesian-bootstrap row weights as strength levers. This also
+retires the "winner's curse on greedy argmax" story as the explanation for the
+clf_num cluster. Probe: `benchmarks/probe_catboost_ablation.py` (resumable,
+`--table-only` reprints).
+
+Note the two candidates killed so far were the two that three independent
+ideation lenses ranked highest. Cheap probes earned their keep twice.
+
+---
+
+## FINDING 3 — the real blind spot: we have never measured the variant strata against the field
+
+Scanning every recent result file: **no run contains both external competitors
+and the `@sus25`/`@sus50`/`@time` variant strata.** The runs that carry those
+strata are ChimeraBoost-only A/B arms; the runs that carry competitors are
+base-stratum only.
+
+So our competitive standing is unknown in exactly the two regimes that matter
+most for the ambition:
+- **`@sus25`/`@sus50`** — the small-data regime, where tabular foundation
+  models beat GBDTs by the widest margin.
+- **`@time`** — distribution shift, which every random split is blind to and
+  which no GBDT default addresses.
+
+Chasing the 11 remaining CatBoost losses has a hard ceiling of about +8
+win-rate points against one opponent. A whole stratum is a bigger prize, and
+we cannot aim at it while blind.
+
+**Running: the decision tier with the external field on every stratum**
+(`--decide --seeds 3 --models ChimeraBoost CatBoost LightGBM sklearn_HGB
+--save`) — 103 datasets in 7 strata. This is the measurement that decides where
+to aim.
+
+---
+
+## The leverage arithmetic (from the judge panel, and it reframes the hunt)
+
+The decision run carries 177 matchups after the near-solved filter, so **one
+flip is worth 0.56 win-rate points** and the 2-point bar needs 3.5 flips. But
+**26 matchups sit inside a 0.25% band** (19 current wins, 7 current losses).
+
+That means a *broad* quarter-percent shift is worth roughly 4-5 points —
+secures the 19 near-ties we could lose and flips most of the 7 — while winning
+all 11 named CatBoost losses is worth about 6 points against one opponent and
+is capped there forever.
+
+**Broad small levers beat targeted ones on this axis.** This is the same
+flip-curve fact the refit_full program recorded (+0.25% broad primary ≈ +12pp
+win rate). Every candidate should now be judged on how broadly it moves the
+metric, not on how many named losses it targets — which is, in hindsight,
+exactly why the three killed candidates were doomed: all three were aimed at a
+named list of 6-11 datasets.
+
+---
+
+## Rules for this program
+- Every candidate gets a cheap decisive probe BEFORE library work where one
+  exists. Two candidates have already been killed at zero implementation cost.
+- Ship gate is unchanged: tier-1 synth screen, then
+  `--decide --seeds 3 --save` with per-stratum sign tests against
+  `results/20260731-164927.json` (library byte-identical to main).
+- Negative results get written down here in the same change that produces them.

--- a/benchmarks/BREAKTHROUGH_PLAN.md
+++ b/benchmarks/BREAKTHROUGH_PLAN.md
@@ -365,6 +365,28 @@ untouched, multiclass unchanged, `get_params`/`clone` roundtrip.
   touches the bagged rungs (quality 4/5), so single-model defaults and the
   headline chart are unchanged by construction.
 
+#### Tier 1 (synth screen) — PASS on primary, Brier a wash
+
+`results/20260801-022821.json`, both arms in one benchmark, 136 datasets,
+3 seeds.
+
+| judge | result |
+|---|---|
+| **primary** | **71W-27L-38T, mean +0.738%, median +0.035% — sign test PASS** |
+| Brier | 24W-30L-34T, mean **+0.181%**, median +0.000% — sign bar FAIL |
+
+Read honestly: the 34 Brier ties are exactly the 34 multiclass sets the arm
+gates off, so the binary Brier split is 24W-30L on 54 sets — a coin flip
+(p≈0.5), with a positive mean and a median of exactly zero. That is a wash,
+not the broad regression the kill rule names. The aggregate column moves the
+right way too: Bin Brier% 98.3 → **98.6**, Reg RMSE% 97.9 → **99.8**.
+
+Fit cost 4.4x → 4.8x = **+9%**, matching the probe's ~11% estimate.
+
+The Brier sign count is recorded as a **watch item** for tier 2 rather than
+waved away — the B1 lesson is that a classification-touching change can look
+fine on primary and cost Brier, and that the screen predicted it.
+
 ### C2 — the two-way depth race (6 vs 4), whose transfer question is now testable
 
 `A2_PLAN.md` measured this and then shelved it: **+0.398% mean, 16W-4L-16T,

--- a/benchmarks/BREAKTHROUGH_PLAN.md
+++ b/benchmarks/BREAKTHROUGH_PLAN.md
@@ -305,6 +305,41 @@ leaf-value effect) and `scaled` (rounds × 1/max_samples, the faithful
 refit_full analogue, which also grows a tail) — so a win is attributable.
 `benchmarks/probe_bag_member_refit.py`.
 
+#### Probe verdict: CONFIRMED, broadly and unanimously.
+
+10 datasets × 3 seeds, exactly paired (both arms replay the *same* fitted
+members, so only the leaf values differ). Improvement over the shipped bag:
+
+| arm | K=2 | K=3 | K=5 | K=8 |
+|---|---|---|---|---|
+| replay only | **+1.858%** (10/10) | +1.589% (10/10) | +0.920% (9/10) | **+1.023% (10/10)** |
+| replay + regrown tail | +2.262% (9/10) | +1.992% (9/10) | +1.389% (9/10) | **+1.527% (9/10)** |
+
+**The mechanism's own prediction held**: the gain is largest at small K
+(+1.86% at K=2 falling to +1.02% at K=8), which is what "each member is
+individually stronger" implies — with fewer members there is less averaging to
+paper over weak leaf values. If this were a diversity loss the sign would go
+the other way.
+
+Biggest movers are the structured regression sets (sulfur +4.2%,
+Brazilian_houses +2.1%, cpu_act +1.4%) plus electricity (+1.3% Brier); heloc is
+the only near-zero. Nothing regresses at K=8 in the replay-only arm.
+
+**And the Pareto question answers yes**: `refit@5` beats `plain@8` on 7 of 10
+datasets (mean +1.022%), so a five-member refit bag reaches the eight-member
+bag's strength — Ens8 is the 26.8x point on the headline chart.
+
+Cost, measured in the probe: one replay arm is roughly **11% of the member-fit
+time** (replaying a structure is far cheaper than growing it), so this is
+about +1.0-1.5% strength for ~1.1x on the bagged path.
+
+⇒ **Implemented** as `refit_members=False` (opt-in, byte-identical when off).
+`_refit_on_full` gained a `train_frac` override so a member scales its round
+budget by `max_samples` rather than `1 - validation_fraction`. Harness arms
+`ChimeraBoostEns8RM/Ens5RM/Ens3RM` let both variants run inside ONE benchmark,
+so the A/B pairing carries no machine-condition drift (the Sel25 precedent).
+Next: tier-1 synth screen, then the decide gate.
+
 ### C2 — the two-way depth race (6 vs 4), whose transfer question is now testable
 
 `A2_PLAN.md` measured this and then shelved it: **+0.398% mean, 16W-4L-16T,

--- a/benchmarks/BREAKTHROUGH_PLAN.md
+++ b/benchmarks/BREAKTHROUGH_PLAN.md
@@ -387,6 +387,77 @@ The Brier sign count is recorded as a **watch item** for tier 2 rather than
 waved away — the B1 lesson is that a classification-touching change can look
 fine on primary and cost Brier, and that the screen predicted it.
 
+#### Tier 2 (decide) — ALL GATES PASS
+
+`results/20260801-023724.json`, all five arms in ONE benchmark so the pairing
+carries no machine-condition drift. `ChimeraBoostEns8RM` vs `ChimeraBoostEns8`,
+per stratum, never pooled:
+
+| stratum | primary W-L-T | mean | median | Brier W-L | Brier mean |
+|---|---|---|---|---|---|
+| gr:base | **52W-7L-0T** | +0.500% | +0.175% | **20W-3L** | **+1.503%** |
+| gr:sus25 | **12W-0L-0T** | **+1.206%** | +0.304% | 4W-1L | +0.248% |
+| gr:sus50 | **6W-0L-0T** | +0.272% | +0.200% | 2W-0L | +0.736% |
+| hc:base | 7W-2L-5T | +0.395% | +0.035% | 2W-2L-4T | −0.002% |
+| hc:sus25 | 2W-0L-1T | +1.452% | +1.054% | 0W-0L-1T | +0.000% |
+| hc:sus50 | 1W-0L-1T | +0.032% | — | — | — |
+| hc:time | 3W-2L-2T | +1.020% | +0.000% | 0W-2L-2T | −0.102% |
+
+**Every stratum has a positive mean on the primary metric, and the two
+small-data Grinsztajn strata are perfect sweeps (12-0 and 6-0)** — the regime
+Finding 3 identified as our weakness. The three strata that miss the sign bar
+(hc:base, hc:sus50, hc:time) miss it because the bar counts ties against the
+change: hc:base is 7W-2L among decided datasets, hc:sus50 has n=2, hc:time
+n=7. None is a loss.
+
+**The tier-1 Brier watch item resolved positively**: on real data gr:base is
+20W-3L at +1.503% mean. The only negative anywhere is hc:time Brier at
+−0.102% on 4 datasets — inside noise.
+
+Fit cost 4.0x → 4.7x (+17%), a little above the probe's 11% and tier-1's 9%.
+
+#### And the Pareto claim: a 5-member refit bag beats the 8-member plain bag
+
+`ChimeraBoostEns5RM` vs `ChimeraBoostEns8` — **stronger and 20% cheaper**
+(3.2x vs 4.0x):
+
+| stratum | W-L-T | mean |
+|---|---|---|
+| gr:base | 44W-15L | +0.414% |
+| gr:sus25 | **11W-1L** | +0.982% |
+| gr:sus50 | 4W-2L | +0.021% |
+| hc:base | 7W-5L-2T | +0.235% |
+| hc:sus25 | **3W-0L** | +1.296% |
+| hc:time | 3W-4L | +0.848% (median −0.092%) |
+
+That is the frontier move: five refit members dominate eight plain ones on
+both axes. **`Ens3RM` does not** — at 2.1x it is a genuine wash against Ens8
+(35W-24L on base but 2W-10L on high-card, 4W-8L on sus25), so the honest claim
+stops at five members. The blended-% column flatters Ens3RM (99.4 vs 98.9);
+the sign test is the trustworthy reading and it says parity-at-half-cost, not
+dominance.
+
+### VERDICT: SHIP (opt-in)
+
+All pre-registered gates pass. Shipping as `refit_members=True`, opt-in,
+following the `refit_full` precedent where the default flip was Nathan's call.
+
+Honest scope: this moves the **bagged** rungs (quality 4/5) only. The default
+single-model configuration is byte-identical, so `images/pareto.png` and the
+README headline are unchanged by construction and need no refresh. What moves
+is the high-strength end of the frontier — and Ens8 is the blessed bagged mode.
+
+Open follow-ups, owned rather than implied:
+- **Default-flip decision for the bagged path** is Nathan's. The evidence for
+  it is strong (positive mean in all 7 strata, +17% fit).
+- **Multiclass** is gated off and stays a real gap: multiclass Brier is the one
+  column we lose to CatBoost (91.1 vs 98.8, Finding 3). Closing it needs a
+  replay path for vector-leaf trees, which does not exist.
+- **The small-data deficit is only partly addressed.** `refit_members` helps
+  the bagged rungs there (12-0 on sus25); the single-model small-data collapse
+  against CatBoost (81% → 50%/33%) is untouched, and remains the largest known
+  headroom in the project.
+
 ### C2 — the two-way depth race (6 vs 4), whose transfer question is now testable
 
 `A2_PLAN.md` measured this and then shelved it: **+0.398% mean, 16W-4L-16T,

--- a/benchmarks/BREAKTHROUGH_PLAN.md
+++ b/benchmarks/BREAKTHROUGH_PLAN.md
@@ -197,10 +197,67 @@ Chasing the 11 remaining CatBoost losses has a hard ceiling of about +8
 win-rate points against one opponent. A whole stratum is a bigger prize, and
 we cannot aim at it while blind.
 
-**Running: the decision tier with the external field on every stratum**
-(`--decide --seeds 3 --models ChimeraBoost CatBoost LightGBM sklearn_HGB
---save`) — 103 datasets in 7 strata. This is the measurement that decides where
-to aim.
+### Result (`results/20260801-013306.json`, 103 datasets, 3 seeds) — THE FINDING
+
+**Our win rate against CatBoost collapses as training data shrinks.** Head-to-head
+on the primary metric, per stratum:
+
+| stratum | n | vs CatBoost | vs LightGBM | vs sklearn_HGB |
+|---|--:|---|---|---|
+| gr:base | 57 | **81%** | 98% | 96% |
+| gr:sus25 | 12 | **50%** | 83% | 92% |
+| gr:sus50 | 6 | **33%** | 100% | 100% |
+| hc:base | 13 | **31%** | 92% | 83% |
+| hc:sus25 | 3 | **0%** | 100% | 100% |
+| hc:sus50 | 1 | **0%** | 100% | — |
+| hc:time | 7 | **43%** | 71% | 100% |
+
+Against LightGBM and HGB we stay dominant everywhere (71-100%). The collapse is
+**specific to CatBoost, and specific to small data** — which is exactly the
+regime CatBoost's ordered boosting was designed for, and exactly the regime
+tabular foundation models win.
+
+Aggregate over all 7 strata: **83.0% win rate on 283 matchups**, against 91.8%
+on the base stratum alone. One flip is now worth 0.35 points; 38 matchups sit
+inside the 0.25% near-tie band, 15 of them losses.
+
+The headline table also exposes the one column we do not lead:
+
+| | Reg RMSE% | Bin Brier% | **Multi Brier%** | Slowdown |
+|---|---|---|---|---|
+| ChimeraBoost | **99.3** | **99.7** | **91.1** | **4.8x** |
+| CatBoost | 97.5 | 96.7 | **98.8** | 44.6x |
+| LightGBM | 94.7 | 96.3 | 97.5 | 1.1x |
+| sklearn_HGB | 94.6 | 95.0 | 68.2 | 5.3x |
+
+We beat the field on regression and binary while fitting **9x faster than
+CatBoost** — and lose multiclass Brier by 7.7 points.
+
+### The mechanism, from the worst case
+
+`hc:eucalyptus@time` is our worst matchup anywhere (+56% vs CatBoost, +68% vs
+LightGBM) and alone drags the hc:time *mean* gap to +4.877% while its *median*
+is −1.215%. The per-seed numbers name the failure:
+
+| seed (temporal cut) | ChimeraBoost | CatBoost | LightGBM | sklearn_HGB |
+|---|---|---|---|---|
+| 0 | 0.530 | 0.543 | 0.545 | 0.648 |
+| 1 | 0.770 | 0.484 | 0.430 | 0.880 |
+| 2 | **1.030** (log loss 2.99) | 0.464 | 0.409 | **1.104** |
+
+We degrade monotonically across the cuts and end at Brier > 1.0 with log loss
+near 3 — **confidently wrong**, not merely weak. sklearn_HGB fails the same way
+on the same cuts; CatBoost and LightGBM stay flat. On the base variant of the
+same dataset (552 rows, no shift) the gap is only +3.17%, so it is small data
+*plus* shift that breaks us, and the failure mode is overconfidence.
+
+Caveat kept honest: eucalyptus has 736 total rows, so each temporal test window
+is small and these three numbers carry real variance. It is a pointer, not a
+sign test.
+
+⇒ **The program's target is now one regime, not a loss list: small data, and
+small data under distribution shift.** Base-stratum Grinsztajn is close to
+saturated at 91.8%; the headroom is in the strata nobody had measured.
 
 ---
 
@@ -267,6 +324,26 @@ worth building; if it is flat on `@sus*` too, the thread closes for good.
 Cheap first step, **no library change**: the harness already exposes
 `--chimera-depth 4`, and the run above provides a perfectly paired depth-6
 baseline on identical splits and seeds. One decide run answers it.
+
+### Deprioritized by cheap analysis: per-leaf capacity (semi-oblivious trees)
+
+The panel's highest-novelty structural idea was to break the oblivious
+constraint at the last level, on the theory that one shared split per level
+underfits against LightGBM's ~30 conditions per tree. The supporting anecdote
+was electricity, where we beat CatBoost by 5.8% yet lose to both leafwise
+libraries.
+
+Measuring it directly: **the best oblivious model still loses to a leafwise
+one on 2 of 57 datasets** — electricity (+1.07%) and road-safety (+0.32%) —
+and those two sets have **zero overlap** with the 11 where CatBoost beats us.
+Since ChimeraBoost and CatBoost are both oblivious, that pattern is the only
+clean signature of the architectural tax, and it is worth ~1.4% on two
+datasets total.
+
+So the oblivious constraint is not what is costing us; it is most of why we
+beat CatBoost while fitting in half the time. The panel's most expensive build
+(judged feasibility 3.0, the lowest of 15) would chase the smallest target.
+Not pursued. Script: `scratchpad/oblivious_tax.py`.
 
 ### C3 — the regressor has no effective min-leaf constraint (unprobed)
 

--- a/benchmarks/BREAKTHROUGH_PLAN.md
+++ b/benchmarks/BREAKTHROUGH_PLAN.md
@@ -338,7 +338,32 @@ about +1.0-1.5% strength for ~1.1x on the bagged path.
 budget by `max_samples` rather than `1 - validation_fraction`. Harness arms
 `ChimeraBoostEns8RM/Ens5RM/Ens3RM` let both variants run inside ONE benchmark,
 so the A/B pairing carries no machine-condition drift (the Sel25 precedent).
-Next: tier-1 synth screen, then the decide gate.
+
+Gated off for **multiclass**: there is no replay path there
+(`_refit_on_full` rebuilds a vector-leaf model from scratch), so a member
+refit would cost a whole extra fit per member instead of a cheap structure
+replay — a different trade, and one this evidence does not cover.
+
+896 existing tests pass; 10 new ones in `tests/test_refit_members.py` lock the
+contract: default off, off byte-identical, on engages, member structures
+preserved and mutually distinct, single-model and explicit-`eval_set` paths
+untouched, multiclass unchanged, `get_params`/`clone` roundtrip.
+
+#### Pre-registered gate (stated before the runs)
+
+- **Tier 1 (synth screen)**: `--synth --seeds 3 --models ChimeraBoost
+  ChimeraBoostEns8 ChimeraBoostEns8RM --save`, then
+  `compare_runs RUN RUN --model ChimeraBoostEns8 --model-new ChimeraBoostEns8RM`.
+  Also read the Brier column — the standing rule for any
+  classification-touching change.
+- **Tier 2 (decide)**: same arm pair on `--decide`, per-stratum sign tests,
+  never pooled.
+- **Kill rules**: a broad regression in either primary or Brier on any stratum;
+  or a fit-time cost materially above the ~1.1x the probe measured.
+- **Ship shape if it passes**: opt-in `refit_members=True`, following the
+  `refit_full` precedent where the default flip was Nathan's call. It only
+  touches the bagged rungs (quality 4/5), so single-model defaults and the
+  headline chart are unchanged by construction.
 
 ### C2 — the two-way depth race (6 vs 4), whose transfer question is now testable
 

--- a/benchmarks/BREAKTHROUGH_PLAN.md
+++ b/benchmarks/BREAKTHROUGH_PLAN.md
@@ -224,6 +224,61 @@ named list of 6-11 datasets.
 
 ---
 
+## Live candidates (broad by construction)
+
+### C1 — BAGREFIT: replay each bag member on the full row set
+
+`_fit_bagged` hands every member an explicit OOB `eval_set`, and
+`_refit_on_full` fires only when `auto_split` is True, so **no bag member has
+ever run the refit that is worth +2.1 points to the single model.** Each
+member's leaf values come from its 0.8n bag. REFIT_PLAN's "bag members have no
+data tax" holds for the ensemble (every row is in some member's bag) but not
+for any individual member.
+
+Why it should be net positive rather than a diversity loss: the LRE kill
+measured that bag lift is *structural* diversity and that leaf-level
+resampling buys nothing. Replay keeps each member's structure exactly as its
+own bag grew it and only re-estimates leaf values, so it should buy per-member
+strength at close to zero diversity cost.
+
+The prize is Pareto, not just strength: Ens8 is 99.8/99.8 at **26.8x**. If
+refit members let a smaller bag reach that, the frontier moves a long way.
+Probe sweeps K ∈ {2,3,5,8} with two arms — `refit` (same trees, pure
+leaf-value effect) and `scaled` (rounds × 1/max_samples, the faithful
+refit_full analogue, which also grows a tail) — so a win is attributable.
+`benchmarks/probe_bag_member_refit.py`.
+
+### C2 — the two-way depth race (6 vs 4), whose transfer question is now testable
+
+`A2_PLAN.md` measured this and then shelved it: **+0.398% mean, 16W-4L-16T,
+p=0.012, at 1.12–1.24x fit**, on the PMLB tune fold. It was left open with an
+explicit caveat — the gain concentrates on datasets under 2,000 rows
+(+1.09% to +7.41% there, collapsing to +0.1–0.6% above 4,900), the panel
+skewed small, and "the transfer question [is] unresolved". Registered as
+"Nathan's call whether that is worth the run."
+
+**The instrument that settles it did not exist then.** The decision tier now
+carries `@sus25`/`@sus50` — the same datasets cut to a quarter and a half of
+their training rows. That is precisely the small-data regime where depth 4 is
+claimed to win, measured on the suites we actually decide on. If depth 4 wins
+on `@sus*` and is neutral on base, the mechanism transfers and the race is
+worth building; if it is flat on `@sus*` too, the thread closes for good.
+
+Cheap first step, **no library change**: the harness already exposes
+`--chimera-depth 4`, and the run above provides a perfectly paired depth-6
+baseline on identical splits and seeds. One decide run answers it.
+
+### C3 — the regressor has no effective min-leaf constraint (unprobed)
+
+For squared error the Hessian is exactly 1 per row, so `min_child_weight=1.0`
+means "at least one sample" — the weakest possible veto, at every dataset
+size. The classifier fades one in via `_auto_min_child_weight`; the regressor
+pins 1.0 forever. The PMLB random-search study found `min_child_weight` is the
+one knob that transfers. Whether small-data regression wants a real min-leaf
+floor has never been tested, and `@sus*` regression is where it would show.
+
+---
+
 ## Rules for this program
 - Every candidate gets a cheap decisive probe BEFORE library work where one
   exists. Two candidates have already been killed at zero implementation cost.

--- a/benchmarks/BREAKTHROUGH_PLAN.md
+++ b/benchmarks/BREAKTHROUGH_PLAN.md
@@ -325,6 +325,79 @@ Cheap first step, **no library change**: the harness already exposes
 `--chimera-depth 4`, and the run above provides a perfectly paired depth-6
 baseline on identical splits and seeds. One decide run answers it.
 
+#### Verdict: the mechanism TRANSFERS. The sign flips exactly at data size.
+
+`results/20260801-020408.json` (depth 4) paired against `20260801-013306.json`
+(depth 6), same seeds and splits, per stratum:
+
+| stratum | n | depth4 W-L | mean | median | sign test |
+|---|--:|---|---|---|---|
+| gr:base | 57 | — | **−1.102%** | −0.239% | depth 6 |
+| hc:base | 13 | — | −0.331% | +0.000% | depth 6 |
+| **gr:sus25** | 12 | **9W-3L** | **+1.265%** | +0.138% | **PASS** |
+| gr:sus50 | 6 | 3W-3L | +0.214% | +0.008% | fail |
+| hc:sus25 | 3 | 2W-1L | +0.754% | +0.390% | pass (n=3) |
+| hc:sus50 | 2 | 1W-0L-1T | +0.078% | — | fail |
+| hc:time | 7 | 3W-4L | −0.542% | −0.044% | fail |
+
+**Every small-data stratum has a positive mean; every full-size stratum has a
+negative one.** Four independent strata agreeing in direction is the real
+signal — the individual sign tests are underpowered at n=2-6.
+
+Read honestly, though, the *magnitude* is modest and concentrated: gr:sus25's
+median is only +0.138%, and its +1.265% mean is carried by one dataset,
+`cpu_act@sus25` at **+16.41%** (RMSE 3.82 → 3.20). A uniform depth 4 is not
+shippable (base loses 1.1%); the registered answer is a per-dataset race, worth
+roughly the median.
+
+⇒ A2's transfer question is **ANSWERED**: small data does want less capacity,
+and the effect is real but small except where it is enormous. The enormous case
+is the interesting one — see below.
+
+---
+
+## FINDING 4 — the linear-leaf per-leaf guard is far too permissive on small data
+
+`cpu_act@sus25` is both our worst small-data loss (+26.55% vs CatBoost, +41.17%
+vs LightGBM) and the dataset depth 4 rescues by +16.41%. That says the failure
+is **over-capacity**, and the capacity is not where it first appears.
+
+`tree.py::_linear_leaf_fit` falls back to a constant leaf only when
+
+```
+if counts[l] < 2 * d or k == 0:      # d = 1 + k, k = numeric split features
+```
+
+so a leaf fits a **(1+k)-parameter ridge on as few as 2 rows per parameter**,
+with `linear_lambda` fixed at 1.0 regardless of leaf occupancy. At depth 6, k
+can be 6, so d=7 and the guard admits leaves of 14 rows.
+
+The arithmetic lines up with every observation:
+
+| | rows | leaves at d=6 | rows/leaf | rows/parameter |
+|---|--:|--:|--:|--:|
+| cpu_act (base) | 6,144 | 64 | ~96 | ~13.7 |
+| **cpu_act@sus25** | **1,536** | **64** | **~24** | **~3.4** |
+| cpu_act@sus25 at depth 4 | 1,536 | 16 | ~96 | ~13.7 |
+
+Full-size cpu_act is only +0.41% behind CatBoost; at a quarter of the rows it
+is +26.55% behind; and forcing depth 4 — which restores the same rows-per-leaf
+as full size — recovers +16.41%. The gate that decides whether linear leaves
+run at all (`LINEAR_LEAVES_MIN_SAMPLES=1000`) counts **total** rows and is
+blind to depth, so it cannot see this.
+
+If this is right it is a much better lever than the depth race: it is a guard
+correction rather than an extra audition, so it costs **nothing** in fit time,
+and it should help wherever `n / 2^depth` is small rather than on one dataset.
+
+Test running: `--decide --seeds 3 --models ChimeraBoost
+--chimera-no-linear-leaves`, paired against the depth-6 baseline. If forcing
+constant leaves recovers most of the small-data deficit, the diagnosis holds
+and the fix is to make the guard scale with the parameter count properly (and
+possibly to scale `linear_lambda` with leaf occupancy). If constant leaves are
+flat or worse, the blowup is the *selection* mispicking under a small
+validation fold — the Sel25 amplification story — and the fix is different.
+
 ### Deprioritized by cheap analysis: per-leaf capacity (semi-oblivious trees)
 
 The panel's highest-novelty structural idea was to break the oblivious

--- a/benchmarks/BREAKTHROUGH_PLAN.md
+++ b/benchmarks/BREAKTHROUGH_PLAN.md
@@ -390,13 +390,38 @@ If this is right it is a much better lever than the depth race: it is a guard
 correction rather than an extra audition, so it costs **nothing** in fit time,
 and it should help wherever `n / 2^depth` is small rather than on one dataset.
 
-Test running: `--decide --seeds 3 --models ChimeraBoost
---chimera-no-linear-leaves`, paired against the depth-6 baseline. If forcing
-constant leaves recovers most of the small-data deficit, the diagnosis holds
-and the fix is to make the guard scale with the parameter count properly (and
-possibly to scale `linear_lambda` with leaf occupancy). If constant leaves are
-flat or worse, the blowup is the *selection* mispicking under a small
-validation fold — the Sel25 amplification story — and the fix is different.
+Test: `--decide --seeds 3 --models ChimeraBoost --chimera-no-linear-leaves`
+(`results/20260801-020906.json`), paired against the depth-6 baseline.
+
+### Verdict: REFUTED. Linear leaves are not the culprit — they are load-bearing.
+
+Forcing constant leaves is worse in every stratum, small data included:
+
+| stratum | noLL W-L | mean |
+|---|---|---|
+| gr:base | 15W-43L | −0.601% |
+| hc:base | 3W-4L-7T | −1.420% |
+| gr:sus25 | 4W-7L | −0.453% |
+| gr:sus50 | 3W-2L-1T | −0.033% |
+| hc:sus25 | 0W-1L-2T | −4.863% |
+| hc:time | 1W-2L-4T | −5.369% |
+
+And the diagnostic dataset settles it: on `cpu_act@sus25` forcing constant
+leaves is **worse** (RMSE 3.8236 → 3.8639, −1.05%). Linear leaves are *helping*
+there, so the per-leaf ridge is not what blows up. `hc:employee_salaries`
+depends on them enormously (−16.6% base, −14.6% @sus25, −37.8% @time without).
+
+⇒ **KILLED without shipping**: the per-leaf sample-guard theory, and any
+"linear leaves overfit small data" variant. The parameterization I had staged
+for it was reverted rather than left in the tree as unused surface.
+
+**What this leaves standing is simpler and better evidenced:** the small-data
+deficit is plain *tree* over-capacity, independent of leaf model — which is
+exactly what the depth-4 experiment measured directly. cpu_act prefers depth 4
+at **both** sizes (+3.27% at full size, +16.41% at sus25), so capacity
+preference is a per-dataset property, not a size threshold. That is an argument
+for measuring it per dataset (a race) rather than predicting it from n — and it
+is also why the historical size-rule attempts failed.
 
 ### Deprioritized by cheap analysis: per-leaf capacity (semi-oblivious trees)
 

--- a/benchmarks/probe_bag_member_refit.py
+++ b/benchmarks/probe_bag_member_refit.py
@@ -123,7 +123,8 @@ def _replay_member(member, X_full, y_full, cat_features, task):
         replay_donor=donor,
     )
     loss = "Logloss" if task != "regression" else w.loss_name
-    b = GradientBoosting(loss=loss, **kw)
+    lkw = dict(getattr(w, "loss_kwargs", {}) or {})
+    b = GradientBoosting(loss=loss, loss_kwargs=lkw, **kw)
     b.fit(X_full, y_full, cat_features=cat_features)
     return b
 

--- a/benchmarks/probe_bag_member_refit.py
+++ b/benchmarks/probe_bag_member_refit.py
@@ -96,14 +96,28 @@ def _score(task, y, pred):
     return float(np.mean(2.0 * (pred - y) ** 2))
 
 
-def _replay_member(member, X_full, y_full, cat_features, task):
+def _replay_member(member, X_full, y_full, cat_features, task, scale_rounds):
     """Rebuild this member's booster by replaying its splits against full-data
-    gradients. Mirrors _refit_on_full's donor path: same rounds, pinned learning
-    rate, donor binner adopted, no early stopping."""
+    gradients. Mirrors _refit_on_full's donor path: pinned learning rate, donor
+    binner adopted, no early stopping.
+
+    ``scale_rounds`` separates the two mechanisms that _refit_on_full bundles.
+    The booster replays donor tree m while m < len(donor), and GROWS a fresh
+    tree after that, so a round count above the donor's length is a
+    replay-prefix + regrow-tail hybrid:
+      False - exactly len(donor) rounds: pure leaf-value effect, same trees.
+      True  - ceil(len(donor)/max_samples) rounds: the faithful refit_full
+              analogue, which also buys the member extra trees for the extra
+              rows. Any gain here that `False` does not show is the tail, not
+              the leaves.
+    """
     w = member.model_
     donor = (w.trees_, w.prep_)
+    rounds = len(w.trees_)
+    if scale_rounds:
+        rounds = min(int(np.ceil(len(w.trees_) / MAX_SAMPLES)), MAX_ITERS)
     kw = dict(
-        n_estimators=len(w.trees_),
+        n_estimators=rounds,
         learning_rate=float(w.lr_),
         depth=w.depth,
         l2_leaf_reg=w.l2_leaf_reg,
@@ -179,7 +193,7 @@ def main():
 
             seeds_k = np.random.default_rng(seed).integers(
                 0, 2**31 - 1, size=K_MAX)
-            plain_preds, refit_preds = [], []
+            plain_preds, refit_preds, scaled_preds = [], [], []
             t0 = time.time()
             t_refit = 0.0
             for mseed in seeds_k:
@@ -196,29 +210,36 @@ def main():
                 temp = getattr(m, "temperature_", 1.0)
                 plain_preds.append(
                     _member_predict(m.model_, Xte, task, temp))
-                # --- the arm under test: replay this member on ALL train rows
+                # --- the arms under test: replay this member on ALL train rows
                 tr = time.time()
                 y_rep = (ytr_fit if task == "regression"
                          else (ytr_fit == classes[1]).astype(np.float64))
-                b = _replay_member(m, Xtr, y_rep, cat, task)
-                t_refit += time.time() - tr
+                b = _replay_member(m, Xtr, y_rep, cat, task, scale_rounds=False)
                 refit_preds.append(_member_predict(b, Xte, task, temp))
+                b2 = _replay_member(m, Xtr, y_rep, cat, task, scale_rounds=True)
+                scaled_preds.append(_member_predict(b2, Xte, task, temp))
+                t_refit += time.time() - tr
             total_s = time.time() - t0
 
             rec = {"dataset": key, "seed": seed, "task": task, "n_train": int(n),
-                   "fit_s": total_s, "refit_s": t_refit, "plain": {}, "refit": {}}
+                   "fit_s": total_s, "refit_s": t_refit,
+                   "plain": {}, "refit": {}, "scaled": {}}
             for K in KS:
                 rec["plain"][str(K)] = _score(
                     task, yte01, np.mean(plain_preds[:K], axis=0))
                 rec["refit"][str(K)] = _score(
                     task, yte01, np.mean(refit_preds[:K], axis=0))
+                rec["scaled"][str(K)] = _score(
+                    task, yte01, np.mean(scaled_preds[:K], axis=0))
             os.makedirs(os.path.dirname(RESULTS), exist_ok=True)
             with open(RESULTS, "a", encoding="utf-8") as f:
                 f.write(json.dumps(rec) + "\n")
-            g8 = 100.0 * (rec["plain"]["8"] - rec["refit"]["8"]) / rec["plain"]["8"]
-            g2 = 100.0 * (rec["plain"]["2"] - rec["refit"]["2"]) / rec["plain"]["2"]
+            def _g(arm, K):
+                p = rec["plain"][str(K)]
+                return 100.0 * (p - rec[arm][str(K)]) / p
             print(f"  s{seed} {total_s:6.1f}s (replay {t_refit:5.1f}s)  "
-                  f"K=2 {g2:+.3f}%   K=8 {g8:+.3f}%")
+                  f"refit K2 {_g('refit', 2):+.3f}% K8 {_g('refit', 8):+.3f}%  |  "
+                  f"scaled K2 {_g('scaled', 2):+.3f}% K8 {_g('scaled', 8):+.3f}%")
     table()
 
 
@@ -229,66 +250,78 @@ def table():
             if line.strip():
                 rows.append(json.loads(line))
     from collections import defaultdict
+    ARMS = ["refit", "scaled"]
     agg = defaultdict(lambda: defaultdict(list))
     task_of = {}
     for r in rows:
         task_of[r["dataset"]] = r["task"]
         for K in KS:
             agg[r["dataset"]][("plain", K)].append(r["plain"][str(K)])
-            agg[r["dataset"]][("refit", K)].append(r["refit"][str(K)])
-
-    print("\n" + "=" * 116)
-    print("BAG MEMBER REFIT — % improvement from replaying each member on all train rows")
-    print("  positive = refit better. Same member structures in both arms, so this is exactly paired.")
-    print("=" * 116)
-    print(f"{'dataset':34s}{'task':7s}" + "".join(f"{'K=' + str(K):>12s}" for K in KS))
+            for arm in ARMS:
+                if arm in r:
+                    agg[r["dataset"]][(arm, K)].append(r[arm][str(K)])
 
     gains = defaultdict(list)
-    for ds in DATASETS:
-        if ds not in agg:
-            continue
-        line = f"{ds.replace('gr:', '')[:34]:34s}{task_of[ds][:6]:7s}"
-        for K in KS:
-            p = float(np.mean(agg[ds][("plain", K)]))
-            q = float(np.mean(agg[ds][("refit", K)]))
-            g = 100.0 * (p - q) / p
-            gains[K].append(g)
-            line += f"{g:+11.3f}%"
-        print(line)
+    for arm, label in (("refit", "REPLAY ONLY (same trees, leaf values from all rows)"),
+                       ("scaled", "REPLAY + REGROWN TAIL (rounds scaled by 1/max_samples)")):
+        print("\n" + "=" * 116)
+        print(f"BAG MEMBER {label}")
+        print("  % improvement over the shipped member. Same member structures in "
+              "every arm, so this is exactly paired; positive = better.")
+        print("=" * 116)
+        print(f"{'dataset':34s}{'task':7s}"
+              + "".join(f"{'K=' + str(K):>12s}" for K in KS))
+        for ds in DATASETS:
+            if ds not in agg or not agg[ds].get((arm, KS[0])):
+                continue
+            line = f"{ds.replace('gr:', '')[:34]:34s}{task_of[ds][:6]:7s}"
+            for K in KS:
+                p = float(np.mean(agg[ds][("plain", K)]))
+                q = float(np.mean(agg[ds][(arm, K)]))
+                g = 100.0 * (p - q) / p
+                gains[(arm, K)].append(g)
+                line += f"{g:+11.3f}%"
+            print(line)
 
     print("\n" + "=" * 116)
     print("VERDICT — mean improvement by bag size")
     print("=" * 116)
-    for K in KS:
-        g = gains[K]
-        if g:
-            print(f"  K={K}: mean {np.mean(g):+7.3f}%   median {np.median(g):+7.3f}%   "
-                  f"better on {sum(1 for x in g if x > 0)}/{len(g)} datasets")
+    for arm in ARMS:
+        for K in KS:
+            g = gains[(arm, K)]
+            if g:
+                print(f"  {arm:7s} K={K}: mean {np.mean(g):+7.3f}%   "
+                      f"median {np.median(g):+7.3f}%   "
+                      f"better on {sum(1 for x in g if x > 0)}/{len(g)} datasets")
+        print()
 
     # Pareto question: does a small refit bag match a big plain bag?
-    print("\n" + "=" * 116)
-    print("PARETO — can a SMALL refit bag match a LARGE plain bag?")
-    print("  each cell: refit@K vs plain@8, % better (positive = refit@K wins at a fraction of the cost)")
     print("=" * 116)
-    print(f"{'dataset':34s}" + "".join(f"{'refit' + str(K) + ' vs p8':>15s}" for K in KS))
-    tot = defaultdict(list)
-    for ds in DATASETS:
-        if ds not in agg:
-            continue
-        p8 = float(np.mean(agg[ds][("plain", 8)]))
-        line = f"{ds.replace('gr:', '')[:34]:34s}"
+    print("PARETO — can a SMALL refit bag match plain@8 (26.8x on the headline chart)?")
+    print("  each cell: arm@K vs plain@8, % better. Positive = matches or beats the "
+          "big bag at a fraction of the cost.")
+    print("=" * 116)
+    for arm in ARMS:
+        print(f"\n-- {arm} " + "-" * (110 - len(arm)))
+        print(f"{'dataset':34s}"
+              + "".join(f"{arm + str(K) + ' vs p8':>15s}" for K in KS))
+        tot = defaultdict(list)
+        for ds in DATASETS:
+            if ds not in agg or not agg[ds].get((arm, KS[0])):
+                continue
+            p8 = float(np.mean(agg[ds][("plain", 8)]))
+            line = f"{ds.replace('gr:', '')[:34]:34s}"
+            for K in KS:
+                q = float(np.mean(agg[ds][(arm, K)]))
+                d = 100.0 * (p8 - q) / p8
+                tot[K].append(d)
+                line += f"{d:+14.3f}%"
+            print(line)
         for K in KS:
-            q = float(np.mean(agg[ds][("refit", K)]))
-            d = 100.0 * (p8 - q) / p8
-            tot[K].append(d)
-            line += f"{d:+14.3f}%"
-        print(line)
-    print()
-    for K in KS:
-        d = tot[K]
-        if d:
-            print(f"  refit@{K} vs plain@8: mean {np.mean(d):+7.3f}%   "
-                  f"wins on {sum(1 for x in d if x > 0)}/{len(d)} datasets")
+            d = tot[K]
+            if d:
+                print(f"  {arm}@{K} vs plain@8: mean {np.mean(d):+7.3f}%   "
+                      f"wins on {sum(1 for x in d if x > 0)}/{len(d)} datasets")
 
 
 if __name__ == "__main__":

--- a/benchmarks/probe_bag_member_refit.py
+++ b/benchmarks/probe_bag_member_refit.py
@@ -1,0 +1,297 @@
+"""Probe: should each BAGGED MEMBER replay its structure on the full dataset?
+
+MECHANISM HYPOTHESIS (pre-registered 2026-08-01, before any results):
+
+`refit_full="replay"` is default-ON for the single model and was worth +2.1
+points of Grinsztajn RMSE% (96.3 -> 98.4): learn the structure on the 80%
+early-stopping split, then replay those splits against full-data gradients so
+the leaf values see every row.
+
+Bag members never get this. `_fit_bagged` hands each member an explicit
+`eval_set` (its OOB rows), and `_refit_on_full` fires only when
+`auto_split` is True — which requires `eval_set is None`. So every member's
+leaf values are estimated from its 0.8n bag and nothing reclaims the rest.
+
+REFIT_PLAN.md line 100 says "Ens8/bag members have no data tax". That is true
+of the ENSEMBLE (every row is in some member's bag) but not of any INDIVIDUAL
+member: 20% of the dataset contributes to no leaf value in that member.
+
+Why this should be net positive rather than a diversity loss: the LRE
+post-mortem measured that bag lift is STRUCTURAL diversity, and that leaf-only
+resampling buys nothing ("capture -0.14, bag lift is structural diversity").
+Replay keeps each member's structure exactly as its own bag grew it — the
+diverse part — and only re-estimates leaf values on all rows. So it should buy
+per-member strength at close to zero diversity cost. If the LRE finding is
+right, this is the asymmetry to exploit; if diversity really does live in the
+leaves after all, this probe will show it as a wash or a loss.
+
+THE PRIZE IS PARETO, NOT JUST STRENGTH. Ens8 sits at 99.8/99.8 but costs 26.8x.
+If refit members let a SMALLER bag reach the same strength, that is a large
+frontier move (26.8x -> ~10x at equal strength). So the probe sweeps K.
+
+ARMS (identical member structures within a seed — the refit arm replays the
+SAME fitted members, so the comparison is exactly paired):
+  plain@K  - average K members as the library builds them today
+  refit@K  - same K members, each replayed on all n training rows, averaged
+
+PREDICTIONS:
+  If the mechanism is real: refit@K beats plain@K at every K, the gap is
+  largest at small K (fewer members = less averaging to hide weak leaves), and
+  refit@3 is competitive with plain@8.
+  If diversity lives in the leaves: refit@K is flat-to-worse and the whole idea
+  dies here, at the cost of one probe and no library change.
+
+Primary metric: RMSE (regression) / Brier (classification).
+Resumable JSONL; `--table-only` reprints.
+"""
+
+import json
+import os
+import sys
+import time
+
+import numpy as np
+from sklearn.model_selection import train_test_split
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from research import datasets as rdata  # noqa: E402
+
+import chimeraboost  # noqa: E402
+from chimeraboost import ChimeraBoostClassifier, ChimeraBoostRegressor  # noqa: E402
+from chimeraboost.booster import GradientBoosting  # noqa: E402
+from chimeraboost.sklearn_api import (_member_sample_indices,  # noqa: E402
+                                      _member_oob_eval_indices)
+
+RESULTS = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                       "results", "probe-bagrefit.jsonl")
+SEEDS = (0, 1, 2)
+MAX_ITERS = 2000
+PATIENCE = 50
+K_MAX = 8
+KS = (2, 3, 5, 8)
+MAX_SAMPLES = 0.8          # the shipped member draw
+MEMBER_LR = 0.15           # shipped bagged-member defaults (BAGGING_PLAN B3)
+MEMBER_COLSAMPLE = 0.85
+
+DATASETS = [
+    # regression, spanning the sizes where bagging is used
+    "gr:reg_num/cpu_act",
+    "gr:reg_num/sulfur",
+    "gr:reg_num/Brazilian_houses",
+    "gr:reg_num/elevators",
+    "gr:reg_num/wine_quality",
+    # binary
+    "gr:clf_num/bank-marketing",
+    "gr:clf_num/heloc",
+    "gr:clf_num/electricity",
+    "gr:clf_num/MagicTelescope",
+    "gr:clf_num/credit",
+]
+
+
+def _score(task, y, pred):
+    if task == "regression":
+        return float(np.sqrt(np.mean((y - pred) ** 2)))
+    # binary Brier in the harness's K=2 sum form
+    return float(np.mean(2.0 * (pred - y) ** 2))
+
+
+def _replay_member(member, X_full, y_full, cat_features, task):
+    """Rebuild this member's booster by replaying its splits against full-data
+    gradients. Mirrors _refit_on_full's donor path: same rounds, pinned learning
+    rate, donor binner adopted, no early stopping."""
+    w = member.model_
+    donor = (w.trees_, w.prep_)
+    kw = dict(
+        n_estimators=len(w.trees_),
+        learning_rate=float(w.lr_),
+        depth=w.depth,
+        l2_leaf_reg=w.l2_leaf_reg,
+        max_bins=w.max_bins,
+        subsample=w.subsample,
+        colsample=w.colsample,
+        min_child_weight=w.min_child_weight,
+        early_stopping_rounds=None,
+        thread_count=w.thread_count,
+        random_state=w.random_state,
+        cat_combinations=w.cat_combinations,
+        leaf_estimation_iterations=w.leaf_estimation_iterations,
+        linear_leaves=w.linear_leaves,
+        linear_lambda=w.linear_lambda,
+        cross_pairs=w.cross_pairs,
+        quantize_gradients=w.quantize_gradients,
+        replay_donor=donor,
+    )
+    loss = "Logloss" if task != "regression" else w.loss_name
+    b = GradientBoosting(loss=loss, **kw)
+    b.fit(X_full, y_full, cat_features=cat_features)
+    return b
+
+
+def _member_predict(booster, X, task, temperature=1.0):
+    raw = booster.predict_raw(X)
+    if task == "regression":
+        return np.asarray(raw, dtype=np.float64).ravel()
+    p = booster.loss_.transform(np.asarray(raw, dtype=np.float64).ravel()
+                               / temperature)
+    return p
+
+
+def _done():
+    seen = set()
+    if os.path.exists(RESULTS):
+        with open(RESULTS, "r", encoding="utf-8") as f:
+            for line in f:
+                if line.strip():
+                    try:
+                        r = json.loads(line)
+                        seen.add((r["dataset"], r["seed"]))
+                    except Exception:
+                        pass
+    return seen
+
+
+def main():
+    print(f"chimeraboost from {chimeraboost.__file__}")
+    done = _done()
+    for key in DATASETS:
+        X, y, cat, task = rdata.load(key)
+        if task == "multiclass":
+            print(f"skip {key}: multiclass replay is not wired")
+            continue
+        print(f"\n=== {key}  n={len(y)}  p={X.shape[1]}  task={task}")
+        for seed in SEEDS:
+            if (key, seed) in done:
+                continue
+            Xtr, Xte, ytr, yte = train_test_split(
+                X, y, test_size=0.2, random_state=seed,
+                stratify=(y if task != "regression" else None))
+            n = len(ytr)
+            classes = None
+            if task != "regression":
+                classes = np.unique(ytr)
+                yte01 = (yte == classes[1]).astype(np.float64)
+                ytr_fit = ytr
+            else:
+                yte01 = yte.astype(np.float64)
+                ytr_fit = ytr
+
+            seeds_k = np.random.default_rng(seed).integers(
+                0, 2**31 - 1, size=K_MAX)
+            plain_preds, refit_preds = [], []
+            t0 = time.time()
+            t_refit = 0.0
+            for mseed in seeds_k:
+                idx = _member_sample_indices(n, MAX_SAMPLES, int(mseed), None)
+                oob = _member_oob_eval_indices(idx, n, None)
+                Est = (ChimeraBoostRegressor if task == "regression"
+                       else ChimeraBoostClassifier)
+                m = Est(n_estimators=MAX_ITERS, early_stopping_rounds=PATIENCE,
+                        learning_rate=MEMBER_LR, colsample=MEMBER_COLSAMPLE,
+                        random_state=int(mseed))
+                m._is_bag_member = True
+                m.fit(Xtr[idx], ytr_fit[idx], cat_features=cat,
+                      eval_set=(Xtr[oob], ytr_fit[oob]))
+                temp = getattr(m, "temperature_", 1.0)
+                plain_preds.append(
+                    _member_predict(m.model_, Xte, task, temp))
+                # --- the arm under test: replay this member on ALL train rows
+                tr = time.time()
+                y_rep = (ytr_fit if task == "regression"
+                         else (ytr_fit == classes[1]).astype(np.float64))
+                b = _replay_member(m, Xtr, y_rep, cat, task)
+                t_refit += time.time() - tr
+                refit_preds.append(_member_predict(b, Xte, task, temp))
+            total_s = time.time() - t0
+
+            rec = {"dataset": key, "seed": seed, "task": task, "n_train": int(n),
+                   "fit_s": total_s, "refit_s": t_refit, "plain": {}, "refit": {}}
+            for K in KS:
+                rec["plain"][str(K)] = _score(
+                    task, yte01, np.mean(plain_preds[:K], axis=0))
+                rec["refit"][str(K)] = _score(
+                    task, yte01, np.mean(refit_preds[:K], axis=0))
+            os.makedirs(os.path.dirname(RESULTS), exist_ok=True)
+            with open(RESULTS, "a", encoding="utf-8") as f:
+                f.write(json.dumps(rec) + "\n")
+            g8 = 100.0 * (rec["plain"]["8"] - rec["refit"]["8"]) / rec["plain"]["8"]
+            g2 = 100.0 * (rec["plain"]["2"] - rec["refit"]["2"]) / rec["plain"]["2"]
+            print(f"  s{seed} {total_s:6.1f}s (replay {t_refit:5.1f}s)  "
+                  f"K=2 {g2:+.3f}%   K=8 {g8:+.3f}%")
+    table()
+
+
+def table():
+    rows = []
+    with open(RESULTS, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                rows.append(json.loads(line))
+    from collections import defaultdict
+    agg = defaultdict(lambda: defaultdict(list))
+    task_of = {}
+    for r in rows:
+        task_of[r["dataset"]] = r["task"]
+        for K in KS:
+            agg[r["dataset"]][("plain", K)].append(r["plain"][str(K)])
+            agg[r["dataset"]][("refit", K)].append(r["refit"][str(K)])
+
+    print("\n" + "=" * 116)
+    print("BAG MEMBER REFIT — % improvement from replaying each member on all train rows")
+    print("  positive = refit better. Same member structures in both arms, so this is exactly paired.")
+    print("=" * 116)
+    print(f"{'dataset':34s}{'task':7s}" + "".join(f"{'K=' + str(K):>12s}" for K in KS))
+
+    gains = defaultdict(list)
+    for ds in DATASETS:
+        if ds not in agg:
+            continue
+        line = f"{ds.replace('gr:', '')[:34]:34s}{task_of[ds][:6]:7s}"
+        for K in KS:
+            p = float(np.mean(agg[ds][("plain", K)]))
+            q = float(np.mean(agg[ds][("refit", K)]))
+            g = 100.0 * (p - q) / p
+            gains[K].append(g)
+            line += f"{g:+11.3f}%"
+        print(line)
+
+    print("\n" + "=" * 116)
+    print("VERDICT — mean improvement by bag size")
+    print("=" * 116)
+    for K in KS:
+        g = gains[K]
+        if g:
+            print(f"  K={K}: mean {np.mean(g):+7.3f}%   median {np.median(g):+7.3f}%   "
+                  f"better on {sum(1 for x in g if x > 0)}/{len(g)} datasets")
+
+    # Pareto question: does a small refit bag match a big plain bag?
+    print("\n" + "=" * 116)
+    print("PARETO — can a SMALL refit bag match a LARGE plain bag?")
+    print("  each cell: refit@K vs plain@8, % better (positive = refit@K wins at a fraction of the cost)")
+    print("=" * 116)
+    print(f"{'dataset':34s}" + "".join(f"{'refit' + str(K) + ' vs p8':>15s}" for K in KS))
+    tot = defaultdict(list)
+    for ds in DATASETS:
+        if ds not in agg:
+            continue
+        p8 = float(np.mean(agg[ds][("plain", 8)]))
+        line = f"{ds.replace('gr:', '')[:34]:34s}"
+        for K in KS:
+            q = float(np.mean(agg[ds][("refit", K)]))
+            d = 100.0 * (p8 - q) / p8
+            tot[K].append(d)
+            line += f"{d:+14.3f}%"
+        print(line)
+    print()
+    for K in KS:
+        d = tot[K]
+        if d:
+            print(f"  refit@{K} vs plain@8: mean {np.mean(d):+7.3f}%   "
+                  f"wins on {sum(1 for x in d if x > 0)}/{len(d)} datasets")
+
+
+if __name__ == "__main__":
+    if "--table-only" in sys.argv:
+        table()
+    else:
+        main()

--- a/benchmarks/probe_calibration_map.py
+++ b/benchmarks/probe_calibration_map.py
@@ -1,0 +1,299 @@
+"""Probe: can a richer calibration map recover Brier that our scalar temperature leaves on the table?
+
+BACKGROUND (2026-08-01). Two facts that look contradictory but are not:
+
+  (a) We are ALREADY the best-calibrated model in the field. Mean CORP
+      miscalibration (MCB) across the 23 Grinsztajn classification sets:
+      ChimeraBoost 0.00220 < CatBoost 0.00231 < LightGBM 0.00233 < HGB 0.00272.
+      Perfectly recalibrating BOTH sides leaves the head-to-head scoreboard
+      completely unchanged (17W-6L vs CatBoost before and after).
+
+  (b) That is the wrong question for a shipping decision. (a) asks "are we
+      relatively miscalibrated?" — no. The shipping question is "can we recover
+      more of OUR OWN remaining 0.00220 while the opponents stay put?" Those
+      have different answers, and 5 of our 9 losing binary matchups have gaps
+      SMALLER than a fifth of our MCB.
+
+Today `_fit_temperature` (sklearn_api.py) learns a single scalar T minimizing
+validation log loss of sigmoid(raw/T). That family has no intercept, so it
+cannot shift the operating point of a skewed problem at all — on an 11%-positive
+set like bank-marketing the only reachable maps are ones that fix p=0.5 at
+raw=0. A 2-parameter Platt map sigmoid(a*raw + b) can; beta calibration
+(Kull et al., AISTATS 2017) adds a third shape parameter.
+
+THE PROBE: fit ChimeraBoost with an explicit calibration fold, then compare
+calibration maps fitted on that fold and scored OUT OF SAMPLE on the test set.
+Nothing is fitted on test. No library change.
+
+Arms (all fitted on the calibration fold, all scored on test):
+  raw        - no calibration at all (the floor)
+  temp       - scalar T, log-loss objective          == what ships today
+  temp_brier - scalar T, Brier objective             (does the objective matter?)
+  platt      - sigmoid(a*raw + b), log-loss objective (adds the intercept)
+  beta       - beta calibration, 3 parameters
+  isotonic   - out-of-sample isotonic (the nonparametric ceiling, high variance)
+
+PREDICTIONS (stated before running):
+  If the intercept matters, `platt` beats `temp` on the skewed sets
+  (bank-marketing ~11% positives, Diabetes130US, default-of-credit) and is
+  roughly flat on the balanced ones (california, credit, heloc, electricity).
+  If `platt` is flat or negative everywhere, the calibration family is
+  exhausted and the whole reliability lane closes for good.
+
+Primary metric is Brier (the house decision metric for classification).
+Resumable JSONL; `--table-only` reprints.
+"""
+
+import json
+import os
+import sys
+import time
+
+import numpy as np
+from scipy.optimize import minimize, minimize_scalar
+from sklearn.isotonic import IsotonicRegression
+from sklearn.model_selection import train_test_split
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from research import datasets as rdata  # noqa: E402
+
+from chimeraboost import ChimeraBoostClassifier  # noqa: E402
+
+RESULTS = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                       "results", "probe-calib-map.jsonl")
+SEEDS = (0, 1, 2)
+MAX_ITERS = 2000
+PATIENCE = 50
+
+# The binary sets where we currently lose a matchup, plus balanced controls
+# where we win comfortably (a calibration lever must not hurt these).
+LOSING = [
+    "gr:clf_num/bank-marketing",
+    "gr:clf_num/credit",
+    "gr:clf_num/heloc",
+    "gr:clf_num/default-of-credit-card-clients",
+    "gr:clf_num/Diabetes130US",
+    "gr:clf_num/california",
+    "gr:clf_num/electricity",
+]
+CONTROL = [
+    "gr:clf_num/covertype",
+    "gr:clf_num/MagicTelescope",
+    "gr:clf_num/pol",
+    "gr:clf_num/Bioresponse",
+]
+ALL = LOSING + CONTROL
+
+
+def _sig(z):
+    return 1.0 / (1.0 + np.exp(-np.clip(z, -500, 500)))
+
+
+def _brier(y, p):
+    """Binary Brier in the harness's K=2 sum form, so numbers are comparable
+    to the benchmark's `brier` field: sum_k (p_k - onehot_k)^2 = 2*(p-y)^2."""
+    return float(np.mean(2.0 * (p - y) ** 2))
+
+
+def _nll(y, p):
+    p = np.clip(p, 1e-12, 1 - 1e-12)
+    return float(-np.mean(y * np.log(p) + (1 - y) * np.log(1 - p)))
+
+
+# --- calibration maps: each returns a function raw -> probability -----------
+
+def fit_temp_nll(raw, y):
+    def loss(T):
+        z = raw / T
+        return float(np.mean(np.log1p(np.exp(-np.abs(z)))
+                             + np.maximum(z, 0.0) - y * z))
+    r = minimize_scalar(loss, bounds=(0.05, 50.0), method="bounded",
+                        options={"xatol": 1e-4})
+    T = float(r.x) if r.success else 1.0
+    return lambda v: _sig(v / T), {"T": T}
+
+
+def fit_temp_brier(raw, y):
+    def loss(T):
+        return _brier(y, _sig(raw / T))
+    r = minimize_scalar(loss, bounds=(0.05, 50.0), method="bounded",
+                        options={"xatol": 1e-4})
+    T = float(r.x) if r.success else 1.0
+    return lambda v: _sig(v / T), {"T": T}
+
+
+def fit_platt(raw, y):
+    """sigmoid(a*raw + b), log-loss objective. Starts at the shipped scalar
+    solution (a=1/T, b=0) so it can only improve the training objective."""
+    _, info = fit_temp_nll(raw, y)
+    x0 = np.array([1.0 / info["T"], 0.0])
+
+    def loss(th):
+        z = th[0] * raw + th[1]
+        return float(np.mean(np.log1p(np.exp(-np.abs(z)))
+                             + np.maximum(z, 0.0) - y * z))
+    r = minimize(loss, x0, method="Nelder-Mead",
+                 options={"xatol": 1e-6, "fatol": 1e-10, "maxiter": 2000})
+    a, b = (r.x if r.success else x0)
+    return lambda v: _sig(a * v + b), {"a": float(a), "b": float(b)}
+
+
+def fit_beta(raw, y):
+    """Beta calibration on the model's own probabilities:
+    p' = sigmoid(c + a*ln(p) - b*ln(1-p)). Three parameters."""
+    p = np.clip(_sig(raw), 1e-6, 1 - 1e-6)
+    lp, lq = np.log(p), np.log(1 - p)
+
+    def loss(th):
+        z = th[0] * lp - th[1] * lq + th[2]
+        return float(np.mean(np.log1p(np.exp(-np.abs(z)))
+                             + np.maximum(z, 0.0) - y * z))
+    r = minimize(loss, np.array([1.0, 1.0, 0.0]), method="Nelder-Mead",
+                 options={"xatol": 1e-6, "fatol": 1e-10, "maxiter": 4000})
+    a, b, c = (r.x if r.success else np.array([1.0, 1.0, 0.0]))
+
+    def apply(v):
+        pv = np.clip(_sig(v), 1e-6, 1 - 1e-6)
+        return _sig(a * np.log(pv) - b * np.log(1 - pv) + c)
+    return apply, {"a": float(a), "b": float(b), "c": float(c)}
+
+
+def fit_isotonic(raw, y):
+    iso = IsotonicRegression(increasing=True, out_of_bounds="clip")
+    iso.fit(_sig(raw), y)
+    return lambda v: iso.predict(_sig(v)), {}
+
+
+MAPS = {
+    "temp": fit_temp_nll,            # == shipped
+    "temp_brier": fit_temp_brier,
+    "platt": fit_platt,
+    "beta": fit_beta,
+    "isotonic": fit_isotonic,
+}
+
+
+def _done():
+    seen = set()
+    if os.path.exists(RESULTS):
+        with open(RESULTS, "r", encoding="utf-8") as f:
+            for line in f:
+                if line.strip():
+                    try:
+                        r = json.loads(line)
+                        seen.add((r["dataset"], r["seed"]))
+                    except Exception:
+                        pass
+    return seen
+
+
+def main():
+    done = _done()
+    for key in ALL:
+        X, y, cat, task = rdata.load(key)
+        if task != "binary":
+            print(f"skip {key}: {task}")
+            continue
+        classes = np.unique(y)
+        pos_rate = float(np.mean(y == classes[1]))
+        print(f"\n=== {key}  n={len(y)}  p={X.shape[1]}  positives={pos_rate:.1%}")
+        for seed in SEEDS:
+            if (key, seed) in done:
+                continue
+            Xtr, Xte, ytr, yte = train_test_split(
+                X, y, test_size=0.2, random_state=seed, stratify=y)
+            # Explicit calibration fold, carved from train only. The model
+            # early-stops on it, exactly as the auto-split default would.
+            Xa, Xc, ya, yc = train_test_split(
+                Xtr, ytr, test_size=0.2, random_state=seed, stratify=ytr)
+            t = time.time()
+            m = ChimeraBoostClassifier(n_estimators=MAX_ITERS,
+                                       early_stopping_rounds=PATIENCE,
+                                       random_state=seed)
+            m.fit(Xa, ya, eval_set=(Xc, yc), cat_features=cat)
+            fit_s = time.time() - t
+
+            raw_c = np.asarray(m.model_.predict_raw(Xc), dtype=np.float64).ravel()
+            raw_t = np.asarray(m.model_.predict_raw(Xte), dtype=np.float64).ravel()
+            yc01 = (yc == classes[1]).astype(np.float64)
+            yt01 = (yte == classes[1]).astype(np.float64)
+
+            rec = {"dataset": key, "seed": seed, "pos_rate": pos_rate,
+                   "fit_time": fit_s,
+                   "brier": {"raw": _brier(yt01, _sig(raw_t))},
+                   "nll": {"raw": _nll(yt01, _sig(raw_t))}, "params": {}}
+            for name, fitter in MAPS.items():
+                apply, info = fitter(raw_c, yc01)
+                pt = np.clip(apply(raw_t), 0.0, 1.0)
+                rec["brier"][name] = _brier(yt01, pt)
+                rec["nll"][name] = _nll(yt01, pt)
+                rec["params"][name] = info
+            os.makedirs(os.path.dirname(RESULTS), exist_ok=True)
+            with open(RESULTS, "a", encoding="utf-8") as f:
+                f.write(json.dumps(rec) + "\n")
+            b = rec["brier"]
+            print(f"  s{seed} {fit_s:5.1f}s  temp={b['temp']:.6f}  "
+                  f"platt={b['platt']:.6f} ({100*(b['temp']-b['platt'])/b['temp']:+.3f}%)  "
+                  f"beta={b['beta']:.6f}  iso={b['isotonic']:.6f}")
+    table()
+
+
+def table():
+    rows = []
+    with open(RESULTS, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                rows.append(json.loads(line))
+    from collections import defaultdict
+    agg = defaultdict(lambda: defaultdict(list))
+    pos = {}
+    for r in rows:
+        pos[r["dataset"]] = r["pos_rate"]
+        for k, v in r["brier"].items():
+            agg[r["dataset"]][k].append(v)
+
+    arms = ["raw", "temp", "temp_brier", "platt", "beta", "isotonic"]
+    print("\n" + "=" * 120)
+    print("CALIBRATION MAP PROBE — test Brier, maps fitted out-of-sample on the calibration fold")
+    print("  gain columns = improvement over `temp` (what ships today), % of temp's Brier. Positive = better.")
+    print("=" * 120)
+    print(f"{'dataset':38s}{'pos%':>6s}" + "".join(f"{a:>11s}" for a in arms)
+          + f"{'platt':>9s}{'beta':>8s}{'iso':>8s}")
+
+    deltas = defaultdict(list)
+    for group, name in ((LOSING, "LOSING MATCHUPS"), (CONTROL, "CONTROLS (we win these)")):
+        print(f"\n-- {name} " + "-" * (110 - len(name)))
+        for ds in group:
+            if ds not in agg:
+                continue
+            means = {a: float(np.mean(agg[ds][a])) for a in arms if agg[ds][a]}
+            if "temp" not in means:
+                continue
+            line = f"{ds.replace('gr:', '')[:38]:38s}{100*pos[ds]:5.1f}%"
+            for a in arms:
+                line += f"{means.get(a, float('nan')):11.6f}"
+            t = means["temp"]
+            for a in ("platt", "beta", "isotonic"):
+                d = 100.0 * (t - means[a]) / t
+                deltas[(name, a)].append(d)
+                line += f"{d:+8.3f}%"
+            print(line)
+
+    print("\n" + "=" * 120)
+    print("VERDICT — mean improvement over the shipped scalar temperature (% of Brier)")
+    print("=" * 120)
+    for name in ("LOSING MATCHUPS", "CONTROLS (we win these)"):
+        for a in ("platt", "beta", "isotonic"):
+            d = deltas[(name, a)]
+            if d:
+                wins = sum(1 for x in d if x > 0)
+                print(f"  {name:26s} {a:9s} mean {np.mean(d):+7.3f}%   "
+                      f"better on {wins}/{len(d)} datasets   median {np.median(d):+7.3f}%")
+        print()
+
+
+if __name__ == "__main__":
+    if "--table-only" in sys.argv:
+        table()
+    else:
+        main()

--- a/benchmarks/probe_catboost_ablation.py
+++ b/benchmarks/probe_catboost_ablation.py
@@ -1,0 +1,243 @@
+"""Probe: WHICH CatBoost mechanism produces its remaining edge over us?
+
+MECHANISM QUESTION (pre-registered 2026-08-01, before any results):
+On the 2026-07-31 external field we beat CatBoost on 46 of 57 Grinsztajn sets,
+and every remaining loss is noisy low-dimensional BINARY classification
+(bank-marketing, credit, heloc, default-of-credit, Diabetes130US, california),
+with gaps under 1.1% of Brier.
+
+The calibration explanation is already REFUTED (scratch analysis 2026-08-01):
+our miscalibration term (MCB 0.00220) is LOWER than CatBoost's (0.00231),
+LightGBM's (0.00233) and HGB's (0.00272), and subtracting each model's own MCB
+-- i.e. perfectly recalibrating both sides -- leaves the head-to-head scoreboard
+completely unchanged (17W-6L before and after). The deficit is RESOLUTION, not
+reliability.
+
+That leaves CatBoost's structural machinery. On these sets the features are
+numeric, so its ordered target statistics are irrelevant. Its remaining
+distinctive default-ON machinery is two stochastic regularizers we have never
+implemented (architecture map degree-of-freedom #1: "no gain dithering"):
+  * random_strength=1      -- Gaussian noise added to each split score before
+                              the argmax, decaying with the round index.
+  * bagging_temperature=1  -- Bayesian bootstrap: per-tree row weights
+                              w_i = u_i^(1/T), every row kept, mean weight 1.
+Both attack the winner's curse: a split chosen by pure argmax over ~p*128 noisy
+gain estimates is selected partly for its noise and underdelivers out of sample.
+Our split search is a pure greedy argmax with no dithering and (at the default
+subsample=1.0) no row randomness at all.
+
+THE PROBE: ablate the OPPONENT. Run CatBoost at its defaults, then with each
+regularizer disabled, on the sets where it beats us. Using CatBoost as an oracle
+for its own mechanism costs one short benchmark and answers the question that
+decides whether the mechanism is worth building.
+
+PREDICTIONS (stated before running):
+  If the hypothesis is RIGHT: disabling both regularizers costs CatBoost most of
+  its edge on the loss cluster -- its Brier rises to roughly our level -- while
+  the control sets (where we already win big) move little.
+  If the hypothesis is WRONG: CatBoost's Brier barely moves, its edge survives
+  the ablation, and the mechanism lives somewhere else. Then DO NOT build it.
+
+PROTOCOL: paired identical splits (the harness's own _val_split / train_test_split
+convention), 3 seeds, Brier primary (the house decision metric for classification).
+ChimeraBoost at library defaults is included on the same splits as the reference
+line. Resumable JSONL; aggregate table printed at the end.
+"""
+
+import json
+import os
+import sys
+import time
+
+import numpy as np
+from sklearn.model_selection import train_test_split
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from research import datasets as rdata  # noqa: E402
+
+from chimeraboost import ChimeraBoostClassifier  # noqa: E402
+
+RESULTS = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                       "results", "probe-cb-ablation.jsonl")
+SEEDS = (0, 1, 2)
+MAX_ITERS = 2000
+PATIENCE = 50
+
+# The sets where CatBoost still beats us (from 20260731-142609.json).
+LOSS_CLUSTER = [
+    "gr:clf_num/bank-marketing",
+    "gr:clf_num/credit",
+    "gr:clf_num/heloc",
+    "gr:clf_num/default-of-credit-card-clients",
+    "gr:clf_num/Diabetes130US",
+    "gr:clf_num/california",
+]
+# Controls: binary sets where WE win comfortably. If the ablation moves these
+# as much as the loss cluster, the effect is not specific and means nothing.
+CONTROL = [
+    "gr:clf_num/covertype",
+    "gr:clf_num/electricity",
+    "gr:clf_num/MagicTelescope",
+    "gr:clf_num/pol",
+]
+ALL = LOSS_CLUSTER + CONTROL
+
+# CatBoost arms. "default" is what the benchmark harness runs today.
+ARMS = {
+    "cb_default":   {},
+    "cb_no_rs":     {"random_strength": 0.0},
+    "cb_no_bag":    {"bootstrap_type": "No"},
+    "cb_no_both":   {"random_strength": 0.0, "bootstrap_type": "No"},
+}
+
+
+def _brier(y_true, proba, classes):
+    onehot = (np.asarray(y_true)[:, None] == np.asarray(classes)[None, :]).astype(float)
+    return float(np.mean(np.sum((proba - onehot) ** 2, axis=1)))
+
+
+def _split(X, y, seed):
+    """Test split, then the internal validation carve — the harness convention."""
+    Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.2, random_state=seed,
+                                          stratify=y)
+    return Xtr, Xte, ytr, yte
+
+
+def _run_catboost(Xtr, ytr, Xte, yte, cat, seed, overrides):
+    from catboost import CatBoostClassifier
+    Xa, Xv, ya, yv = train_test_split(Xtr, ytr, test_size=0.2,
+                                      random_state=seed, stratify=ytr)
+    params = dict(iterations=MAX_ITERS, random_seed=seed, verbose=False,
+                  thread_count=-1, cat_features=list(cat) if cat else None,
+                  early_stopping_rounds=PATIENCE)
+    params.update(overrides)
+    t = time.time()
+    m = CatBoostClassifier(**params)
+    m.fit(Xa, ya, eval_set=(Xv, yv))
+    fit_s = time.time() - t
+    proba = m.predict_proba(Xte)
+    return _brier(yte, proba, m.classes_), fit_s, int(m.get_best_iteration() or 0)
+
+
+def _run_chimera(Xtr, ytr, Xte, yte, cat, seed):
+    # Library defaults, exactly as the harness measures them: no explicit
+    # eval_set, so ChimeraBoost carves its own early-stopping split.
+    t = time.time()
+    m = ChimeraBoostClassifier(n_estimators=MAX_ITERS,
+                               early_stopping_rounds=PATIENCE,
+                               random_state=seed)
+    m.fit(Xtr, ytr, cat_features=cat)
+    fit_s = time.time() - t
+    proba = m.predict_proba(Xte)
+    return _brier(yte, proba, m.classes_), fit_s, 0
+
+
+def _done_keys():
+    seen = set()
+    if os.path.exists(RESULTS):
+        with open(RESULTS, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    try:
+                        r = json.loads(line)
+                        seen.add((r["dataset"], r["arm"], r["seed"]))
+                    except Exception:
+                        pass
+    return seen
+
+
+def _append(rec):
+    os.makedirs(os.path.dirname(RESULTS), exist_ok=True)
+    with open(RESULTS, "a", encoding="utf-8") as f:
+        f.write(json.dumps(rec) + "\n")
+
+
+def main():
+    done = _done_keys()
+    for key in ALL:
+        X, y, cat, task = rdata.load(key)
+        if task != "binary":
+            print(f"skip {key}: task={task}")
+            continue
+        print(f"\n=== {key}  n={len(y)}  p={X.shape[1]}  cats={len(cat) if cat else 0}")
+        for seed in SEEDS:
+            Xtr, Xte, ytr, yte = _split(X, y, seed)
+            for arm, overrides in ARMS.items():
+                if (key, arm, seed) in done:
+                    continue
+                b, fit_s, bi = _run_catboost(Xtr, ytr, Xte, yte, cat, seed, overrides)
+                _append({"dataset": key, "arm": arm, "seed": seed,
+                         "brier": b, "fit_time": fit_s, "best_iter": bi})
+                print(f"  [{arm:11s} s{seed}] brier={b:.6f}  {fit_s:6.1f}s  it={bi}")
+            if (key, "chimera", seed) not in done:
+                b, fit_s, _ = _run_chimera(Xtr, ytr, Xte, yte, cat, seed)
+                _append({"dataset": key, "arm": "chimera", "seed": seed,
+                         "brier": b, "fit_time": fit_s, "best_iter": 0})
+                print(f"  [{'chimera':11s} s{seed}] brier={b:.6f}  {fit_s:6.1f}s")
+    table()
+
+
+def table():
+    rows = []
+    with open(RESULTS, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    from collections import defaultdict
+    agg = defaultdict(list)
+    for r in rows:
+        agg[(r["dataset"], r["arm"])].append(r["brier"])
+
+    arms = ["chimera", "cb_default", "cb_no_rs", "cb_no_bag", "cb_no_both"]
+    print("\n" + "=" * 118)
+    print("CATBOOST ABLATION — Brier (lower better). "
+          "'edge' = how much CatBoost beats us, as % of our Brier (positive = CatBoost ahead).")
+    print("=" * 118)
+    hdr = f"{'dataset':38s}" + "".join(f"{a:>13s}" for a in arms) + f"{'edge@def':>10s}{'edge@none':>11s}"
+    print(hdr)
+
+    for group, name in ((LOSS_CLUSTER, "LOSS CLUSTER"), (CONTROL, "CONTROLS")):
+        print(f"\n-- {name} " + "-" * (114 - len(name)))
+        for ds in group:
+            vals = {a: (float(np.mean(agg[(ds, a)])) if agg.get((ds, a)) else None)
+                    for a in arms}
+            if vals["chimera"] is None or vals["cb_default"] is None:
+                continue
+            line = f"{ds.replace('gr:', '')[:38]:38s}"
+            for a in arms:
+                v = vals[a]
+                line += f"{v:13.6f}" if v is not None else f"{'-':>13s}"
+            ours = vals["chimera"]
+            e_def = 100.0 * (ours - vals["cb_default"]) / ours
+            line += f"{e_def:9.2f}%"
+            if vals["cb_no_both"] is not None:
+                e_non = 100.0 * (ours - vals["cb_no_both"]) / ours
+                line += f"{e_non:10.2f}%"
+            print(line)
+
+    # Summary: does the ablation remove CatBoost's edge where it beats us?
+    print("\n" + "=" * 118)
+    print("VERDICT — mean CatBoost edge over ChimeraBoost (% of our Brier, positive = they win)")
+    print("=" * 118)
+    for group, name in ((LOSS_CLUSTER, "loss cluster"), (CONTROL, "controls")):
+        for arm in ("cb_default", "cb_no_rs", "cb_no_bag", "cb_no_both"):
+            edges = []
+            for ds in group:
+                o = agg.get((ds, "chimera"))
+                c = agg.get((ds, arm))
+                if o and c:
+                    ours, theirs = float(np.mean(o)), float(np.mean(c))
+                    edges.append(100.0 * (ours - theirs) / ours)
+            if edges:
+                print(f"  {name:14s} {arm:12s} mean edge {np.mean(edges):+7.3f}%   "
+                      f"(n={len(edges)}, CatBoost ahead on {sum(1 for e in edges if e > 0)})")
+        print()
+
+
+if __name__ == "__main__":
+    if "--table-only" in sys.argv:
+        table()
+    else:
+        main()

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -1115,17 +1115,22 @@ ENSEMBLE_N = 10
 
 
 def _chimera_ens(n, task, Xtr, ytr, Xte, yte, cat, threads, lr=None,
-                 subsample=1.0, colsample=None, quantize=False):
+                 subsample=1.0, colsample=None, quantize=False,
+                 refit_members=False):
     """Shared implementation for all bagged-ChimeraBoost runners.
 
     ensemble_n_jobs is left at the shipped default (parallel members inside
     the task's thread budget) so the chart measures the shipped config
     (BAGGING_PLAN.md B4; same core budget as every other model). lr /
     subsample / colsample / quantize forward to the members (the B3
-    member-defaults grid rides the same --chimera-* flags as the single arm)."""
+    member-defaults grid rides the same --chimera-* flags as the single arm).
+    `refit_members` is the BREAKTHROUGH_PLAN C1 arm: each member replays its
+    own structure against all-row gradients after early stopping."""
     t = time.time()
     Est = ChimeraBoostRegressor if task == "regression" else ChimeraBoostClassifier
     kw = {"quantize_gradients": True} if quantize else {}
+    if refit_members:
+        kw["refit_members"] = True
     m = Est(n_estimators=MAX_ITERS, early_stopping=True, early_stopping_rounds=PATIENCE,
             n_ensembles=n, learning_rate=lr,
             subsample=subsample, colsample=colsample,
@@ -1150,6 +1155,29 @@ def _run_chimera_ensemble_8(task, Xtr, ytr, Xte, yte, cat, threads, **kw):
     # The blessed bagged config (BAGGING_PLAN.md B3): K=8 with the library's
     # bagged-member defaults.
     return _chimera_ens(8, task, Xtr, ytr, Xte, yte, cat, threads, **kw)
+
+
+# --- BREAKTHROUGH C1: per-member full-data refit ----------------------------
+# Members train on max_samples of the rows and early-stop on their OOB
+# complement, so the ordinary full-data refit never fires and every member's
+# leaf values come from 0.8n rows. These arms replay each member's own
+# structure against all-row gradients. Pinned operating points: they ignore
+# the --chimera-* knobs so several can run side by side in ONE benchmark,
+# which is what makes the A/B pairing free of machine-condition drift.
+def _run_chimera_ens8_rm(task, Xtr, ytr, Xte, yte, cat, threads):
+    return _chimera_ens(8, task, Xtr, ytr, Xte, yte, cat, threads,
+                        refit_members=True)
+
+
+def _run_chimera_ens5_rm(task, Xtr, ytr, Xte, yte, cat, threads):
+    return _chimera_ens(5, task, Xtr, ytr, Xte, yte, cat, threads,
+                        refit_members=True)
+
+
+def _run_chimera_ens3_rm(task, Xtr, ytr, Xte, yte, cat, threads):
+    # The Pareto question: does a 3-member refit bag reach plain Ens8?
+    return _chimera_ens(3, task, Xtr, ytr, Xte, yte, cat, threads,
+                        refit_members=True)
 
 
 # --- SELECT program arms (benchmarks/SELECT_PLAN.md) ------------------------
@@ -1356,6 +1384,9 @@ RUNNERS = {
     "ChimeraBoostEns5": _run_chimera_ensemble_5,
     "ChimeraBoostEns8": _run_chimera_ensemble_8,
     "ChimeraBoostEns10": _run_chimera_ensemble,
+    "ChimeraBoostEns8RM": _run_chimera_ens8_rm,
+    "ChimeraBoostEns5RM": _run_chimera_ens5_rm,
+    "ChimeraBoostEns3RM": _run_chimera_ens3_rm,
     "ChimeraBoostOne": _run_chimera_one,
     "ChimeraBoostOneLin": _run_chimera_one_lin,
     "ChimeraBoostSel25": _run_chimera_sel25,
@@ -1374,6 +1405,8 @@ RUNNERS = {
 _ALWAYS = ("ChimeraBoost", "sklearn_HGB")
 _OFF_BY_DEFAULT = ("XGBoost", "ChimeraBoostEns2", "ChimeraBoostEns5",
                    "ChimeraBoostEns8", "ChimeraBoostEns10",
+                   "ChimeraBoostEns8RM", "ChimeraBoostEns5RM",
+                   "ChimeraBoostEns3RM",
                    "ChimeraBoostOne", "ChimeraBoostOneLin",
                    "ChimeraBoostSel25", "ChimeraBoostRefit",
                    "ChimeraBoostNoRefit", "ChimeraBoostNoRefitSel25")

--- a/benchmarks/strata_standing.py
+++ b/benchmarks/strata_standing.py
@@ -1,0 +1,170 @@
+"""Where do we stand against the external field, per decision-suite stratum?
+
+The decide tier runs 7 strata: Grinsztajn and the high-card suite, each with
+their @sus25 / @sus50 small-data twins and @time temporal splits. Until
+2026-08-01 no run had ever combined external competitors with the variant
+strata, so our standing in the small-data and shift regimes was unmeasured.
+
+Reports, per stratum and per opponent: head-to-head win rate on the primary
+metric (RMSE regression / Brier classification), the median relative gap, and
+the count of near-tie matchups (|gap| < 0.25%) -- the near-ties are where the
+leverage is, since a broad shift converts them wholesale.
+
+Usage:  python benchmarks/strata_standing.py RESULTS.json
+        python benchmarks/strata_standing.py --latest
+"""
+
+import glob
+import json
+import os
+import sys
+from collections import defaultdict
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from summarize import primary_scores  # noqa: E402
+
+OURS = "ChimeraBoost"
+OPPS = ["CatBoost", "LightGBM", "sklearn_HGB", "XGBoost"]
+NEAR_TIE = 0.25          # % of opponent metric
+
+
+def _load(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _stratum(ds, meta):
+    suite = "hc" if ds.startswith("hc:") else "gr"
+    var = meta.get("variant") or "base"
+    return f"{suite}:{var}"
+
+
+def analyse(path):
+    blob = _load(path)
+    recs, meta = blob["records"], blob["datasets"]
+    cfg = blob.get("config", {})
+    print(f"# {os.path.basename(path)}   seeds={cfg.get('seeds')}  "
+          f"timing={cfg.get('timing')}")
+
+    present = sorted({r["model"] for r in recs})
+    opps = [o for o in OPPS if o in present]
+    print(f"models present: {', '.join(present)}\n")
+
+    # primary_scores applies the house near-solved exclusions (regression
+    # best-NRMSE < 2%, classification best-Brier < 1e-3), so this sees exactly
+    # the data the headline table and the win-rate axis see.
+    primary = primary_scores(blob)
+    n_excluded = len(meta) - len(primary)
+    if n_excluded:
+        print(f"near-solved datasets excluded: {n_excluded}\n")
+
+    # stratum -> opponent -> list of (dataset, relative gap %)
+    book = defaultdict(lambda: defaultdict(list))
+
+    for ds, scores in primary.items():
+        ours = scores.get(OURS)
+        if ours is None:
+            continue
+        st = _stratum(ds, meta[ds])
+        for opp in opps:
+            theirs = scores.get(opp)
+            if theirs is None or theirs <= 0:
+                continue
+            gap = 100.0 * (ours - theirs) / theirs     # positive = we lose
+            book[st][opp].append((ds, gap))
+
+    order = ["gr:base", "gr:sus25", "gr:sus50", "gr:time",
+             "hc:base", "hc:sus25", "hc:sus50", "hc:time"]
+    strata = [s for s in order if s in book] + \
+             [s for s in sorted(book) if s not in order]
+
+    print("=" * 104)
+    print("HEAD-TO-HEAD BY STRATUM — win rate on the primary metric (higher = better for us)")
+    print("=" * 104)
+    hdr = f"{'stratum':12s}{'n':>4s}  " + "".join(f"{o[:13]:>22s}" for o in opps)
+    print(hdr)
+    print("-" * 104)
+
+    for st in strata:
+        n_ds = max(len(v) for v in book[st].values()) if book[st] else 0
+        line = f"{st:12s}{n_ds:4d}  "
+        for opp in opps:
+            rows = book[st].get(opp, [])
+            if not rows:
+                line += f"{'-':>22s}"
+                continue
+            w = sum(1 for _, g in rows if g < 0)
+            tot = len(rows)
+            med = float(np.median([g for _, g in rows]))
+            line += f"{f'{w}/{tot} = {100*w/tot:4.0f}%  m{med:+5.2f}':>22s}"
+        print(line)
+
+    # Leverage: how many matchups sit inside the near-tie band, per stratum
+    print("\n" + "=" * 104)
+    print(f"LEVERAGE — matchups inside a {NEAR_TIE}% band (a broad shift converts these wholesale)")
+    print("=" * 104)
+    print(f"{'stratum':12s}{'matchups':>10s}{'near-ties':>11s}{'  of which losses':>19s}"
+          f"{'   win rate':>12s}{'  if all flip':>14s}")
+    grand = [0, 0, 0, 0]
+    for st in strata:
+        allrows = [(ds, g) for opp in opps for ds, g in book[st].get(opp, [])]
+        if not allrows:
+            continue
+        tot = len(allrows)
+        wins = sum(1 for _, g in allrows if g < 0)
+        near = [g for _, g in allrows if abs(g) < NEAR_TIE]
+        near_loss = sum(1 for g in near if g >= 0)
+        grand[0] += tot
+        grand[1] += wins
+        grand[2] += len(near)
+        grand[3] += near_loss
+        print(f"{st:12s}{tot:10d}{len(near):11d}{near_loss:19d}"
+              f"{100*wins/tot:11.1f}%{100*(wins+near_loss)/tot:13.1f}%")
+    if grand[0]:
+        print("-" * 104)
+        print(f"{'ALL':12s}{grand[0]:10d}{grand[2]:11d}{grand[3]:19d}"
+              f"{100*grand[1]/grand[0]:11.1f}%{100*(grand[1]+grand[3])/grand[0]:13.1f}%")
+        print(f"\none matchup flip = {100/grand[0]:.2f} win-rate points; "
+              f"the +2-point bar needs {int(np.ceil(0.02*grand[0]))} flips")
+
+    # Worst losses, so the next mechanism has a target list
+    print("\n" + "=" * 104)
+    print("WORST LOSSES ACROSS ALL STRATA (positive = we lose, % of opponent metric)")
+    print("=" * 104)
+    flat = [(g, st, opp, ds) for st in strata for opp in opps
+            for ds, g in book[st].get(opp, []) if g > 0]
+    flat.sort(reverse=True)
+    for g, st, opp, ds in flat[:22]:
+        print(f"  {g:+7.2f}%  {st:10s} vs {opp:12s} {ds}")
+    if not flat:
+        print("  (none — we win every matchup)")
+
+    # Per-stratum mean gap: is a whole regime weak?
+    print("\n" + "=" * 104)
+    print("MEAN / MEDIAN RELATIVE GAP BY STRATUM (negative = we are ahead)")
+    print("=" * 104)
+    for st in strata:
+        allg = [g for opp in opps for _, g in book[st].get(opp, [])]
+        if allg:
+            print(f"  {st:12s} mean {np.mean(allg):+7.3f}%   median "
+                  f"{np.median(allg):+7.3f}%   n={len(allg)}")
+
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    if "--latest" in sys.argv or not args:
+        here = os.path.dirname(os.path.abspath(__file__))
+        cands = sorted(glob.glob(os.path.join(here, "results", "2026*.json")))
+        if not cands:
+            print("no results json found")
+            return
+        path = cands[-1]
+    else:
+        path = args[0]
+    analyse(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -50,7 +50,8 @@ def _fit_temperature(raw, y, multiclass, sample_weight=None):
 _SKLEARN_ONLY = frozenset({"early_stopping", "validation_fraction",
                            "n_ensembles", "ensemble_n_jobs", "max_samples",
                            "cat_features", "cross_features",
-                           "selection_rounds", "refit_full", "quality"})
+                           "selection_rounds", "refit_full", "refit_members",
+                           "quality"})
 
 # --- quality: named operating points on the strength/slowdown Pareto --------
 # Evidence: benchmarks/SELECT_PLAN.md. Every recipe only pins parameters that
@@ -598,8 +599,18 @@ def _fit_bagged(estimator, X, y, cat_features, eval_set, groups, sample_weight):
                            if len(oob_idx) > 0 else None)
         else:
             member_eval = eval_set
+        # Member-level full-data refit (benchmarks/BREAKTHROUGH_PLAN.md C1):
+        # after early stopping has used the OOB rows, replay this member's own
+        # structure against gradients from EVERY row, so its leaf values stop
+        # being estimated from max_samples*n. Only the leaf values move -- the
+        # splits stay exactly as this member's bag grew them, which is the
+        # diversity the bag actually trades on. Off by default; nothing below
+        # runs and the member is byte-identical when refit_members is False.
+        if getattr(estimator, "refit_members", False) and eval_set is None:
+            member._bag_refit_rows_ = (X, y, sample_weight, ms)
         member.fit(X[idx], y[idx], cat_features=cat_features, eval_set=member_eval,
                    groups=gb, sample_weight=wb)
+        member._bag_refit_rows_ = None
         # Members train on bare ndarray rows, so they would otherwise warn
         # "fitted without feature names" on every DataFrame predict; give them
         # the parent's captured names so the column-order guard applies
@@ -1204,8 +1215,27 @@ def _stop_if_behind(k, target_best):
     return cb
 
 
+def _bag_refit_rows(est):
+    """The full row set a BAG MEMBER should re-estimate its leaf values on, or
+    None when this is not a member of a refitting bag.
+
+    A member trains on ``max_samples`` of the rows and early-stops on the
+    out-of-bag complement, so `auto_split` is False and the ordinary full-data
+    refit never fires: every member's leaf values come from 0.8n rows and
+    nothing reclaims the rest. REFIT_PLAN's "bag members have no data tax" is
+    true of the ENSEMBLE — every row is in some member's bag — but not of any
+    individual member.
+
+    Replaying the member's own structure against all-row gradients is safe for
+    the ensemble because bag lift is STRUCTURAL diversity, measured in the LRE
+    post-mortem ("leaf-only diversity is dead, structural diversity is the
+    value"): the structures stay exactly as each member's own bag grew them,
+    and only the leaf values change. See benchmarks/BREAKTHROUGH_PLAN.md."""
+    return getattr(est, "_bag_refit_rows_", None)
+
+
 def _refit_on_full(est, winner, X_full, y_full, sw_full, cat_features, kw,
-                   loss_kwargs=None, replay=False):
+                   loss_kwargs=None, replay=False, train_frac=None):
     """Retrain ``winner``'s configuration on all rows (benchmarks/
     REFIT_PLAN.md): rounds scaled by the train-size ratio, resolved learning
     rate pinned so the early-stopped budget keeps its meaning, selected
@@ -1213,9 +1243,17 @@ def _refit_on_full(est, winner, X_full, y_full, sw_full, cat_features, kw,
     are copied so ``validation_history_`` keeps reporting the curve that
     chose the budget. Size-adaptive autos (the classifier's min_child_weight,
     cat_combinations) re-resolve at the full row count; user callbacks
-    observed the ES fits and are not re-run."""
+    observed the ES fits and are not re-run.
+
+    ``train_frac`` is the fraction of ``X_full`` the winner actually trained
+    on, which sets how far the round budget scales up. It defaults to the
+    auto-split's ``1 - validation_fraction``; a bag member passes its
+    ``max_samples`` instead, since what its leaf values never saw is the
+    out-of-bag complement rather than a validation holdout."""
     t_star = len(winner.trees_)
-    rounds = min(int(np.ceil(t_star / (1.0 - est.validation_fraction))),
+    frac = (1.0 - est.validation_fraction) if train_frac is None \
+        else float(train_frac)
+    rounds = min(int(np.ceil(t_star / max(frac, 1e-9))),
                  int(est.n_estimators))
     rkw = dict(kw)
     rkw["n_estimators"] = rounds
@@ -1498,7 +1536,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                  n_ensembles=None, ensemble_n_jobs=-1, max_samples=0.8,
                  cat_features=None, quantize_gradients=True,
                  eval_metric=None, delta=1.0, tweedie_variance_power=1.5,
-                 refit_full="replay", quality=None):
+                 refit_full="replay", refit_members=False, quality=None):
         self.n_estimators = n_estimators
         self.learning_rate = learning_rate
         self.depth = depth
@@ -1533,6 +1571,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         self.max_samples = max_samples
         self.quantize_gradients = quantize_gradients
         self.refit_full = refit_full
+        self.refit_members = refit_members
         self.quality = quality
 
     def fit(self, X, y, cat_features=None, eval_set=None, groups=None,
@@ -1876,6 +1915,12 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
             self.model_ = _refit_on_full(
                 self, self.model_, X_full, y_full, sw_full, cat_features, kw,
                 loss_kwargs=loss_kwargs, replay=self.refit_full == "replay")
+        elif _bag_refit_rows(self) is not None and self.loss != "Quantile" \
+                and self.model_.trees_:
+            bx, byy, bsw, bfrac = _bag_refit_rows(self)
+            self.model_ = _refit_on_full(
+                self, self.model_, bx, byy, bsw, cat_features, kw,
+                loss_kwargs=loss_kwargs, replay=True, train_frac=bfrac)
         return self
 
     def _transform_raw(self, raw):
@@ -2177,7 +2222,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                  early_stopping=True, validation_fraction=0.2,
                  n_ensembles=None, ensemble_n_jobs=-1, max_samples=0.8,
                  cat_features=None, quantize_gradients=True,
-                 eval_metric=None, refit_full="replay",
+                 eval_metric=None, refit_full="replay", refit_members=False,
                  quality=None):
         self.n_estimators = n_estimators
         self.learning_rate = learning_rate
@@ -2209,6 +2254,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         self.max_samples = max_samples
         self.quantize_gradients = quantize_gradients
         self.refit_full = refit_full
+        self.refit_members = refit_members
         self.quality = quality
 
     def fit(self, X, y, cat_features=None, eval_set=None, groups=None,
@@ -2515,6 +2561,18 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
             self.model_ = _refit_on_full(
                 self, self.model_, X_full, y_refit, sw_full, cat_features, kw,
                 replay=self.refit_full == "replay")
+        elif (_bag_refit_rows(self) is not None and self.model_.trees_
+                and not self._multiclass):
+            # Binary only: multiclass has no replay path (`_refit_on_full`
+            # rebuilds a vector-leaf model from scratch there), so a member
+            # refit would cost a whole extra fit per member instead of a cheap
+            # structure replay -- a different trade that this evidence does
+            # not cover. Multiclass bags are unchanged.
+            bx, byy, bsw, bfrac = _bag_refit_rows(self)
+            y_refit = (byy == self.classes_[1]).astype(np.float64)
+            self.model_ = _refit_on_full(
+                self, self.model_, bx, y_refit, bsw, cat_features, kw,
+                replay=True, train_frac=bfrac)
         return self
 
     def predict_proba(self, X):

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -125,6 +125,7 @@ See the User Guide: [early stopping](recipes.md#early-stopping) for `eval_set` a
 | `n_ensembles` | `None` | `None` or `1` is a single model. `2` or more averages members fit on random row subsamples, which reduces variance. 8 is the recommended size. See the User Guide: [bagging](recipes.md#bagging). |
 | `ensemble_n_jobs` | `-1` | Worker processes fitting members concurrently, each on an equal share of the thread budget. Same total cores, identical models, 1.2 to 2x faster wall clock. `1` fits members sequentially. |
 | `max_samples` | `0.8` | Fraction of rows each member trains on, drawn without replacement. This beats the classic bootstrap on both accuracy and fit time; `1.0` restores the full-size with-replacement bootstrap. |
+| `refit_members` | `False` | After a member early-stops on its out-of-bag rows, replay its own tree structure against gradients from every row, so its leaf values stop being estimated from `max_samples` of the data. The splits are untouched, which is where a bag's diversity actually lives. Costs about 10% more fit time. Regression and binary only. |
 
 ## System
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -265,6 +265,24 @@ them sequentially.
 
 `feature_importances_` and `shap_values` average across the bag automatically.
 
+### Reclaiming the per-member data tax
+
+Each member's leaf values are estimated from only the rows it sampled — the
+out-of-bag rows it early-stopped on never inform them. `refit_members=True`
+replays each member's own tree structure against gradients from every row once
+early stopping is finished:
+
+```python
+reg = ChimeraBoostRegressor(n_ensembles=8, refit_members=True,
+                            random_state=0).fit(X_train, y_train)
+```
+
+Only the leaf values change; the splits stay exactly as each member's own
+sample grew them, which is where a bag's diversity actually lives. Expect
+roughly 10% more fit time. Regression and binary classification only —
+multiclass members would need a full refit rather than a cheap replay, so the
+flag is ignored there.
+
 ## Full-data refit
 
 Once early stopping has chosen the tree budget on the automatic validation split, the

--- a/tests/test_refit_members.py
+++ b/tests/test_refit_members.py
@@ -1,0 +1,127 @@
+"""Per-member full-data refit in the bagged path (benchmarks/BREAKTHROUGH_PLAN.md C1).
+
+A bag member trains on ``max_samples`` of the rows and early-stops on its
+out-of-bag complement, so ``auto_split`` is False and the ordinary full-data
+refit never fires -- every member's leaf values come from 0.8n rows.
+``refit_members=True`` replays each member's OWN structure against all-row
+gradients, which is safe for the ensemble because bag lift is structural
+diversity (the LRE post-mortem), not leaf-value diversity.
+
+These tests lock the contract, not the accuracy: off is byte-identical, on
+engages, structures survive, and the paths that must not change do not.
+"""
+
+import numpy as np
+import pytest
+
+from chimeraboost import ChimeraBoostClassifier, ChimeraBoostRegressor
+
+
+def _data(n=1500, p=6, seed=0):
+    rng = np.random.default_rng(seed)
+    X = rng.normal(size=(n, p))
+    y = X[:, 0] * 2 + X[:, 1] ** 2 - 0.5 * X[:, 2] + rng.normal(scale=0.4, size=n)
+    return X, y
+
+
+BAG = dict(n_estimators=120, early_stopping_rounds=20, n_ensembles=3,
+           ensemble_n_jobs=1, random_state=0)
+
+
+def test_default_is_off_and_off_is_byte_identical():
+    """The default must not change any shipped prediction."""
+    X, y = _data()
+    Xte = X[:200]
+    assert ChimeraBoostRegressor().refit_members is False
+    a = ChimeraBoostRegressor(**BAG).fit(X, y)
+    b = ChimeraBoostRegressor(refit_members=False, **BAG).fit(X, y)
+    assert np.array_equal(a.predict(Xte), b.predict(Xte))
+
+
+def test_on_changes_predictions_regressor():
+    X, y = _data()
+    Xte = X[:200]
+    a = ChimeraBoostRegressor(**BAG).fit(X, y)
+    c = ChimeraBoostRegressor(refit_members=True, **BAG).fit(X, y)
+    assert not np.allclose(a.predict(Xte), c.predict(Xte))
+
+
+def test_on_changes_probabilities_classifier():
+    X, y = _data()
+    yc = (y > np.median(y)).astype(int)
+    Xte = X[:200]
+    a = ChimeraBoostClassifier(**BAG).fit(X, yc)
+    c = ChimeraBoostClassifier(refit_members=True, **BAG).fit(X, yc)
+    assert not np.allclose(a.predict_proba(Xte), c.predict_proba(Xte))
+
+
+def test_member_structures_are_preserved():
+    """Only leaf values may move -- the splits are the diversity the bag
+    trades on, so each member must keep the structure its own bag grew."""
+    X, y = _data()
+    plain = ChimeraBoostRegressor(**BAG).fit(X, y)
+    refit = ChimeraBoostRegressor(refit_members=True, **BAG).fit(X, y)
+    for mp, mr in zip(plain.estimators_, refit.estimators_):
+        tp, tr = mp.model_.trees_, mr.model_.trees_
+        # the refit replays every donor tree, then may grow a scaled-up tail
+        assert len(tr) >= len(tp)
+        for a, b in zip(tp, tr[:len(tp)]):
+            assert np.array_equal(a.splits_feat, b.splits_feat)
+            assert np.array_equal(a.splits_thr, b.splits_thr)
+
+    sigs = {tuple(tuple(t.splits_feat.tolist()) for t in m.model_.trees_[:3])
+            for m in refit.estimators_}
+    assert len(sigs) == len(refit.estimators_), "members must stay distinct"
+
+
+def test_single_model_path_untouched():
+    """refit_members is a bagged-path parameter; a single model must ignore it."""
+    X, y = _data()
+    Xte = X[:200]
+    kw = dict(n_estimators=120, early_stopping_rounds=20, random_state=0)
+    a = ChimeraBoostRegressor(**kw).fit(X, y)
+    b = ChimeraBoostRegressor(refit_members=True, **kw).fit(X, y)
+    assert np.array_equal(a.predict(Xte), b.predict(Xte))
+
+
+def test_explicit_eval_set_disables_member_refit():
+    """With a user eval_set the members never carve OOB rows, so there is no
+    member-level data tax to reclaim and the arm must stay inert."""
+    X, y = _data()
+    Xte = X[:200]
+    ev = (X[:300], y[:300])
+    a = ChimeraBoostRegressor(**BAG).fit(X, y, eval_set=ev)
+    b = ChimeraBoostRegressor(refit_members=True, **BAG).fit(X, y, eval_set=ev)
+    assert np.array_equal(a.predict(Xte), b.predict(Xte))
+
+
+def test_multiclass_bag_is_unchanged():
+    """Multiclass has no replay path, so a member refit there would cost a
+    whole extra fit per member rather than a cheap structure replay. Gated off."""
+    rng = np.random.default_rng(1)
+    X = rng.normal(size=(1200, 5))
+    y = rng.integers(0, 3, size=1200)
+    Xte = X[:200]
+    a = ChimeraBoostClassifier(**BAG).fit(X, y)
+    b = ChimeraBoostClassifier(refit_members=True, **BAG).fit(X, y)
+    assert np.array_equal(a.predict_proba(Xte), b.predict_proba(Xte))
+
+
+def test_members_fit_on_more_rows_than_their_bag():
+    """The point of the arm: leaf values stop being estimated from 0.8n rows.
+    Train-set error should improve, since every row now informs some leaf."""
+    X, y = _data(n=2000)
+    plain = ChimeraBoostRegressor(**BAG).fit(X, y)
+    refit = ChimeraBoostRegressor(refit_members=True, **BAG).fit(X, y)
+    rp = float(np.sqrt(np.mean((y - plain.predict(X)) ** 2)))
+    rr = float(np.sqrt(np.mean((y - refit.predict(X)) ** 2)))
+    assert rr < rp
+
+
+@pytest.mark.parametrize("cls", [ChimeraBoostRegressor, ChimeraBoostClassifier])
+def test_get_params_roundtrip(cls):
+    """sklearn clone contract: the parameter must survive get/set_params."""
+    est = cls(refit_members=True)
+    assert est.get_params()["refit_members"] is True
+    from sklearn.base import clone
+    assert clone(est).refit_members is True


### PR DESCRIPTION
## The finding that reframed the hunt

No benchmark had ever combined external competitors with the `@sus`/`@time` variant strata — runs had one or the other. Running both together (103 datasets, `results/20260801-013306.json`) shows **our win rate against CatBoost collapses as training data shrinks**:

| stratum | gr:base | gr:sus25 | gr:sus50 | hc:base | hc:sus25 | hc:sus50 | hc:time |
|---|---|---|---|---|---|---|---|
| vs CatBoost | **81%** | **50%** | **33%** | **31%** | **0%** | **0%** | **43%** |

Against LightGBM and HGB we stay dominant everywhere (71–100%), so it is specific to CatBoost and specific to small data — the regime its ordered boosting was built for. Base Grinsztajn is close to saturated at 91.8%; the headroom was in strata nobody had measured.

## What ships: `refit_members`

**No bag member had ever run the full-data refit.** `_fit_bagged` hands each member an explicit out-of-bag `eval_set`, and `_refit_on_full` fires only when `auto_split` is True — so every member's leaf values were estimated from `max_samples` (0.8) of the rows and nothing reclaimed the rest. `REFIT_PLAN.md` records "bag members have no data tax", which is true of the *ensemble* (every row is in some member's bag) but not of any individual member.

Replaying a member's own structure against all-row gradients is safe because the **LRE post-mortem measured that bag lift is structural diversity**, not leaf-value diversity. The splits stay exactly as each member's own sample grew them; only the leaf values move.

### Gates (full `/experiment` protocol, both arms in ONE benchmark)

**Tier 1 synth** — primary 71W-27L-38T, mean +0.738%, sign test PASS. Brier 24W-30L-34T logged as a watch item (the 34 ties are the gated-off multiclass sets, so binary Brier was a 24-30 coin flip with a positive mean).

**Tier 2 decide** (`results/20260801-023724.json`), `Ens8RM` vs `Ens8`, per stratum, never pooled:

| stratum | primary | mean | Brier | Brier mean |
|---|---|---|---|---|
| gr:base | **52W-7L** | +0.500% | **20W-3L** | **+1.503%** |
| gr:sus25 | **12W-0L** | **+1.206%** | 4W-1L | +0.248% |
| gr:sus50 | **6W-0L** | +0.272% | 2W-0L | +0.736% |
| hc:base | 7W-2L-5T | +0.395% | 2W-2L-4T | −0.002% |
| hc:sus25 | 2W-0L-1T | +1.452% | — | — |
| hc:time | 3W-2L-2T | +1.020% | 0W-2L-2T | −0.102% |

**Positive mean in every stratum, with perfect sweeps on both small-data Grinsztajn strata** — exactly the regime the diagnosis identified. The strata that miss the sign bar miss it because the bar counts ties against the change (hc:base is 7W-2L among decided sets; hc:sus50 has n=2). The tier-1 Brier watch item resolved positively. Fit cost 4.0x → 4.7x.

### The Pareto move

**A 5-member refit bag beats the plain 8-member bag on both axes** — stronger in five of seven strata (gr:base 44W-15L, gr:sus25 11W-1L, hc:sus25 3W-0L) at **3.2x vs 4.0x fit time**. So the cheapest way to buy accuracy from bagging is now fewer, better members.

`Ens3RM` does **not** clear that bar — at 2.1x it is a genuine wash (35W-24L on base but 2W-10L on high-card). The blended-% column flatters it; the sign test is the trustworthy reading, so the claim stops at five members.

## Scope and honesty

- Bagged rungs (quality 4/5) only. **Default single-model behaviour is byte-identical**, so `images/pareto.png` and the README need no refresh.
- Opt-in `refit_members=False`, following the `refit_full` precedent where the default flip was Nathan's call.
- **Multiclass is gated off** — there is no replay path for vector-leaf trees, so a member refit would cost a full extra fit rather than a cheap replay. Multiclass Brier remains the one column we lose to CatBoost (91.1 vs 98.8).
- The **single-model** small-data collapse is untouched and remains the largest known headroom.

906 tests pass; 10 new ones lock the contract (default off, off byte-identical, on engages, member structures preserved and mutually distinct, single-model and explicit-`eval_set` paths untouched, multiclass unchanged, clone roundtrip).

## Also in this PR: four hypotheses killed before any library change

All four were top-ranked by a 15-candidate ideation and a three-judge panel. Each was killed by a cheap probe, and each is written down in `benchmarks/BREAKTHROUGH_PLAN.md`:

1. **"We lose because we're miscalibrated"** — refuted from the MCB term the harness already records. We are the *best*-calibrated model in the field (0.00220 vs CatBoost 0.00231), and perfectly recalibrating both sides leaves the scoreboard identical.
2. **Richer calibration maps** (Platt/beta/isotonic) — killed out-of-sample. Platt is a wash, and *uncalibrated* probabilities already score like the shipped temperature. Every Grinsztajn binary set is class-balanced, so the intercept has no skewed operating point to correct.
3. **CatBoost's `random_strength` + `bagging_temperature`** — killed by **ablating the opponent**. CatBoost's edge on the six sets where it beats us is +0.624% at defaults and +0.269% with both disabled, with the single ablations disagreeing about direction.
4. **A linear-leaf per-leaf guard theory** — refuted; forcing constant leaves is worse in every stratum, so linear leaves are load-bearing. The parameterisation staged for it was reverted rather than left as unused surface.

Also settles A2's shelved depth question: the mechanism transfers (every small-data stratum prefers depth 4, every full-size one depth 6), though the magnitude is modest and `cpu_act@sus25` carries most of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
