### PR TITLE
C3: the regressor min-leaf floor is real in direction and too small to ship

### DIFF
--- a/benchmarks/BREAKTHROUGH_PLAN.md
+++ b/benchmarks/BREAKTHROUGH_PLAN.md
@@ -281,7 +281,20 @@ named list of 6-11 datasets.
 
 ---
 
-## Live candidates (broad by construction)
+## Candidates (broad by construction) — ALL THREE RESOLVED as of 2026-08-01
+
+| | candidate | outcome |
+|---|---|---|
+| C1 | bag-member refit | **SHIPPED** opt-in as `refit_members`; all gates passed, and `Ens5RM` dominates `Ens8` on both axes |
+| C2 | per-dataset depth race | mechanism transfers, race **NOT BUILT** — priced below the bar by C3's oracle |
+| C3 | regressor min-leaf floor | **KILLED**: direction real (p=0.002), magnitude inside noise, ceiling too low |
+
+**No live candidate remains in this program.** What the hunt established is in
+Finding 3: the small-data collapse against CatBoost (81% → 50%/33%/0%) is the
+largest known headroom, `refit_members` addresses the bagged half of it, and
+the single-model half is still open. Three capacity levers were aimed at it
+and all three came back too small — capacity is not the mechanism. The next
+program needs a different hypothesis, not another capacity knob.
 
 ### C1 — BAGREFIT: replay each bag member on the full row set
 
@@ -507,6 +520,15 @@ roughly the median.
 and the effect is real but small except where it is enormous. The enormous case
 is the interesting one — see below.
 
+**And the race itself is now closed, priced rather than run** (2026-08-01, by
+C3 below). A per-dataset depth race and a per-dataset `min_child_weight` are
+the same object: a capacity choice with a real direction and a per-dataset
+optimum. C3 measured that family's *oracle* — perfect selection, which no
+implementation can beat — at a median +0.12% per dataset and +0.29% at quarter
+size, against A2's own finding that validation recovers only ~20% of an oracle
+like this. So the achievable prize is roughly +0.02–0.06%, against a program
+bar of a broad +0.25%. **Do not build the depth race.**
+
 ---
 
 ## FINDING 4 — the linear-leaf per-leaf guard is far too permissive on small data
@@ -659,6 +681,70 @@ Pre-registered predictions:
   values and the honest finding is "these arms did nothing", not "the
   mechanism is refuted" — that would call for larger arms, not a closed
   thread.
+
+### Verdict: the effect is REAL and DIRECTIONAL, and far too small to ship. KILLED.
+
+378 cells (42 datasets × 3 seeds × 3 sizes), `results/probe-reg-mcw.jsonl`.
+Two things are true at once, and the program only cares about the second.
+
+**The direction is confirmed, significantly.** Each dataset's own best `mcw`
+rises as its rows shrink on 22 datasets, falls on 5, unchanged on 13 — a sign
+test at **p=0.002**. Small-data regression really does want more min-leaf, and
+the oracle grows the right way too (median best-arm gain +0.104% at full size
+→ +0.290% at quarter size, and +0.577% on the 15 smallest cells).
+
+**The primary pre-registered test fails outright.** `mcw=8` at frac 0.25 is
+23W-17L, median **+0.085%**, Holm-adjusted **p=1.000**. No arm at any size
+comes close — the best p anywhere is 0.615.
+
+| frac | mcw=4 | mcw=8 (primary) | mcw=16 | mcw=32 |
+|---|---|---|---|---|
+| 1.00 | +0.013% (21W-19L) | −0.070% (16W-24L) | −0.266% (15W-25L) | −0.136% (15W-25L) |
+| 0.50 | +0.012% (21W-19L) | −0.043% (19W-21L) | +0.038% (22W-18L) | −0.156% (20W-20L) |
+| 0.25 | +0.046% (21W-19L) | **+0.085% (23W-17L)** | +0.047% (24W-16L) | +0.012% (20W-20L) |
+
+The full-size half of the prediction also holds directionally and weakly: the
+two large arms are the worst cells in the table at frac 1.00, which is the
+oblivious-veto underfit the classifier auto was built to avoid.
+
+**The pre-registered escape hatch does not apply.** The kill rule was
+suspended if rounds and fit seconds were also unmoved, since that would mean
+the veto never bound. It bound: rounds run **1.05–1.24×** and fit time
+**1.01–1.10×** above the mcw=1 arm. The constraint is changing the trees and
+forcing early stopping to run longer — it simply does not pay. So this is a
+refutation, not a null from arms that were too small. It is not even a speed
+win to trade against.
+
+**And the ship shape is priced dead.** The pre-registered ship was a
+size-adaptive auto. The best *fixed* arm captures only 13–31% of the oracle,
+so a schedule cannot recover the per-dataset scatter — at frac 0.25 the
+winning arm is spread across all five values. The alternative shape, a
+per-dataset race, is capped by the oracle itself: median **+0.120%** per
+dataset, and A2's config-portfolio measured that validation recovers only
+**~20% of an oracle** like this. That lands around +0.02–0.06% against a
+program bar of a broad +0.25%.
+
+⇒ **KILLED without shipping**: `min_child_weight` as a small-data regression
+lever, in both the fixed and size-adaptive forms. The regressor keeps 1.0.
+
+**What this also settles, by pricing the shape rather than the knob**: C2's
+depth race is the same object — a per-dataset capacity choice with a real
+direction and a per-dataset optimum. Its own measured prize was a +0.138%
+median on `gr:sus25`; this probe independently prices the whole
+capacity-racing family at a +0.12–0.29% *oracle*, before the ~80% haircut
+that selecting on validation costs. **Racing capacity per dataset is below
+the bar as a family**, which is a stronger statement than either measurement
+alone and is why C2 should not be built either. (An argument from a priced
+ceiling, not a sign test on the depth race — but the ceiling is the binding
+constraint, and it binds well under the bar.)
+
+The one dataset that keeps confessing is `cpu_act@0.25`: **+7.77%** from
+`mcw=8`, after **+16.41%** from depth 4. Same story as Finding 4 — its
+capacity preference is enormous and idiosyncratic. Everything the program has
+measured says that is a property of that dataset, not a rule we can infer
+from n.
+
+Probe: `benchmarks/probe_reg_mcw.py` (resumable, `--table-only` reprints).
 
 ---
 

