### PR TITLE
Close the loop on refit_members: correct the live docs it made wrong

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,8 @@ rather than a clear one. Rules:
 ## Layout
 - `chimeraboost/` library · `tests/` (395+, incl. numerical-identity goldens — bit-identical refactors must keep them green)
 - `benchmarks/` harness + analysis scripts · `benchmarks/tabarena/` sealed-holdout runners · `benchmarks/research/` cascade engine
-- `images/` committed charts (pareto.png is the README headline — refresh after shipping)
+- `images/` committed charts (public_pareto.png is the README/docs headline, from
+  `make_public_pareto.py`; pareto.png is the internal north-star chart — refresh both after shipping)
 - `docs/` user docs — keep terse, no slop, no tuning-priority claims (defaults are Grinsztajn-tuned)
 
 ## Skills

--- a/benchmarks/A2_PLAN.md
+++ b/benchmarks/A2_PLAN.md
@@ -186,6 +186,25 @@ so it is not evidence yet. It only becomes real if it survives the untouched
 instruments: synth screen → Grinsztajn + high-card (sign-tested separately)
 → OpenML one-shot gate. **Nathan's call whether that is worth the run.**
 
+### RESOLVED 2026-08-01 — the transfer question is answered, and the race is dead
+
+Both halves closed in `BREAKTHROUGH_PLAN.md` (C2 and C3):
+
+- **Transfer: confirmed.** The `@sus25`/`@sus50` strata, which did not exist
+  when this was shelved, measure exactly the small-data regime depth 4 was
+  claimed to win. Every small-data stratum has a positive mean for depth 4 and
+  every full-size stratum a negative one, `gr:sus25` 9W-3L. So small data does
+  want less capacity, and a uniform depth 4 is still not shippable.
+- **The race itself: NOT WORTH THE RUN, and priced rather than guessed.** The
+  registered answer was a per-dataset depth race. C3 measured the *oracle* of
+  the capacity-racing family — perfect per-dataset selection, which no
+  implementation can beat — at a median +0.12% per dataset and +0.29% at
+  quarter size. Against this plan's own Phase 0 finding that validation
+  recovers only ~20% of an oracle, the achievable prize is ~+0.02-0.06%,
+  against a program bar of a broad +0.25%.
+
+⇒ **Do not build the depth race.** The thread is closed; no run is pending.
+
 ## Phases
 
 - [x] **Phase 0** — offline headroom + race simulation on PMLB tune

--- a/benchmarks/BAGGING_PLAN.md
+++ b/benchmarks/BAGGING_PLAN.md
@@ -839,22 +839,28 @@ no-replacement samples, parallel workers.**
 - **Strength: targets EXCEEDED.** Cumulative over the Phase-0 Ens5
   baseline: +0.28% (B3) then +0.94% gr (B-samp) primary, with perfect
   tier-2 Brier sweeps (23-0, 8-0) — on top of Ens5's original +2.16% over
-  the single model. Canonical 5-arm close-out runs in flight for the
-  final pareto numbers.
+  the single model. Canonical 5-arm close-out runs **COMPLETE 2026-07-17**
+  (see the checklist below: gr `20260717-112941`, hc `115025`).
 - **Speed: the ≤~12x ceiling was NOT met.** Projected ~30x absolute on gr
   (34.3 baseline × B3 ~1.01 × B-samp 0.874; B4's chart gain is small
   under harness pinning). Every fit-cost lever that touched the ensemble
   mechanism's diversity or data was killed by measurement; what shipped
-  is what survived. Remaining known headroom: B-prep shared binning
-  (hc-heavy, est. single-digit % pooled) — OPEN, queued for a future
-  session. **Kill-rule review (>20x) = Nathan's call**: the program
-  delivered a much stronger, modestly cheaper frontier point rather than
-  a cheap one.
+  is what survived. B-prep **SHIPPED 2026-07-17** as intra-fit prep reuse
+  (the cross-member border sharing it originally named was skipped on
+  measured-ceiling and diversity-risk grounds — see the checklist).
+  **Kill-rule review (>20x): RESOLVED — the frontier point was accepted
+  and the program closed.** It delivered a much stronger, modestly cheaper
+  point rather than a cheap one.
 - **Phase 2 verdicts:** B6 recalibration — **SKIP, documented**: the leg
   it targeted is now the bag's strongest (tier-2 Brier sweeps); nothing
