### PR TITLE
Recover the gate-robustness guards orphaned after PR #73

### DIFF
--- a/.claude/skills/experiment/SKILL.md
+++ b/.claude/skills/experiment/SKILL.md
@@ -78,6 +78,15 @@ Ship rules:
 A/B trap (cost an hour once): editable install means `python script.py` runs **repo** code from any
 CWD. For worktree baselines set `PYTHONPATH=<worktree>` and print `chimeraboost.__file__` in both arms.
 
+**Before letting any number decide a ship, read `benchmarks/GATE_ROBUSTNESS.md`** — the eight ways
+this process has produced numbers that looked like evidence and weren't, each with the incident that
+proved it. The four questions it ends on, in short: how many INDEPENDENT things is this actually;
+what happens if I drop the single biggest contributor; am I comparing the same statistic on both
+sides; was this instrument built to be decided on? Highest-frequency traps: `@time` replication is
+capped at 3 rolling origins so extra seeds duplicate (the harness now warns); a stratum under ~8
+decided datasets is a pointer, not a gate; ties count against the change, so a conditionally-gated
+change reads FAIL at 6W-0L; and a mean far from its median is one dataset (compare_runs now names it).
+
 After a ship: update CHANGELOG [Unreleased], regenerate the Pareto (`/pareto`), and record the
 verdict (win or kill — kills are valuable) in memory's algorithm history.
 