--- a/benchmarks/BREAKTHROUGH_PLAN.md
+++ b/benchmarks/BREAKTHROUGH_PLAN.md
@@ -596,7 +596,7 @@ beat CatBoost while fitting in half the time. The panel's most expensive build
 (judged feasibility 3.0, the lowest of 15) would chase the smallest target.
 Not pursued. Script: `scratchpad/oblivious_tax.py`.
 
-### C3 — the regressor has no effective min-leaf constraint (unprobed)
+### C3 — the regressor has no effective min-leaf constraint
 
 For squared error the Hessian is exactly 1 per row, so `min_child_weight=1.0`
 means "at least one sample" — the weakest possible veto, at every dataset
@@ -604,6 +604,61 @@ size. The classifier fades one in via `_auto_min_child_weight`; the regressor
 pins 1.0 forever. The PMLB random-search study found `min_child_weight` is the
 one knob that transfers. Whether small-data regression wants a real min-leaf
 floor has never been tested, and `@sus*` regression is where it would show.
+
+#### Probe design (pre-registered 2026-08-01, before any results)
+
+`benchmarks/probe_reg_mcw.py`. The decide strata carry too few regression
+sets at `@sus*` (6-7 in gr:sus25, 3 in gr:sus50) to answer this, so the probe
+applies the sus mechanism to **every** decision-suite regression set:
+
+- **Datasets**: all 42 regression sets we decide on — 19 `gr:reg_num`,
+  17 `gr:reg_cat`, 6 `hc:` (wine-reviews, colleges, house_prices_nominal,
+  black_friday, employee_salaries, Moneyball). No `pub:` (post-hoc only),
+  no TabArena in any form.
+- **Sizes**: train fraction ∈ {1.00, 0.50, 0.25} using the harness's own
+  `_subsample_train` (random_state=0, **test set unchanged**) — exactly the
+  `@sus` semantics, learning-curve reading.
+- **No extra row cap**: `frac=1.0` is the harness's own size (the 50k `gr:` /
+  100k `hc:` builder caps), so the top of every curve is the regime the
+  decide gate actually runs. A 20k cap was in the first draft and was cut
+  after pricing it: it would have shrunk the full-size arm on 20 of the 42
+  sets (`hc:wine-reviews` 75,000 → 15,000 rows) while saving 16 minutes on a
+  ~45-minute run — measured, not guessed, from the decide run's own recorded
+  fit times (105.3 s for one seed across all 42 sets).
+- **Arms**: `min_child_weight` ∈ {1 (shipped), 4, 8, 16, 32} — for squared
+  error these ARE min rows per child. Everything else is the out-of-box
+  default the harness measures (`n_estimators=2000`,
+  `early_stopping_rounds=50`, `random_state=0`). Split 0.25 test at
+  `random_state=seed`, seeds 0-2, all arms exactly paired on each split.
+- **Primary arm is `mcw=8`**, named here before the run. Four arms × three
+  sizes is twelve chances to find a majority in noise, so the other three are
+  supporting evidence and every sign test carries a **Holm correction across
+  the four arms**.
+- **Reading**, all conventions matched to the house tools: seeds averaged on
+  the metric before any ratio (never a mean of per-seed percentages);
+  wins/losses/**ties** on `compare_runs`' ±1e-9 dead band, so an arm whose
+  veto never binds reads as a tie rather than a loss; near-solved excluded on
+  the **best** arm in the cell, matching `compare_runs.is_near_solved`;
+  per-dataset rows printed before any aggregate. Rounds and fit seconds are
+  printed as ratios — a real veto should make fits cheaper.
+
+Pre-registered predictions:
+
+- **C3 right**: `mcw=8` beats `mcw=1` at frac 0.25 on a Holm-corrected sign
+  test, each dataset's **own** best mcw rises as its rows shrink (counted
+  within datasets, so it cannot be an artefact of which datasets sit in which
+  size bucket), and at full size large mcw is neutral-to-harmful (the
+  oblivious-veto underfit that made the classifier auto fade to zero above 2k
+  rows). Ship shape: a size-adaptive regressor auto analogous to
+  `_auto_min_child_weight`, then the standard tier-1 synth + tier-2 decide
+  gates.
+- **C3 wrong**: flat-to-negative at every size ⇒ the thread closes for good:
+  the regressor keeps `min_child_weight=1.0` and the small-data deficit is
+  not a min-leaf story. **One caveat is pre-registered against that kill**:
+  if rounds and fit seconds are *also* unmoved, the veto never bound at these
+  values and the honest finding is "these arms did nothing", not "the
+  mechanism is refuted" — that would call for larger arms, not a closed
+  thread.
 
 ---
 

--- a/benchmarks/probe_reg_mcw.py
+++ b/benchmarks/probe_reg_mcw.py
@@ -1,0 +1,422 @@
+"""Probe C3: does small-data REGRESSION want a real min_child_weight floor?
+
+MECHANISM HYPOTHESIS (pre-registered 2026-08-01, before any results —
+BREAKTHROUGH_PLAN.md "C3"):
+
+For squared error the Hessian is exactly 1 per row, so the regressor's
+min_child_weight=1.0 means "each child holds >= 1 sample" — no constraint at
+all, at every dataset size. The classifier fades a veto in below ~2k rows
+(`_auto_min_child_weight`: full veto under 500 rows, gone above 2000); the
+regressor pins 1.0 forever. The PMLB random-search study found
+min_child_weight is the ONE knob whose tuning transfers. And Finding 3 says
+our win rate vs CatBoost collapses exactly on small data, where sparse leaves
+are the obvious suspect the regressor is structurally blind to.
+
+For squared error, min_child_weight IS min-rows-per-child, so the arms below
+read directly as a per-leaf sample floor.
+
+DESIGN. The decide strata carry too few regression sets at @sus* (6-7 in
+gr:sus25, 3 in gr:sus50) to answer this, so the probe applies the sus
+mechanism to EVERY decision-suite regression set: split 25% test at
+random_state=seed (the harness convention), then shrink the TRAINING rows to
+{100%, 50%, 25%} with the harness's own `_subsample_train` (random_state=0,
+test set unchanged) — each dataset becomes its own three-point learning
+curve, scored on identical test rows. NO extra row cap: frac=1.0 is the
+harness's own size (the 50k gr: / 100k hc: builder caps), so the top of the
+curve is the regime the decide gate actually runs.
+
+ARMS (exactly paired: same split, same shrink, only min_child_weight moves):
+    mcw in {1 (shipped), 4, 8, 16, 32}
+Everything else is the out-of-box default the harness measures
+(n_estimators=2000, early_stopping_rounds=50, random_state=0). PRIMARY ARM
+is mcw=8, named before the run; the other three are supporting evidence and
+the sign tests carry a Holm correction across the four, because four arms
+times three sizes is twelve chances to find a majority in noise.
+
+PREDICTIONS:
+  C3 right: the primary arm beats mcw=1 at frac 0.25 on a Holm-corrected
+  sign test, each dataset's own best mcw rises as its rows shrink, and at
+  full size large mcw is neutral-to-harmful (the oblivious-veto underfit that
+  made the classifier auto fade to zero). Ship shape: a size-adaptive
+  regressor auto, then the standard tier-1/tier-2 gates.
+  C3 wrong: flat-to-negative at every size => thread closes; the small-data
+  deficit is not a min-leaf story. Read the COST block before concluding
+  that: if rounds and fit seconds are also unmoved, the veto never bound and
+  the honest finding is "the arm did nothing at these values", not "the
+  mechanism is refuted".
+
+READING CONVENTIONS, all matched to the house tools:
+  * seeds are averaged on the METRIC, then one ratio is formed per cell
+    (compare_runs / probe_bag_member_refit convention) — not a mean of
+    per-seed percentages, which would weight the easiest split most.
+  * wins/losses/ties use compare_runs' +/-1e-9 dead band, so "the veto never
+    bound" shows as a tie rather than being booked as a loss.
+  * near-solved cells are excluded on the BEST arm in the cell, matching
+    compare_runs.is_near_solved (best across models), not on the baseline.
+  * per-dataset rows are printed before any verdict, so the size claim is
+    checkable rather than eyeballed off a population median.
+
+CAVEATS THE OUTPUT STATES RATHER THAN HIDES:
+  * 8 of the 42 keys are the same source data entered twice (abalone,
+    Bike_Sharing_Demand, Brazilian_houses, delays_zurich_transport, diamonds,
+    house_sales, medical_charges, nyc-taxi-green-dec-2016 appear in both
+    reg_num and reg_cat), so the win denominators rest on ~34 independent
+    sources.
+  * `rounds` is `best_iteration_`, which under the default refit_full="replay"
+    is the full-data refit budget (~t_star/0.8, clipped at n_estimators), not
+    the raw early-stopping optimum. Direction survives, magnitude is rescaled.
+  * fit seconds are probe-internal only (thread_count is left at the class
+    default, while the harness pins it), never comparable to a harness
+    slowdown figure.
+  * n_train is PRE-split; the model's own early-stopping split takes 20%, so
+    the classifier's 500/2000-row fade region lands at 625/2500 on this axis.
+    The tables print post-split rows to keep the comparison honest.
+
+Primary metric: test RMSE. Resumable JSONL; `--table-only` reprints.
+"""
+
+import json
+import math
+import os
+import sys
+import time
+
+import numpy as np
+from sklearn.model_selection import train_test_split
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import run_benchmarks as rb                     # noqa: E402
+from research import datasets as rdata          # noqa: E402
+from summarize import NEAR_SOLVED_NRMSE         # noqa: E402
+
+import chimeraboost                             # noqa: E402
+from chimeraboost import ChimeraBoostRegressor  # noqa: E402
+
+RESULTS = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                       "results", "probe-reg-mcw.jsonl")
+SEEDS = (0, 1, 2)
+FRACS = (1.0, 0.5, 0.25)
+ARMS = (1.0, 4.0, 8.0, 16.0, 32.0)      # 1.0 == the shipped regressor default
+PRIMARY_ARM = "8"                       # named before the run
+TIE_BAND = 1e-9                         # compare_runs' dead band
+ES_FRACTION = 0.8                       # model's own early-stopping split keeps 80%
+
+# hc: first — those six need a live OpenML fetch (nothing is cached locally and
+# two are 100k rows), so a network problem surfaces in the first minute rather
+# than after an hour of Grinsztajn work.
+DATASETS = (
+    [f"hc:{n}" for n, spec in rb.HC_DATASETS.items()
+     if spec["task"] == "regression"]
+    + [f"gr:reg_num/{n}" for n in rb.GRINSZTAJN_DATASETS["reg_num"]]
+    + [f"gr:reg_cat/{n}" for n in rb.GRINSZTAJN_DATASETS["reg_cat"]]
+)
+
+
+def _done():
+    seen = set()
+    if os.path.exists(RESULTS):
+        with open(RESULTS, "r", encoding="utf-8") as f:
+            for line in f:
+                if line.strip():
+                    try:
+                        r = json.loads(line)
+                        seen.add((r["dataset"], r["seed"], r["frac"]))
+                    except Exception:
+                        pass
+    return seen
+
+
+def main():
+    print(f"chimeraboost from {chimeraboost.__file__}")
+    rb._add_highcard_datasets()   # rdata registers oml/gr/pm but not hc
+    done = _done()
+    try:
+        for key in DATASETS:
+            try:
+                X, y, cat, task = rdata.load(key)
+                assert task == "regression", f"{key} is not regression"
+                print(f"\n=== {key}  n={len(y)}  p={X.shape[1]}", flush=True)
+                for seed in SEEDS:
+                    Xtr0, Xte, ytr0, yte = train_test_split(
+                        X, y, test_size=0.25, random_state=seed)
+                    y_std = float(np.std(y))
+                    for frac in FRACS:
+                        if (key, seed, frac) in done:
+                            continue
+                        _run_cell(key, seed, frac, Xtr0, ytr0, Xte, yte,
+                                  cat, y_std)
+            except Exception as exc:            # one bad dataset must not
+                print(f"  [skip] {key}: {type(exc).__name__}: {exc}",
+                      flush=True)               # cost the other 41
+    finally:
+        table()
+
+
+def _run_cell(key, seed, frac, Xtr0, ytr0, Xte, yte, cat, y_std):
+    Xtr, ytr = rb._subsample_train(Xtr0, ytr0, frac, "regression")
+    rec = {"dataset": key, "seed": seed, "frac": frac,
+           "n_train": int(len(ytr)), "y_std": y_std,
+           "rmse": {}, "rounds": {}, "fit_s": {}}
+    line = f"  s{seed} f{frac:4.2f} n={len(ytr):>6d} "
+    for mcw in ARMS:
+        t0 = time.time()
+        m = ChimeraBoostRegressor(
+            n_estimators=rb.MAX_ITERS, early_stopping_rounds=rb.PATIENCE,
+            min_child_weight=mcw, random_state=0)
+        m.fit(Xtr, ytr, cat_features=cat)
+        fit_s = time.time() - t0
+        k = str(int(mcw))
+        rec["rmse"][k] = float(np.sqrt(np.mean((yte - m.predict(Xte)) ** 2)))
+        rec["rounds"][k] = int(m.best_iteration_)
+        rec["fit_s"][k] = fit_s
+        line += f" | {k}: {rec['rmse'][k]:.5g}"
+    os.makedirs(os.path.dirname(RESULTS), exist_ok=True)
+    with open(RESULTS, "a", encoding="utf-8") as f:
+        f.write(json.dumps(rec) + "\n")
+    print(line, flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+def _sign_p(w, l):
+    """Two-sided exact binomial p at q=0.5 (ties already excluded)."""
+    n = w + l
+    if n == 0:
+        return 1.0
+    k = min(w, l)
+    tail = sum(math.comb(n, i) for i in range(0, k + 1)) / (2.0 ** n)
+    return min(1.0, 2.0 * tail)
+
+
+def _holm(pvals):
+    """Holm-Bonferroni adjusted p-values, same order as the input."""
+    order = sorted(range(len(pvals)), key=lambda i: pvals[i])
+    out, running = [0.0] * len(pvals), 0.0
+    for rank, i in enumerate(order):
+        adj = min(1.0, pvals[i] * (len(pvals) - rank))
+        running = max(running, adj)      # enforce monotonicity
+        out[i] = running
+    return out
+
+
+def _median_ci(vals, n_boot=2000, seed=0):
+    if not vals:
+        return (float("nan"), float("nan"))
+    rng = np.random.default_rng(seed)
+    a = np.asarray(vals, dtype=float)
+    meds = np.median(rng.choice(a, size=(n_boot, len(a)), replace=True), axis=1)
+    return float(np.percentile(meds, 2.5)), float(np.percentile(meds, 97.5))
+
+
+def _wlt(gains):
+    w = sum(1 for g in gains if g > TIE_BAND)
+    l = sum(1 for g in gains if g < -TIE_BAND)
+    return w, l, len(gains) - w - l
+
+
+def _cells(rows):
+    """{(dataset, frac): {arm: mean rmse over seeds, ...}} plus metadata.
+
+    Seeds are averaged on the METRIC before any ratio is formed — the house
+    convention (compare_runs, probe_bag_member_refit)."""
+    from collections import defaultdict
+    grouped = defaultdict(list)
+    for r in rows:
+        grouped[(r["dataset"], r["frac"])].append(r)
+    out = {}
+    for cellkey, rs in grouped.items():
+        arms = {k: float(np.mean([r["rmse"][k] for r in rs]))
+                for k in rs[0]["rmse"]}
+        out[cellkey] = {
+            "rmse": arms,
+            "rounds": {k: float(np.mean([r["rounds"][k] for r in rs]))
+                       for k in rs[0]["rounds"]},
+            "fit_s": {k: float(np.mean([r["fit_s"][k] for r in rs]))
+                      for k in rs[0]["fit_s"]},
+            "n_train": int(np.mean([r["n_train"] for r in rs])),
+            "y_std": rs[0]["y_std"],
+            "n_seeds": len(rs),
+        }
+    return out
+
+
+def table():
+    if not os.path.exists(RESULTS):
+        print("no results yet")
+        return
+    rows = []
+    with open(RESULTS, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                rows.append(json.loads(line))
+    if not rows:
+        print("no results yet")
+        return
+
+    arm_keys = [str(int(a)) for a in ARMS if a != 1.0]
+    all_keys = [str(int(a)) for a in ARMS]
+    cells = _cells(rows)
+
+    # Near-solved exclusion on the BEST arm in the cell (compare_runs rule),
+    # plus explicit drops for degenerate targets that the ratio cannot express.
+    kept, dropped = {}, []
+    for ck, c in cells.items():
+        base = c["rmse"].get("1")
+        best = min(c["rmse"].values()) if c["rmse"] else None
+        if not base or base <= 0 or c["y_std"] <= 0:
+            dropped.append((ck, "degenerate"))
+        elif best / c["y_std"] < NEAR_SOLVED_NRMSE:
+            dropped.append((ck, "near-solved"))
+        else:
+            kept[ck] = c
+
+    def gain(c, k):
+        return 100.0 * (c["rmse"]["1"] - c["rmse"][k]) / c["rmse"]["1"]
+
+    datasets = sorted({ds for ds, _ in kept})
+    print("\n" + "=" * 104)
+    print("C3 PROBE - regressor min_child_weight sweep")
+    print("  % RMSE improvement over the shipped mcw=1. Cells are 3-seed means "
+          "of RMSE, then one ratio.")
+    print("  Positive = the min-leaf floor helps. Near-solved cells excluded on "
+          "the best arm.")
+    print(f"  PRIMARY ARM (named before the run): mcw={PRIMARY_ARM}. Sign tests "
+          "are Holm-corrected across the 4 arms.")
+    print("  NOTE: 8 of 42 keys are the same source data in both reg_num and "
+          "reg_cat, so the")
+    print("  denominators rest on ~34 independent sources.")
+    print("=" * 104)
+
+    # ---- Block A: per-dataset rows, printed BEFORE any verdict -------------
+    for frac in FRACS:
+        present = [ds for ds in datasets if (ds, frac) in kept]
+        if not present:
+            continue
+        print(f"\n-- per dataset, train fraction {frac:.2f} " + "-" * 60)
+        print(f"{'dataset':44s}{'rows':>7s}{'post':>7s}"
+              + "".join(f"{'mcw=' + k:>11s}" for k in arm_keys) + "   best")
+        for ds in present:
+            c = kept[(ds, frac)]
+            best = min(all_keys, key=lambda k: c["rmse"][k])
+            line = (f"{ds[:44]:44s}{c['n_train']:>7d}"
+                    f"{int(c['n_train'] * ES_FRACTION):>7d}")
+            for k in arm_keys:
+                line += f"{gain(c, k):+10.3f}%"
+            print(line + f"   {best:>4s}")
+
+    # ---- Block B: verdict per fraction, W-L-T + Holm sign test ------------
+    print("\n" + "=" * 104)
+    print("VERDICT by train fraction (W-L-T uses compare_runs' 1e-9 dead band; "
+          "p is Holm-adjusted)")
+    print("=" * 104)
+    for frac in FRACS:
+        present = [ds for ds in datasets if (ds, frac) in kept]
+        if not present:
+            continue
+        gains = {k: [gain(kept[(ds, frac)], k) for ds in present]
+                 for k in arm_keys}
+        raw_p = [_sign_p(*_wlt(gains[k])[:2]) for k in arm_keys]
+        adj_p = _holm(raw_p)
+        print(f"\n  frac {frac:.2f}   ({len(present)} datasets)")
+        for k, p in zip(arm_keys, adj_p):
+            w, l, t = _wlt(gains[k])
+            lo, hi = _median_ci(gains[k])
+            star = "  <== PRIMARY" if k == PRIMARY_ARM else ""
+            print(f"    mcw={k:>2s}  median {np.median(gains[k]):+7.3f}% "
+                  f"[{lo:+.3f}, {hi:+.3f}]   {w:>2d}W-{l:>2d}L-{t:>2d}T   "
+                  f"p={p:.3f}{star}")
+
+    # ---- Block C: the cost read (pre-registered) --------------------------
+    print("\n" + "=" * 104)
+    print("COST - median ratio to the mcw=1 arm. A veto that never BINDS moves "
+          "neither column;")
+    print("  that reads as 'the arm did nothing', not as a refutation. "
+          "(fit seconds are probe-internal:")
+    print("  thread_count is unpinned, so never compare these to a harness "
+          "slowdown.)")
+    print("=" * 104)
+    print(f"{'frac':>6s}" + "".join(f"{'mcw=' + k:>22s}" for k in arm_keys))
+    print(f"{'':>6s}" + "".join(f"{'rounds    fit':>22s}" for k in arm_keys))
+    for frac in FRACS:
+        present = [ds for ds in datasets if (ds, frac) in kept]
+        if not present:
+            continue
+        line = f"{frac:>6.2f}"
+        for k in arm_keys:
+            rr = np.median([kept[(ds, frac)]["rounds"][k]
+                            / max(kept[(ds, frac)]["rounds"]["1"], 1)
+                            for ds in present])
+            fr = np.median([kept[(ds, frac)]["fit_s"][k]
+                            / max(kept[(ds, frac)]["fit_s"]["1"], 1e-9)
+                            for ds in present])
+            line += f"{rr:>13.2f}x{fr:>7.2f}x"
+        print(line)
+
+    # ---- Block D: the mechanism read, per dataset -------------------------
+    # "the best mcw rises as rows shrink" is a WITHIN-dataset claim, so count
+    # datasets, not pooled cells.
+    print("\n" + "=" * 104)
+    print("MECHANISM - does each dataset's OWN best mcw rise as its rows "
+          "shrink?")
+    print("  Per dataset: the argmin-RMSE arm at each fraction. This is the "
+          "pre-registered claim,")
+    print("  counted within datasets so bucket membership cannot stand in for "
+          "dataset identity.")
+    print("=" * 104)
+    up = down = flat = 0
+    print(f"{'dataset':44s}{'f=1.00':>9s}{'f=0.50':>9s}{'f=0.25':>9s}"
+          f"{'  direction':>12s}")
+    for ds in datasets:
+        best = {}
+        for frac in FRACS:
+            if (ds, frac) in kept:
+                c = kept[(ds, frac)]
+                best[frac] = int(min(all_keys, key=lambda k: c["rmse"][k]))
+        if len(best) < 2:
+            continue
+        hi_f, lo_f = max(best), min(best)
+        d = best[lo_f] - best[hi_f]      # smaller data minus larger data
+        direction = "rises" if d > 0 else ("falls" if d < 0 else "flat")
+        up += d > 0
+        down += d < 0
+        flat += d == 0
+        print(f"{ds[:44]:44s}"
+              + "".join(f"{best.get(f, '-'):>9}" for f in FRACS)
+              + f"{direction:>12s}")
+    print(f"\n  best arm RISES as data shrinks on {up} datasets, FALLS on "
+          f"{down}, unchanged on {flat}.")
+    print(f"  sign test on the datasets that moved: p={_sign_p(up, down):.3f}")
+
+    # ---- Block E: extremes, with the denominator visible ------------------
+    flat_list = []
+    for (ds, frac), c in kept.items():
+        for k in arm_keys:
+            flat_list.append((gain(c, k), ds, frac, k,
+                              c["rmse"]["1"] / c["y_std"],
+                              c["rmse"]["1"] - c["rmse"][k]))
+    flat_list.sort()
+    print("\n" + "=" * 104)
+    print("EXTREMES - baseline NRMSE and the ABSOLUTE delta are printed so a "
+          "big % on a tiny")
+    print("  denominator cannot pass for a big effect.")
+    print("=" * 104)
+    for g, ds, frac, k, nrmse, delta in flat_list[:6]:
+        print(f"  {g:+9.3f}%  {ds[:40]:40s} f={frac:.2f} mcw={k:>2s}  "
+              f"NRMSE={nrmse:6.3f}  dRMSE={delta:+.5g}")
+    print("  ...")
+    for g, ds, frac, k, nrmse, delta in flat_list[-6:]:
+        print(f"  {g:+9.3f}%  {ds[:40]:40s} f={frac:.2f} mcw={k:>2s}  "
+              f"NRMSE={nrmse:6.3f}  dRMSE={delta:+.5g}")
+
+    if dropped:
+        print(f"\nexcluded cells ({len(dropped)}): "
+              + ", ".join(f"{d}@{f}[{why}]" for (d, f), why in dropped))
+
+
+if __name__ == "__main__":
+    if "--table-only" in sys.argv:
+        table()
+    else:
+        main()


### PR DESCRIPTION
Closes the last open candidate in the breakthrough program. **No library change** — this is a probe script plus the verdict it produced.

## What C3 asked

For squared error the Hessian is exactly 1 per row, so the regressor's `min_child_weight=1.0` means "a leaf needs at least one sample" — no constraint at all, at any dataset size. The classifier fades a real floor in below ~2,000 rows (`_auto_min_child_weight`); the regressor never has. Since our win rate against CatBoost collapses precisely on small data (Finding 3), sparse leaves were the obvious suspect the regressor is structurally blind to.

The decide strata carry too few regression sets at `@sus*` to answer this, so the probe applies the sus mechanism to **every** decision-suite regression set: split test at `random_state=seed`, then shrink training rows to 100/50/25% with the harness's own `_subsample_train`, so each dataset becomes its own three-point learning curve scored on identical test rows. 42 datasets × 3 seeds × 3 sizes = 378 cells.

## Verdict: real direction, unshippable magnitude. KILLED.

**The direction is confirmed, significantly.** Each dataset's own best `mcw` rises as its rows shrink on 22 datasets, falls on 5, unchanged on 13 — sign test **p=0.002**.

**The primary pre-registered test fails outright.** `mcw=8` at quarter size is 23W-17L, median **+0.085%**, Holm-adjusted **p=1.000**. The best p anywhere in the table is 0.615.

| frac | mcw=4 | mcw=8 (primary) | mcw=16 | mcw=32 |
|---|---|---|---|---|
| 1.00 | +0.013% (21W-19L) | −0.070% (16W-24L) | −0.266% (15W-25L) | −0.136% (15W-25L) |
| 0.50 | +0.012% (21W-19L) | −0.043% (19W-21L) | +0.038% (22W-18L) | −0.156% (20W-20L) |
| 0.25 | +0.046% (21W-19L) | **+0.085% (23W-17L)** | +0.047% (24W-16L) | +0.012% (20W-20L) |

**The pre-registered escape hatch does not apply.** The kill was to be suspended if rounds and fit seconds were unmoved, since that would mean the veto never bound. It bound: rounds run 1.05–1.24× and fit 1.01–1.10× above baseline. The constraint changes the trees and makes early stopping run longer — it just does not pay, and is not even a speed win to trade against.

**The ship shape is priced dead.** The best fixed arm captures only 13–31% of the oracle, so no schedule recovers the per-dataset scatter. A per-dataset race is capped by the oracle itself: median **+0.120%** per dataset, and A2 measured that validation recovers only ~20% of such an oracle — roughly +0.02–0.06% against a program bar of a broad +0.25%.

**That pricing also closes C2.** A depth race and an mcw race are the same object, so the capacity-racing *family* is below the bar — a stronger statement than either measurement alone. The depth race should not be built.

## Process note

A three-lens adversarial review ran against the probe *before* the expensive run and caught a blocker of mine: the first draft capped datasets at 20,000 rows, which would have shrunk the full-size arm on 20 of 42 datasets (`hc:wine-reviews` 75,000 → 15,000) to save 16 minutes on a 45-minute run — deleting exactly the half of the pre-registration that tests whether a large floor hurts at full size. It also caught that the effective-size table pooled each dataset with its own nested shrunken twins, the same pooling the decide protocol forbids. Both fixed before the run, along with tie counting on `compare_runs`' dead band, a Holm correction, and a named primary arm.

## Program status

All three candidates are now resolved: C1 shipped (`refit_members`), C2 priced out, C3 killed. Three capacity levers aimed at the small-data collapse all came back too small — capacity is not the mechanism, and the next program needs a different hypothesis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