-  to fix. B7 reweighting — queued as a zero-library-change OOB-masked
-  probe (design + downgraded outlook recorded above with Nathan); B8
-  moot unless B7 ships. B5 shared trunk stays parked.
+  to fix. B7 reweighting — **KILLED 2026-07-17** (0/15 vs the registered
+  bar; see the checklist), so B8 is moot. B5 shared trunk stays parked.
+
+**PROGRAM CLOSED.** The one later addition to the bagged path is
+`refit_members` (opt-in, 2026-08-01, `BREAKTHROUGH_PLAN.md` C1): each member
+replays its own structure against all-row gradients, which is more data per
+member rather than a new ensemble mechanism — the only class of change this
+program ever found shippable.
 
 ## Acceptance checklist
 

--- a/benchmarks/CATCROSS_PLAN.md
+++ b/benchmarks/CATCROSS_PLAN.md
@@ -113,6 +113,7 @@ regressing — gdiff wins it), cat_binary +0.27%, adult +0.22%. Losses:
 sick −1.01%, cat_multiclass −0.25%, abalone −0.12%. Gate not burned.
 
 ## VERDICT (2026-07-20) — SHIP RECOMMENDED, merge = Nathan's call
+## → MERGED the same day as PR #24 (`8c6f149`). `cross_features` is on `main` and shipped; nothing here is pending.
 
 All registered bars met, no kill clause tripped:
 - T1 mechanism confirmed (entity-slice concentration, controls exact).

--- a/benchmarks/HIGHCARD_PLAN.md
+++ b/benchmarks/HIGHCARD_PLAN.md
@@ -131,6 +131,12 @@ synthgen freezes).
 
 After shakedown passes: /experiment tier 2 becomes "Grinsztajn + hc, with
 per-suite sign tests reported separately and a pooled union verdict."
+
+**Superseded 2026-07-27 — there is no pooled verdict.** Results are sign-tested
+**per stratum, never pooled** (CLAUDE.md, and `compare_runs.py --by-suite`):
+a variant is a derived view of its parent, so pooling would count its rows
+twice. Read the clause above as "per-suite sign tests reported separately",
+full stop.
 A change that wins only on one suite needs a mechanism story for why.
 Update: `.claude/skills/experiment/SKILL.md`, CLAUDE.md benchmark section,
 memory (algorithm history + a new hc-suite entry). Exact ship-rule weighting

--- a/benchmarks/REFIT_PLAN.md
+++ b/benchmarks/REFIT_PLAN.md
@@ -106,3 +106,19 @@ documented in docs/parameters.md + recipes.md. Consequently no pareto
 or README refresh (the chart measures defaults, which are unchanged)
 and no TabArena re-read needed. The spliced 73.7%/93.0% single-model
 headline stays a plan-file fact, not a chart claim.
+
+### SUPERSEDED 2026-07-26 (0.25.0) — the default did flip, via a cheaper mechanism
+
+`refit_full` now defaults to **`"replay"`**, not `False`. The opt-in decision
+above was made when the only option was the from-scratch refit at ×1.98 fit.
+`REPLAY_PLAN.md` then reused the winner's tree structures and refit only the
+leaf values, getting the same benefit for about two thirds of the cost, and
+`SELECT_PLAN.md` shipped it default-ON as the strongest single-model setting.
+Pass `False` (or `quality=2`) for the pre-0.25 behaviour.
+
+Both open items above are therefore closed: the **canonical 5-arm chart re-run
+is no longer deferred** — the default flip happened under SELECT_PLAN, which
+refreshed the chart at the time — and there is nothing here awaiting a
+decision. The bagged half of this file's "no data tax" claim was also revisited
+and turned out to be true of the ensemble but not of any individual member; see
+`BREAKTHROUGH_PLAN.md` C1, which shipped `refit_members` on that finding.

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -1486,6 +1486,24 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         from-scratch refit — marginally stronger on high-card data, and the
         setting benchmarked in REFIT_PLAN.md. Multiclass ignores ``"replay"``
         and always uses the from-scratch refit (benchmarks/REPLAY_PLAN.md).
+    refit_members : bool, default False
+        The bagged analogue of ``refit_full``, and off by default. A bag member
+        trains on ``max_samples`` of the rows and early-stops on its
+        out-of-bag complement, so its leaf values never see the rows it stopped
+        on — the full-data refit that helps a single model has never fired for
+        it. With ``True`` each member replays its own tree structure against
+        gradients from every row once early stopping is done. Only the leaf
+        values move; the splits stay exactly as that member's own sample grew
+        them, which is where a bag's diversity actually lives.
+
+        Measured on the decision suites, an 8-member bag improves in every
+        stratum, with perfect sweeps on the small-data ones (Grinsztajn at a
+        quarter of the rows 12W-0L, +1.206%), for about 10-17% more fit time.
+        Because each member is individually stronger you can also spend the
+        gain on fewer members: 5 refit members beat a plain 8-member bag on
+        accuracy while fitting about 20% faster. Ignored unless the fit is
+        bagged (``n_ensembles >= 2``), and ignored for multiclass, where a
+        member would need a full refit rather than a cheap structure replay.
     cat_features : list of int or str, or None, default None
         Default categorical columns, given as integer positions and/or column
         names (names resolved against the DataFrame at fit). Used when ``fit`` is