--- a/benchmarks/GATE_ROBUSTNESS.md
+++ b/benchmarks/GATE_ROBUSTNESS.md
@@ -1,0 +1,134 @@
+# Gate robustness — how our benchmark process fools us
+
+Companion to the `/experiment` skill, which says *what* to run. This says where
+the process is brittle, with the incident that proved each one.
+
+The theme, and it recurs: **a number that looks like evidence and isn't.** In
+one day (2026-08-01, SMALLDATA) three separate readings nearly decided a ship
+wrongly — duplicated seeds, a four-dataset stratum, and a mean driven by one
+near-zero denominator. Each was individually reasonable and each was empty. The
+common defence is the same in all three cases: **print the effective sample size
+and the dominant contributor next to every aggregate**, so an empty number
+cannot look full.
+
+---
+
+## 1. Sample size that does not exist
+
+`_temporal_split` takes `TEMPORAL_CUTS[seed % 3]` and has no other
+seed-dependent randomness. **Seed 3 reproduces seed 0 exactly.** A `--seeds 6`
+run on `@time` is still three windows per dataset; the extra seeds return
+identical numbers and the run looks twice as strong as it is.
+
+The `@time` universe is 7 datasets × 3 cuts. That is all of it.
+
+- **Do**: vary `TEMPORAL_CUTS` in a probe when you need more temporal windows.
+- **Don't**: add seeds and believe the denominator.
+- **Guard added**: `run_benchmarks.py` now warns when `--seeds` exceeds the
+  number of distinct cuts and `@time` datasets are in the run.
+
+*Incident*: SMALLDATA C5. The instinct on seeing a 4-dataset regression was
+"run more seeds", which would have produced the identical table and a false
+sense of confirmation.
+
+## 2. Verdicts rendered on strata too small to carry one
+
+Tier-2 prints PASS/FAIL per stratum including `hc:sus50` (n=2, both ties) and
+`hc:time` (7 datasets, 4 of which engaged the change). One of those FAILs was
+carried into a shipping recommendation and later measured as **21W-21L,
+p=1.000** — a coin flip.
+
+- A stratum below roughly 8 decided datasets cannot distinguish a real
+  regression from noise. Read it as a pointer, never as a gate.
+- Before letting a single stratum block a ship, **probe that stratum directly**
+  with more windows or more sources. It is one run and it is decisive.
+
+*Incident*: SMALLDATA tier-2 → C5.
+
+## 3. Hard thresholds always have a just-above case
+
+The near-solved guard excludes classification sets below Brier 0.001. On the
+tier-1 screen `syn:v2/117` sat at **0.0018** — just above — and moved
+0.0018 → 0.0036, an absolute delta of 0.0018 that reads as **−99.85%**. That
+single dataset dragged an 86-set mean to −1.171%; without it the mean is
+−0.010%.
+
+This is the **second** time this class of bug has bitten: the original
+near-solved fix (PR #31) was itself a response to an 88-set mean reading −144%.
+Adding a threshold did not remove the failure mode, it moved it one step out.
+
+- **Never gate on a mean.** The house rule is the sign test and the median.
+- **Guard added**: `compare_runs.py` names the single largest contributor to
+  the mean whenever `|mean| > 3×|median|`, so a distorted mean announces itself
+  instead of being quietly read.
+
+## 4. The sign bar counts ties against the change
+
+`wins >= n//2 + 1` over **all** datasets. A change that is byte-identical on
+part of the suite therefore fails by construction: tier-2's `hc:base` was
+**6W-0L — zero losses** — and read FAIL because 8 ties outvoted it.
+
+This will get worse, not better. Every conditionally-gated change we ship
+(size-gated, feature-gated, dtype-gated) is deliberately inert on part of the
+suite, so its tie count grows with the quality of its gating.
+
+- Read the **decided-only** count beside the all-dataset bar. `compare_runs`
+  already prints an "excluding near-solved" line; the decided-only reading is
+  the one that answers "when this engaged, did it help?".
+- Record both in plan files. "6W-0L-8T, bar FAIL" is honest; "FAIL" alone is
+  not.
+
+## 5. Cross-program comparisons that mix statistics
+
+Plan files record means and medians inconsistently. A candidate was **killed**
+by comparing its median against `refit_members`' mean — "a quarter of the
+strength for three to five times the cost". On like-for-like medians it was
++0.275% vs +0.304%, i.e. the same trade, and the kill was withdrawn.
+
+- Plan files record **both**, always labelled.
+- Any comparison across programs states which statistic it is using.
+
+## 6. Decision-grade conclusions from non-decision-grade instruments
+
+The first learning-rate probe printed fit-time ratios with `thread_count`
+unpinned, carrying an explicit "never compare to a harness slowdown" caveat —
+and the cost axis then became the axis the decision turned on. The caveat was
+right there and still nearly lost.
+
+- If a number will gate a decision, produce it under pinned conditions. If it
+  cannot be, the probe should refuse to print the column rather than print it
+  with a warning nobody weighs.
+
+## 7. Sweep design: saturation hides the knee
+
+A rate sweep of 0.1 / 0.05 / 0.03 showed strength saturating by 0.05 while cost
+kept climbing. The best point — 0.07, which dominates 0.05 on both axes — was
+never sampled.
+
+- **If the metric saturates at your first alternative while cost keeps rising,
+  the optimum is between it and the baseline.** Sample there before concluding
+  anything about the family.
+
+## 8. Pre-registration has to survive contact with the data
+
+The 0.07 arm was chosen *after* seeing the pilot, which makes that run
+exploratory, not confirmatory — it cannot be cited as a passed test.
+
+- Label post-hoc arm selection as such, in the plan file, at the time.
+- Confirm on data that did not select it. Here tier-1 (synth) and tier-2
+  (decide) did exactly that, which is why the result stands.
+
+---
+
+## The short version
+
+Before a stratum, a mean, or a seed count is allowed to decide anything, ask:
+
+1. **How many independent things is this actually?** (not how many rows the
+   table has)
+2. **What happens to it if I drop the single biggest contributor?**
+3. **Am I comparing the same statistic on both sides?**
+4. **Was this instrument built to be decided on?**
+
+Three of this project's worst readings — −144%, −8e21%, and −1.171% — all
+failed question 2.

--- a/benchmarks/compare_runs.py
+++ b/benchmarks/compare_runs.py
@@ -177,7 +177,7 @@ def _report(shared, base, new, ds_meta, rmse_b, rmse_n, brier_b, brier_n,
 
     wins = losses = ties = 0
     print(f"{'dataset':22s} {base_label:>12s} {new_label:>12s} {'delta':>12s}  result")
-    rel_deltas, all_pairs = [], []
+    rel_deltas, all_pairs, rel_named = [], [], []
     for ds in shared:
         b, n = base[ds], new[ds]
         d = n - b                       # primary is higher-better
@@ -195,6 +195,7 @@ def _report(shared, base, new, ds_meta, rmse_b, rmse_n, brier_b, brier_n,
         # relative improvement (guard tiny/zero base)
         rel = d / abs(b) if abs(b) > 1e-12 else 0.0
         rel_deltas.append(rel)
+        rel_named.append((rel, ds))
         print(f"{ds:22s} {b:12.4f} {n:12.4f} {d:+12.4f}  {tag}  ({rel:+.2%})")
 
     n_ds = len(shared)
@@ -211,9 +212,25 @@ def _report(shared, base, new, ds_meta, rmse_b, rmse_n, brier_b, brier_n,
               f"classification Brier < {NEAR_SOLVED_BRIER}): "
               + ", ".join(sorted(near)))
     if rel_deltas:
+        mean_v, med_v = float(np.mean(rel_deltas)), float(np.median(rel_deltas))
         print(f"mean relative change in {args.metric} (+ = better): "
-              f"{np.mean(rel_deltas):+.3%}   "
-              f"[median {np.median(rel_deltas):+.3%}, n={len(rel_deltas)}]")
+              f"{mean_v:+.3%}   "
+              f"[median {med_v:+.3%}, n={len(rel_deltas)}]")
+        # A mean far from its median is being carried by one or two datasets --
+        # usually a near-zero denominator that sits just ABOVE the near-solved
+        # cutoff, so the guard above never fired. This project has been misread
+        # that way three times (-144%, -8e21%, -1.171%), so name the culprit
+        # rather than leaving the mean to be quoted on its own. Print-only: no
+        # verdict depends on it (benchmarks/GATE_ROBUSTNESS.md #3).
+        if rel_named and abs(mean_v) > 3 * abs(med_v) + 1e-12:
+            worst = max(rel_named, key=lambda t: abs(t[0] - med_v))
+            without = [r for r, d in rel_named if d != worst[1]]
+            if without:
+                print(f"  !! mean is {abs(mean_v) / (abs(med_v) + 1e-12):.0f}x "
+                      f"its median -- largest single contributor is "
+                      f"{worst[1]} at {worst[0]:+.2%}; "
+                      f"mean without it: {float(np.mean(without)):+.3%}. "
+                      f"Read the sign test and the median.")
     else:
         print(f"mean relative change in {args.metric}: n/a (no scored datasets)")
 

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -2052,6 +2052,21 @@ def main():
           + (f"  synth={args.synth_suite}" if args.synth else "")
           + "\n")
 
+    # @time replication is capped by the number of rolling origins, NOT by
+    # --seeds: _temporal_split takes TEMPORAL_CUTS[seed % 3] and nothing else in
+    # that path is seed-dependent, so seed 3 reproduces seed 0 exactly. Without
+    # this warning a --seeds 6 run reports twice the temporal evidence it has
+    # (benchmarks/GATE_ROBUSTNESS.md #1).
+    n_time = sum(1 for ds in selected if ds.endswith(f"{VARIANT_SEP}time"))
+    if n_time and args.seeds > len(TEMPORAL_CUTS):
+        print(f"!! WARNING: {n_time} @time dataset(s) in this run, but "
+              f"--seeds {args.seeds} exceeds the {len(TEMPORAL_CUTS)} rolling "
+              f"origins in TEMPORAL_CUTS. Seeds beyond the first "
+              f"{len(TEMPORAL_CUTS)} REPRODUCE earlier ones exactly on those "
+              f"datasets -- the @time stratum has {len(TEMPORAL_CUTS)} distinct "
+              f"windows per dataset no matter how many seeds you run. Vary "
+              f"TEMPORAL_CUTS in a probe if you need more.\n")
+
     # Run every (dataset, seed) draw, in parallel processes unless jobs == 1.
     tasks = [(ds, s, args.scale, threads_per, model_names, chimera_cfg,
               PATIENCE, ENSEMBLE_N, need_openml, need_grinsztajn, need_pmlb,


### PR DESCRIPTION
`de5b4d1` was pushed to `worktree-smalldata-hunt` *after* PR #73 had already merged, so it never reached `main`. This is the same failure mode as PR #56 → #60. Cherry-picked onto a fresh branch, unchanged.

What it restores:

- **`benchmarks/GATE_ROBUSTNESS.md`** — eight ways a benchmark reading can look like evidence and be empty, each with the incident that proved it, ending on the four questions to ask before any number decides a ship.
- **A `--seeds` warning in `run_benchmarks.py`** — `_temporal_split` indexes `TEMPORAL_CUTS[seed % 3]`, so on `@time` datasets seed 3 reproduces seed 0 exactly. A `--seeds 6` run silently reported twice the temporal evidence it had.
- **A largest-contributor warning in `compare_runs.py`** — when the mean of relative changes exceeds three times its median, name the dataset carrying it and print the mean without that dataset. Print-only; no verdict depends on it.

Verified on this branch:

- The `compare_runs.py` guard fires on the tier-1 synthetic screen: *"mean is 6x its median — largest single contributor is syn:v2/255 at +11.15%; mean without it: +0.431%."*
- Both benchmark scripts compile, and the `run_benchmarks.py` warning's variables are all in scope at that point in `main()`.
- Full suite: 920 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)