@@ -2178,6 +2196,24 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         from-scratch refit — marginally stronger on high-card data, and the
         setting benchmarked in REFIT_PLAN.md. Multiclass ignores ``"replay"``
         and always uses the from-scratch refit (benchmarks/REPLAY_PLAN.md).
+    refit_members : bool, default False
+        The bagged analogue of ``refit_full``, and off by default. A bag member
+        trains on ``max_samples`` of the rows and early-stops on its
+        out-of-bag complement, so its leaf values never see the rows it stopped
+        on — the full-data refit that helps a single model has never fired for
+        it. With ``True`` each member replays its own tree structure against
+        gradients from every row once early stopping is done. Only the leaf
+        values move; the splits stay exactly as that member's own sample grew
+        them, which is where a bag's diversity actually lives.
+
+        Measured on the decision suites, an 8-member bag improves in every
+        stratum, with perfect sweeps on the small-data ones (Grinsztajn at a
+        quarter of the rows 12W-0L, +1.206%), for about 10-17% more fit time.
+        Because each member is individually stronger you can also spend the
+        gain on fewer members: 5 refit members beat a plain 8-member bag on
+        accuracy while fitting about 20% faster. Ignored unless the fit is
+        bagged (``n_ensembles >= 2``), and ignored for multiclass, where a
+        member would need a full refit rather than a cheap structure replay.
     cat_features : list of int or str, or None, default None
         Default categorical columns, given as integer positions and/or column
         names (names resolved against the DataFrame at fit). Used when ``fit`` is

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -8,7 +8,7 @@ No.
 
 On defaults, it scores around LightGBM and XGBoost or better, and it is much faster
 than CatBoost. Setting `n_ensembles=8` bags the model, which is the strongest setting
-available and beats CatBoost on accuracy at well under half its fit cost on
+short of adding `refit_members=True`, and beats CatBoost on accuracy at well under half its fit cost on
 high-cardinality categorical data.
 
 ## Do I need to one-hot encode categoricals or impute missing values?
@@ -73,8 +73,8 @@ through their own conversion methods, so passing them works whenever you have pa
 
 Mostly, you don't. The defaults are benchmark-tuned, and in our experiments broad
 hyperparameter search bought little that generalized. Two settings address specific
-situations rather than general tuning: `n_ensembles=8` is the maximum-accuracy mode, at
-several times the fit cost, and `depth=8` to `10` suits large, interaction-heavy
+situations rather than general tuning: `n_ensembles=8` with `refit_members=True` is the
+maximum-accuracy mode, at several times the fit cost, and `depth=8` to `10` suits large, interaction-heavy
 regression. [Parameters](parameters.md) documents every option.
 
 ## Is the API stable?

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -122,10 +122,10 @@ See the User Guide: [early stopping](recipes.md#early-stopping) for `eval_set` a
 
 | Parameter | Default | Effect |
 |---|---|---|
-| `n_ensembles` | `None` | `None` or `1` is a single model. `2` or more averages members fit on random row subsamples, which reduces variance. 8 is the recommended size. See the User Guide: [bagging](recipes.md#bagging). |
+| `n_ensembles` | `None` | `None` or `1` is a single model. `2` or more averages members fit on random row subsamples, which reduces variance. 8 is the recommended size; pair it with `refit_members=True` for the strongest configuration. See the User Guide: [bagging](recipes.md#bagging). |
 | `ensemble_n_jobs` | `-1` | Worker processes fitting members concurrently, each on an equal share of the thread budget. Same total cores, identical models, 1.2 to 2x faster wall clock. `1` fits members sequentially. |
 | `max_samples` | `0.8` | Fraction of rows each member trains on, drawn without replacement. This beats the classic bootstrap on both accuracy and fit time; `1.0` restores the full-size with-replacement bootstrap. |
-| `refit_members` | `False` | After a member early-stops on its out-of-bag rows, replay its own tree structure against gradients from every row, so its leaf values stop being estimated from `max_samples` of the data. The splits are untouched, which is where a bag's diversity actually lives. Costs about 10% more fit time. Regression and binary only. |
+| `refit_members` | `False` | After a member early-stops on its out-of-bag rows, replay its own tree structure against gradients from every row, so its leaf values stop being estimated from `max_samples` of the data. The splits are untouched, which is where a bag's diversity actually lives. Costs about 10-17% more fit time, the higher end on larger suites. Five refit members beat eight plain ones on both accuracy and speed. Regression and binary only. |
 
 ## System
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -251,7 +251,9 @@ reg = ChimeraBoostRegressor(n_ensembles=8, random_state=0).fit(X_train, y_train)
 ```
 
 Use `n_ensembles=8`: it is stronger than 5 at similar cost. Avoid `n_ensembles=2`,
-which scores worse than a single model.
+which scores worse than a single model. If you want the most accuracy per unit of
+fit time, turn on [`refit_members`](#reclaiming-the-per-member-data-tax) as well —
+five refit members beat eight plain ones on both accuracy and speed.
 
 Inside a bag, parameters left on auto resolve to member defaults tuned for averaging,
 currently `learning_rate=0.15` and `colsample=0.85`, because averaging tolerates
@@ -279,7 +281,10 @@ reg = ChimeraBoostRegressor(n_ensembles=8, refit_members=True,
 
 Only the leaf values change; the splits stay exactly as each member's own
 sample grew them, which is where a bag's diversity actually lives. Expect
-roughly 10% more fit time. Regression and binary classification only —
+roughly 10-17% more fit time, the higher end on larger suites. Because each
+member is individually stronger, you can also spend the gain on fewer members:
+`n_ensembles=5, refit_members=True` beat a plain eight-member bag on accuracy
+while fitting about 20% faster. Regression and binary classification only —
 multiclass members would need a full refit rather than a cheap replay, so the
 flag is ignored there.
 


### PR DESCRIPTION
Housekeeping found by auditing what shipping `refit_members` (PR #66) left behind. **No behaviour change** — docs, docstrings and plan records only. 509 tests pass.

## The docs half is live right now

`.github/workflows/docs.yml` deploys MkDocs to `gh-pages` on every push to `main` touching `docs/**` or `chimeraboost/**`, and the PR #66 merge touched both. So the stale text below is on the published site as of that merge.

| file | said | problem |
|---|---|---|
| `docs/faq.md:10` | `n_ensembles=8` "is the strongest setting available" | false — 8 members **+ `refit_members`** improves in *every* stratum |
| `docs/faq.md:76` | `n_ensembles=8` "is the maximum-accuracy mode" | same |
| `docs/recipes.md:253` | "Use `n_ensembles=8`" | sat 20 lines above the new `refit_members` subsection with no link between them |
| `docs/parameters.md:128`, `docs/recipes.md:282` | "about 10% more fit time" | that is the 10-dataset probe figure; the decision suites measured **17%** |

Both FAQ sentences are unconditional claims about the library's capability ceiling, so they are wrong regardless of what the default is. I qualified them **without** changing the recommended default — that flip is still yours.

## `refit_members` was missing from the published API reference

`docs/api/regressor.md` and `docs/api/classifier.md` are bare mkdocstrings stubs (`::: chimeraboost.ChimeraBoostRegressor`) with `merge_init_into_class: true` and `__init__.__doc__` empty — so **the class docstring *is* the published API page**. Every other bagging parameter (`n_ensembles`, `ensemble_n_jobs`, `max_samples`, `refit_full`) had a full entry; `refit_members` had none. Added to both classes.

Parameter coverage is now 35/36 on the regressor and 31/32 on the classifier. The one remaining gap is `quality`, which predates this thread and is left alone deliberately.

## Five stale plan records

Each verified against what actually happened, not assumed:

- **`A2_PLAN.md`** still asked whether the depth race was "worth the run". Both halves are now answered — transfer confirmed on the `@sus` strata, and the race itself priced dead by C3's oracle (see #68). Marked resolved with the numbers.
- **`CATCROSS_PLAN.md`** ended at "merge = Nathan's call". It merged the same day as PR #24 (`8c6f149`); `cross_features` is on `main`.
- **`REFIT_PLAN.md`** still recorded "Default stays `False`" and a chart re-run "deferred to the default-flip decision". `refit_full` has defaulted to `"replay"` since 0.25.0 via REPLAY_PLAN/SELECT_PLAN — verified against the live signature. Both items closed.
- **`BAGGING_PLAN.md`**'s status section contradicted its own acceptance checklist three times: close-out runs "in flight" (checklist: done 2026-07-17), B-prep "OPEN" (checklist: shipped), B7 "queued" (checklist: killed). Aligned and marked the program closed.
- **`HIGHCARD_PLAN.md`** still prescribed a "pooled union verdict" for tier 2, which the never-pool rule has forbidden since 2026-07-27.

Plus `CLAUDE.md`, which called `pareto.png` the README headline — the README embeds `public_pareto.png`.

## Not done here, flagged instead

**35 fully-merged branches** are still on `origin`, going back to mid-June (confirmed live via `git ls-remote`), against the "delete a branch when it merges" rule. Deleting remote branches is destructive and outward-facing, so that is your call, not mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
