### PR TITLE
Say plainly what is borrowed and what is ours

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ reg.fit(X, y)
 * Bagging as a first-class feature (using `n_ensembles`)
 * Automatic early stopping
 * Automatic linear-leaf auditioning
+* Replay mechanism for faster refitting after early stopping
+* Gradient-matrix free multi-quantile split search
 * numba is very fast
 
 <p><a href="https://github.com/bbstats/chimeraboost/blob/main/images/public_pareto.png"><img src="https://raw.githubusercontent.com/bbstats/chimeraboost/main/images/public_pareto.png" width="500" alt="Average rank vs fit-time slowdown on the public suite" /></a></p>
@@ -53,29 +55,16 @@ reg.fit(X, y)
 
 ## Documentation
 
-* [Getting started](https://bbstats.github.io/chimeraboost/getting-started/): install and first models
-* [Recipes](https://bbstats.github.io/chimeraboost/recipes/): categoricals, quantiles, bagging, custom losses, and more
-* [Parameters](https://bbstats.github.io/chimeraboost/parameters/): every option, with defaults and guidance
-* [FAQ](https://bbstats.github.io/chimeraboost/faq/): common questions
-* [Where the ideas come from](https://bbstats.github.io/chimeraboost/attribution/): what is borrowed, what is ours
+* [Getting started](https://bbstats.github.io/chimeraboost/getting-started/)
+* [Recipes](https://bbstats.github.io/chimeraboost/recipes/)
+* [Parameters](https://bbstats.github.io/chimeraboost/parameters/)
+* [FAQ](https://bbstats.github.io/chimeraboost/faq/)
+* [Where the ideas come from](https://bbstats.github.io/chimeraboost/attribution/)
 
 ## Credit where it is due
 
-Almost every idea in ChimeraBoost is someone else's. It is a from-scratch Python
-implementation of published work — the algorithms below were invented by the people
-listed next to them, not by us. If a credit is missing or wrong, please open an issue.
+Most ideas in ChimeraBoost were someone else's.
 
-**What we did build**, so it is not a mystery: the **structure-transfer refit**, where
-early stopping picks the tree count and those trees are then replayed over all your data
-instead of being regrown, so the held-out rows still reach the model. Growing trees is
-about 85% of a fit, and a from-scratch refit re-pays for structure it already has. This
-does not: fit time falls 34.8% on the Grinsztajn suite, faster on 58 of 59 datasets, at
-unchanged accuracy. It is on by default. Also ours: a multi-quantile split search that
-never builds the per-level gradient matrix, and a set of small size-dependent defaults.
-**[Where the ideas come from](https://bbstats.github.io/chimeraboost/attribution/)** maps
-all of it out feature by feature — including which parts of those are themselves borrowed.
-
-* **Gradient boosting**, Friedman, *Annals of Statistics* 2001, and *Stochastic Gradient Boosting*, *Computational Statistics & Data Analysis* 2002. The algorithm itself, shrinkage, row subsampling, and the terminal-node override used for MAE and quantile losses.
 * **CatBoost**, Prokhorenkova et al., *NeurIPS* 2018. Oblivious trees (the tree type itself from Kohavi & Li, *IJCAI* 1995), ordered target statistics, feature combinations, ordered boosting, and the size-dependent automatic learning rate (`adaptive_learning_rate`).
 * **XGBoost**, Chen & Guestrin, *KDD* 2016. Regularized objective, second-order split gain, Newton leaf estimation, `min_child_weight`.
 * **LightGBM**, Ke et al., *NeurIPS* 2017. Histogram-based split finding, which that paper itself treats as prior art (McRank, Li et al. 2007; pGBRT, Tyree et al. 2011).
@@ -85,9 +74,6 @@ all of it out feature by feature — including which parts of those are themselv
 * **Linear-leaf trees**, Shi, Li & Li, *IJCAI* 2019 (arXiv:1802.05640). Piece-wise-linear regression trees (`linear_leaves`); model trees back to Quinlan's M5, 1992.
 * **TreeSHAP**, Lundberg et al., *Nature Machine Intelligence* 2020 (orig. SHAP, *NeurIPS* 2017). Exact additive feature attributions (`shap_values`).
 * **OpenFE**, Zhang et al., *ICML* 2023 (arXiv:2211.12507). Automated pairwise feature generation (`cross_features`).
-* **Quantile regression** — Koenker & Bassett, *Econometrica* 1978; one model for every level, Meinshausen, *JMLR* 2006; the shared-split scoring of **generalized random forests**, Athey, Tibshirani & Wager, *AoS* 2019; the location/spread contrasts it projects on (**L-moments**, Hosking, *JRSS-B* 1990) and cycling through them (**gamboostLSS**, Mayr et al., *JRSS-C* 2012); non-crossing by **monotone rearrangement**, Chernozhukov, Fernández-Val & Galichon, *Econometrica* 2010.
 * **Conformal prediction**, Papadopoulos et al. 2002 and Vovk et al. 2005; **conformalized quantile regression**, Romano, Patterson & Candès, *NeurIPS* 2019. Distribution-free interval calibration (`conformalize`).
 * **Temperature scaling**, Guo et al., *ICML* 2017 (Platt 1999 lineage). Probability calibration.
 * **Bagging and out-of-bag estimation**, Breiman 1996; **subagging**, Bühlmann & Yu, *Annals of Statistics* 2002; column subsampling from *Random Forests* 2001 and random subspaces, Ho, *IEEE TPAMI* 1998. The `n_ensembles` path and `colsample`.
-* **AutoGluon**, Erickson et al. 2020. Refitting the selected model on all the data, and named quality presets. The other half of our replay refit — refreshing leaf values on a tree structure you already have — is XGBoost's `refresh` updater and LightGBM's `Booster.refit()`. Putting the two together is the part that is ours.
-* **scikit-learn**, Buitinck et al., *ECML-PKDD* 2013, and **numba**, Lam, Pitrou & Seibert, 2015. The API conventions and the compiler this is all built on.

--- a/README.md
+++ b/README.md
@@ -67,10 +67,11 @@ listed next to them, not by us. **[Where the ideas come from](https://bbstats.gi
 maps this out feature by feature, including the short list of what actually originated
 here. If a credit is missing or wrong, please open an issue.
 
-* **Gradient boosting**, Friedman, *Annals of Statistics* 2001 (and *Stochastic Gradient Boosting*, 2002). The algorithm itself, shrinkage, and the terminal-node override used for MAE and quantile losses.
-* **CatBoost**, Prokhorenkova et al., *NeurIPS* 2018. Oblivious trees, ordered target statistics, feature combinations, ordered boosting, and the size-dependent automatic learning rate (`adaptive_learning_rate`).
-* **XGBoost**, Chen & Guestrin, *KDD* 2016. Regularized objective, second-order split gain, Newton leaf estimation, `min_child_weight`, column subsampling.
-* **LightGBM**, Ke et al., *NeurIPS* 2017. Histogram-based split finding.
+* **Gradient boosting**, Friedman, *Annals of Statistics* 2001, and *Stochastic Gradient Boosting*, *Computational Statistics & Data Analysis* 2002. The algorithm itself, shrinkage, row subsampling, and the terminal-node override used for MAE and quantile losses.
+* **CatBoost**, Prokhorenkova et al., *NeurIPS* 2018. Oblivious trees (the tree type itself from Kohavi & Li, *IJCAI* 1995), ordered target statistics, feature combinations, ordered boosting, and the size-dependent automatic learning rate (`adaptive_learning_rate`).
+* **XGBoost**, Chen & Guestrin, *KDD* 2016. Regularized objective, second-order split gain, Newton leaf estimation, `min_child_weight`.
+* **Column subsampling** (`colsample`), Breiman, *Random Forests*, 2001; random subspaces, Ho, *IEEE TPAMI* 1998. The XGBoost paper credits these rather than claiming it, and so do we.
+* **LightGBM**, Ke et al., *NeurIPS* 2017. Histogram-based split finding, which that paper itself treats as prior art (McRank, Li et al. 2007; pGBRT, Tyree et al. 2011).
 * **Minimum Variance Sampling**, Ibragimov & Gusev, *NeurIPS* 2019. Gradient-weighted row sampling (`subsample`).
 * **Quantized GBDT training**, Shi, Ke et al., *NeurIPS* 2022. Integer gradient histograms (`quantize_gradients`).
 * **SketchBoost**, Iosipoi & Vakhrushev, *NeurIPS* 2022, and **GBDT-MO**, Zhang & Jung. Vector leaves and the projected gradient used for multiclass and multi-quantile splits.
@@ -78,6 +79,8 @@ here. If a credit is missing or wrong, please open an issue.
 * **TreeSHAP**, Lundberg et al., *Nature Machine Intelligence* 2020 (orig. SHAP, *NeurIPS* 2017). Exact additive feature attributions (`shap_values`).
 * **OpenFE**, Zhang et al., *ICML* 2023 (arXiv:2211.12507). Automated pairwise feature generation (`cross_features`).
 * **Pinball loss**, Koenker & Bassett, *Econometrica* 1978, and **monotone rearrangement**, Chernozhukov, Fernández-Val & Galichon, *Econometrica* 2010. Quantile regression and its non-crossing guarantee.
+* **Quantile regression forests**, Meinshausen, *JMLR* 2006, and **generalized random forests**, Athey, Tibshirani & Wager, *Annals of Statistics* 2019. One fitted model serving every quantile level, and labelling each row by the grid bucket it falls in.
+* **L-moments**, Hosking, *JRSS-B* 1990, and **gamboostLSS**, Mayr et al., *JRSS-C* 2012. The shifted-Legendre location/spread/skew contrasts the quantile split search projects on, and cycling updates through them.
 * **Conformal prediction**, Papadopoulos et al. 2002 and Vovk et al. 2005; **conformalized quantile regression**, Romano, Patterson & Candès, *NeurIPS* 2019. Distribution-free interval calibration (`conformalize`).
 * **Temperature scaling**, Guo et al., *ICML* 2017 (Platt 1999 lineage). Probability calibration.
 * **Bagging and out-of-bag estimation**, Breiman 1996; **subagging**, Bühlmann & Yu, *Annals of Statistics* 2002. The `n_ensembles` path.

--- a/README.md
+++ b/README.md
@@ -63,14 +63,21 @@ reg.fit(X, y)
 
 Almost every idea in ChimeraBoost is someone else's. It is a from-scratch Python
 implementation of published work — the algorithms below were invented by the people
-listed next to them, not by us. **[Where the ideas come from](https://bbstats.github.io/chimeraboost/attribution/)**
-maps this out feature by feature, including the short list of what actually originated
-here. If a credit is missing or wrong, please open an issue.
+listed next to them, not by us. If a credit is missing or wrong, please open an issue.
+
+**What we did build**, so it is not a mystery: the **structure-transfer refit**, where
+early stopping picks the tree count and those trees are then replayed over all your data
+instead of being regrown, so the held-out rows still reach the model. Growing trees is
+about 85% of a fit, and a from-scratch refit re-pays for structure it already has. This
+does not: fit time falls 34.8% on the Grinsztajn suite, faster on 58 of 59 datasets, at
+unchanged accuracy. It is on by default. Also ours: a multi-quantile split search that
+never builds the per-level gradient matrix, and a set of small size-dependent defaults.
+**[Where the ideas come from](https://bbstats.github.io/chimeraboost/attribution/)** maps
+all of it out feature by feature — including which parts of those are themselves borrowed.
 
 * **Gradient boosting**, Friedman, *Annals of Statistics* 2001, and *Stochastic Gradient Boosting*, *Computational Statistics & Data Analysis* 2002. The algorithm itself, shrinkage, row subsampling, and the terminal-node override used for MAE and quantile losses.
 * **CatBoost**, Prokhorenkova et al., *NeurIPS* 2018. Oblivious trees (the tree type itself from Kohavi & Li, *IJCAI* 1995), ordered target statistics, feature combinations, ordered boosting, and the size-dependent automatic learning rate (`adaptive_learning_rate`).
 * **XGBoost**, Chen & Guestrin, *KDD* 2016. Regularized objective, second-order split gain, Newton leaf estimation, `min_child_weight`.
-* **Column subsampling** (`colsample`), Breiman, *Random Forests*, 2001; random subspaces, Ho, *IEEE TPAMI* 1998. The XGBoost paper credits these rather than claiming it, and so do we.
 * **LightGBM**, Ke et al., *NeurIPS* 2017. Histogram-based split finding, which that paper itself treats as prior art (McRank, Li et al. 2007; pGBRT, Tyree et al. 2011).
 * **Minimum Variance Sampling**, Ibragimov & Gusev, *NeurIPS* 2019. Gradient-weighted row sampling (`subsample`).
 * **Quantized GBDT training**, Shi, Ke et al., *NeurIPS* 2022. Integer gradient histograms (`quantize_gradients`).
@@ -78,11 +85,9 @@ here. If a credit is missing or wrong, please open an issue.
 * **Linear-leaf trees**, Shi, Li & Li, *IJCAI* 2019 (arXiv:1802.05640). Piece-wise-linear regression trees (`linear_leaves`); model trees back to Quinlan's M5, 1992.
 * **TreeSHAP**, Lundberg et al., *Nature Machine Intelligence* 2020 (orig. SHAP, *NeurIPS* 2017). Exact additive feature attributions (`shap_values`).
 * **OpenFE**, Zhang et al., *ICML* 2023 (arXiv:2211.12507). Automated pairwise feature generation (`cross_features`).
-* **Pinball loss**, Koenker & Bassett, *Econometrica* 1978, and **monotone rearrangement**, Chernozhukov, Fernández-Val & Galichon, *Econometrica* 2010. Quantile regression and its non-crossing guarantee.
-* **Quantile regression forests**, Meinshausen, *JMLR* 2006, and **generalized random forests**, Athey, Tibshirani & Wager, *Annals of Statistics* 2019. One fitted model serving every quantile level, and labelling each row by the grid bucket it falls in.
-* **L-moments**, Hosking, *JRSS-B* 1990, and **gamboostLSS**, Mayr et al., *JRSS-C* 2012. The shifted-Legendre location/spread/skew contrasts the quantile split search projects on, and cycling updates through them.
+* **Quantile regression** — Koenker & Bassett, *Econometrica* 1978; one model for every level, Meinshausen, *JMLR* 2006; the shared-split scoring of **generalized random forests**, Athey, Tibshirani & Wager, *AoS* 2019; the location/spread contrasts it projects on (**L-moments**, Hosking, *JRSS-B* 1990) and cycling through them (**gamboostLSS**, Mayr et al., *JRSS-C* 2012); non-crossing by **monotone rearrangement**, Chernozhukov, Fernández-Val & Galichon, *Econometrica* 2010.
 * **Conformal prediction**, Papadopoulos et al. 2002 and Vovk et al. 2005; **conformalized quantile regression**, Romano, Patterson & Candès, *NeurIPS* 2019. Distribution-free interval calibration (`conformalize`).
 * **Temperature scaling**, Guo et al., *ICML* 2017 (Platt 1999 lineage). Probability calibration.
-* **Bagging and out-of-bag estimation**, Breiman 1996; **subagging**, Bühlmann & Yu, *Annals of Statistics* 2002. The `n_ensembles` path.
-* **AutoGluon**, Erickson et al. 2020. Refitting the selected model on all the data, and named quality presets.
+* **Bagging and out-of-bag estimation**, Breiman 1996; **subagging**, Bühlmann & Yu, *Annals of Statistics* 2002; column subsampling from *Random Forests* 2001 and random subspaces, Ho, *IEEE TPAMI* 1998. The `n_ensembles` path and `colsample`.
+* **AutoGluon**, Erickson et al. 2020. Refitting the selected model on all the data, and named quality presets. The other half of our replay refit — refreshing leaf values on a tree structure you already have — is XGBoost's `refresh` updater and LightGBM's `Booster.refit()`. Putting the two together is the part that is ours.
 * **scikit-learn**, Buitinck et al., *ECML-PKDD* 2013, and **numba**, Lam, Pitrou & Seibert, 2015. The API conventions and the compiler this is all built on.

--- a/README.md
+++ b/README.md
@@ -57,13 +57,29 @@ reg.fit(X, y)
 * [Recipes](https://bbstats.github.io/chimeraboost/recipes/): categoricals, quantiles, bagging, custom losses, and more
 * [Parameters](https://bbstats.github.io/chimeraboost/parameters/): every option, with defaults and guidance
 * [FAQ](https://bbstats.github.io/chimeraboost/faq/): common questions
+* [Where the ideas come from](https://bbstats.github.io/chimeraboost/attribution/): what is borrowed, what is ours
 
-## Inspirations / Citations
+## Credit where it is due
 
-* **CatBoost**, Prokhorenkova et al., *NeurIPS* 2018. Ordered boosting, ordered target statistics, oblivious trees.
-* **XGBoost**, Chen & Guestrin, *KDD* 2016. Regularized objective, Newton leaf estimation, column subsampling.
+Almost every idea in ChimeraBoost is someone else's. It is a from-scratch Python
+implementation of published work — the algorithms below were invented by the people
+listed next to them, not by us. **[Where the ideas come from](https://bbstats.github.io/chimeraboost/attribution/)**
+maps this out feature by feature, including the short list of what actually originated
+here. If a credit is missing or wrong, please open an issue.
+
+* **Gradient boosting**, Friedman, *Annals of Statistics* 2001 (and *Stochastic Gradient Boosting*, 2002). The algorithm itself, shrinkage, and the terminal-node override used for MAE and quantile losses.
+* **CatBoost**, Prokhorenkova et al., *NeurIPS* 2018. Oblivious trees, ordered target statistics, feature combinations, ordered boosting, and the size-dependent automatic learning rate (`adaptive_learning_rate`).
+* **XGBoost**, Chen & Guestrin, *KDD* 2016. Regularized objective, second-order split gain, Newton leaf estimation, `min_child_weight`, column subsampling.
 * **LightGBM**, Ke et al., *NeurIPS* 2017. Histogram-based split finding.
-* **Linear-leaf trees**, Shi et al., *IJCAI* 2019 (arXiv:1802.05640). Piece-wise-linear regression trees (`linear_leaves`).
+* **Minimum Variance Sampling**, Ibragimov & Gusev, *NeurIPS* 2019. Gradient-weighted row sampling (`subsample`).
+* **Quantized GBDT training**, Shi, Ke et al., *NeurIPS* 2022. Integer gradient histograms (`quantize_gradients`).
+* **SketchBoost**, Iosipoi & Vakhrushev, *NeurIPS* 2022, and **GBDT-MO**, Zhang & Jung. Vector leaves and the projected gradient used for multiclass and multi-quantile splits.
+* **Linear-leaf trees**, Shi, Li & Li, *IJCAI* 2019 (arXiv:1802.05640). Piece-wise-linear regression trees (`linear_leaves`); model trees back to Quinlan's M5, 1992.
 * **TreeSHAP**, Lundberg et al., *Nature Machine Intelligence* 2020 (orig. SHAP, *NeurIPS* 2017). Exact additive feature attributions (`shap_values`).
 * **OpenFE**, Zhang et al., *ICML* 2023 (arXiv:2211.12507). Automated pairwise feature generation (`cross_features`).
-* **Conformalized quantile regression**, Romano, Patterson & Candès, *NeurIPS* 2019. Distribution-free interval calibration (`conformalize`).
+* **Pinball loss**, Koenker & Bassett, *Econometrica* 1978, and **monotone rearrangement**, Chernozhukov, Fernández-Val & Galichon, *Econometrica* 2010. Quantile regression and its non-crossing guarantee.
+* **Conformal prediction**, Papadopoulos et al. 2002 and Vovk et al. 2005; **conformalized quantile regression**, Romano, Patterson & Candès, *NeurIPS* 2019. Distribution-free interval calibration (`conformalize`).
+* **Temperature scaling**, Guo et al., *ICML* 2017 (Platt 1999 lineage). Probability calibration.
+* **Bagging and out-of-bag estimation**, Breiman 1996; **subagging**, Bühlmann & Yu, *Annals of Statistics* 2002. The `n_ensembles` path.
+* **AutoGluon**, Erickson et al. 2020. Refitting the selected model on all the data, and named quality presets.
+* **scikit-learn**, Buitinck et al., *ECML-PKDD* 2013, and **numba**, Lam, Pitrou & Seibert, 2015. The API conventions and the compiler this is all built on.

--- a/chimeraboost/__init__.py
+++ b/chimeraboost/__init__.py
@@ -1,9 +1,15 @@
 """ChimeraBoost: a CatBoost-inspired gradient boosting library in pure Python.
 
-Key ingredients borrowed from CatBoost:
+Borrowed from CatBoost (Prokhorenkova et al. 2018):
   * Ordered target statistics for categorical features (anti-leakage encoding)
   * Oblivious / symmetric trees (fast, strongly regularized -> good defaults)
-  * Histogram-based quantized splitting (numba accelerated)
+
+Borrowed from LightGBM:
+  * Histogram-based split finding on pre-binned features (Ke et al. 2017)
+  * Quantized gradient histograms (Shi, Ke et al. 2022)
+
+docs/attribution.md maps every technique to its source, and says which of them
+originated here.
 
 Public API:
   >>> from chimeraboost import ChimeraBoostRegressor, ChimeraBoostClassifier

--- a/docs/attribution.md
+++ b/docs/attribution.md
@@ -1,0 +1,113 @@
+# Where the ideas come from
+
+Almost everything ChimeraBoost does was invented by someone else. The gradient boosting
+algorithm, the oblivious tree, the way categoricals are encoded, the histogram split
+search, the leaf formula, the calibration step, the conformal intervals — all published
+work by other people, listed below with the source.
+
+This page exists so nobody has to guess which parts are borrowed. If a credit here is
+wrong, missing, or too generous to us, please open an issue; being corrected on this is
+the point of writing it down.
+
+## Borrowed
+
+Taken from published work or from another library. The implementation is ours, written
+from the paper or the described behaviour; the idea is not.
+
+| What | Where it came from |
+|---|---|
+| Gradient boosting, shrinkage, the terminal-node value override used for MAE and quantile losses | Friedman, *Greedy Function Approximation*, Annals of Statistics 2001; *Stochastic Gradient Boosting*, 2002 |
+| Oblivious (symmetric) trees — one shared split per level | CatBoost, Prokhorenkova et al., NeurIPS 2018. The tree type itself goes back to Kohavi & Li, IJCAI 1995 |
+| Ordered target statistics for categoricals, multi-permutation averaging, feature combinations, `leaf_estimation_iterations` | CatBoost, Prokhorenkova et al., NeurIPS 2018 |
+| Smoothing a category's target estimate toward the prior | Micci-Barreca, SIGKDD Explorations 2001 |
+| Histogram-based split finding on pre-binned features | LightGBM, Ke et al., NeurIPS 2017; earlier in McRank (Li et al. 2007) and pGBRT (Tyree et al. 2011) |
+| Second-order split gain `G²/(H+λ)`, Newton leaf values, `min_child_weight` | XGBoost, Chen & Guestrin, KDD 2016 |
+| Minimum Variance Sampling — the gradient-weighted row draw behind `subsample` | Ibragimov & Gusev, NeurIPS 2019 (CatBoost's MVS) |
+| Quantized gradient histograms (`quantize_gradients`) | Shi, Ke et al., *Quantized Training of Gradient Boosting Decision Trees*, NeurIPS 2022 (LightGBM) |
+| Vector leaves for multiclass, and the random-projection gradient sketch that scores their splits | SketchBoost, Iosipoi & Vakhrushev, NeurIPS 2022; GBDT-MO, Zhang & Jung, IEEE TNNLS 2021 |
+| Linear (ridge) leaves | Shi, Li & Li, IJCAI 2019; model trees back to Quinlan's M5, 1992 |
+| Exact TreeSHAP attributions, interventional formulation | Lundberg & Lee, NeurIPS 2017; Lundberg et al., Nature Machine Intelligence 2020 |
+| Automatic pairwise feature generation (`cross_features`) | OpenFE, Zhang et al., ICML 2023 |
+| Pinball loss | Koenker & Bassett, Econometrica 1978 |
+| Non-crossing quantiles by monotone rearrangement | Chernozhukov, Fernández-Val & Galichon, Econometrica 2010 |
+| Split-conformal calibration | Papadopoulos et al. 2002; Vovk, Gammerman & Shafer 2005; Lei et al., JASA 2018 |
+| Conformalized quantile regression (`conformalize`) | Romano, Patterson & Candès, NeurIPS 2019 |
+| Temperature scaling of classifier probabilities | Guo, Pleiss, Sun & Weinberger, ICML 2017; Platt 1999 |
+| Bagging, subagging, out-of-bag estimation | Breiman 1996; Bühlmann & Yu, Annals of Statistics 2002 |
+| Refitting the selected model on all the data; named quality presets | AutoGluon, Erickson et al. 2020; the CV-then-refit convention in scikit-learn |
+| Refreshing leaf values on a fixed tree structure — the mechanism `refit_full="replay"` uses | XGBoost's `refresh` updater; LightGBM's `Booster.refit()` |
+| Racing candidate configurations under a shared budget and killing the loser early | Hoeffding races, Maron & Moore 1994; Karnin et al., ICML 2013; Jamieson & Talwalkar, AISTATS 2016 |
+| CRPS as mean pinball loss over a quantile grid | Gneiting & Raftery, JASA 2007 |
+| The estimator API — `fit`/`predict`, `get_params`, validation and error conventions | scikit-learn, Buitinck et al., ECML-PKDD 2013 |
+| SplitMix64, the counter-based generator behind stochastic rounding | Steele, Lea & Flood, OOPSLA 2014 |
+| Synthetic data drawn from structural-causal-model priors (the `--synth` screen) | the prior-sampling approach of TabPFN, Hollmann et al., ICLR 2023, and its descendants |
+
+## Adapted
+
+A borrowed idea, changed enough here that the difference is worth stating. The credit
+still belongs upstream.
+
+| What | Borrowed from | What is different here |
+|---|---|---|
+| `adaptive_learning_rate` | CatBoost's automatic learning rate, its one size-dependent default | We found it by diffing CatBoost's resolved parameters across dataset sizes, then measured how much of its small-data advantage the schedule accounts for. The fade curve is ours; the idea that the rate should depend on `n` is entirely theirs |
+| `min_child_weight` on oblivious trees | XGBoost's `min_child_weight` | One sparse child vetoes the whole level, because the split is shared. Empty children are exempt so pure leaves do not cap depth |
+| `refit_members` | The fixed-structure leaf refresh above | Applied per bag member, to recover the data each member gives up to its own out-of-bag split |
+| `cat_combinations` default | CatBoost's feature combinations | The rule that turns them on automatically for all-categorical data is ours |
+| Interval calibration | Conformalized quantile regression | Applied as a per-level multiplicative scale around the predicted median rather than the usual additive widening, so that calibrating cannot reorder the quantile grid. Scaled conformity scores are a known variant of CQR, not something we invented |
+| The multi-quantile head | CatBoost's `MultiQuantile` loss — one model, vector leaves, all levels at once | The split search is ours; see below |
+| Bag member draws | Subagging and the cluster bootstrap | Group-disjoint draws, so grouped data keeps a usable out-of-bag set |
+
+## Ours
+
+Written here, by Nathan Walker and Claude. It is a short list, and most of it is
+engineering or small default-setting rather than new learning theory.
+
+**The multi-quantile split search.** A row's entire K-channel pinball gradient is
+determined by one integer — where its label falls in the predicted quantile grid — so
+the split search never builds the `(n, K)` gradient matrix at all. Gains are scored by
+projecting onto one direction, which for the pinball loss is provably the rank-1
+truncation of the exact gain rather than a heuristic, and the direction cycles through
+low-order polynomial contrasts so that changes in spread are visible and not just
+changes in location. SketchBoost's random projections are the nearest relative we know
+of; the rank-lookup form and the contrast schedule we have not found elsewhere.
+
+**Structure-transfer refit.** Reusing a donor model's tree structures and refitting only
+the leaves is the borrowed part. Using it to give a fitted model the data its own
+early-stopping split consumed, by default, is the composition we added.
+
+**Small default policies.** Fading `min_child_weight` out as the training set grows;
+defaulting quantile models to shallower trees because tail estimates need more rows per
+leaf; deriving a leaf-size floor from the most extreme quantile level; injecting a donor
+row when a bag member's draw misses a class entirely. Each is a few lines, and each
+exists because a benchmark caught the failure it prevents.
+
+**Equivalence-preserving engineering.** The fused per-level kernel, the bit-identical
+splice that adds cross features to an already-fitted preprocessor, the audited fast path
+for factorizing numeric categories, and the numerical-identity tests that hold all of it
+in place. Kernel fusion is not new; what is ours is the discipline that every fast path
+must produce bit-identical output to the slow one it replaces, enforced by tests.
+
+**A cold-start notice.** Detecting that numba is about to spend fifteen seconds
+compiling, and saying so, instead of appearing to hang.
+
+**Two benchmarking methods.** Diffing an opponent's resolved parameters across dataset
+sizes to find which of its defaults depend on `n`; and forcing an opponent to adopt our
+setting to measure what its own choice was worth. Ablation is ordinary science — running
+it on the opponent rather than on ourselves is the part we have not seen done elsewhere.
+
+## Benchmarks
+
+The evaluation leans on other people's work too:
+
+- **Grinsztajn, Oyallon & Varoquaux**, NeurIPS 2022 — the tabular benchmark that decides
+  whether a change ships here.
+- **PMLB**, Olson et al. 2017 and Romano et al. 2021 — the Penn Machine Learning
+  Benchmarks, used only for hyperparameter tuning.
+- **TabArena** — the community leaderboard, run by its maintainers on their own defaults.
+  It is read and reported, never tuned against.
+- **OpenML** and **Hugging Face** host most of the datasets.
+
+## Built on
+
+numba (Lam, Pitrou & Seibert, LLVM-HPC 2015), NumPy, SciPy, and scikit-learn. There is
+no ChimeraBoost without them.

--- a/docs/attribution.md
+++ b/docs/attribution.md
@@ -18,10 +18,11 @@ from the paper or the described behaviour; the idea is not.
 |---|---|
 | Gradient boosting, shrinkage, the terminal-node value override used for MAE and quantile losses | Friedman, *Greedy Function Approximation*, Annals of Statistics 2001; *Stochastic Gradient Boosting*, 2002 |
 | Oblivious (symmetric) trees — one shared split per level | CatBoost, Prokhorenkova et al., NeurIPS 2018. The tree type itself goes back to Kohavi & Li, IJCAI 1995 |
-| Ordered target statistics for categoricals, multi-permutation averaging, feature combinations, `leaf_estimation_iterations` | CatBoost, Prokhorenkova et al., NeurIPS 2018 |
+| Ordered target statistics for categoricals, multi-permutation averaging, ordered boosting, feature combinations, `leaf_estimation_iterations` | CatBoost, Prokhorenkova et al., NeurIPS 2018 |
 | Smoothing a category's target estimate toward the prior | Micci-Barreca, SIGKDD Explorations 2001 |
 | Histogram-based split finding on pre-binned features | LightGBM, Ke et al., NeurIPS 2017; earlier in McRank (Li et al. 2007) and pGBRT (Tyree et al. 2011) |
 | Second-order split gain `G²/(H+λ)`, Newton leaf values, `min_child_weight` | XGBoost, Chen & Guestrin, KDD 2016 |
+| Column subsampling (`colsample`) | Breiman, *Random Forests*, 2001; random subspaces, Ho, IEEE TPAMI 1998 — the sources the XGBoost paper itself names for it |
 | Minimum Variance Sampling — the gradient-weighted row draw behind `subsample` | Ibragimov & Gusev, NeurIPS 2019 (CatBoost's MVS) |
 | Quantized gradient histograms (`quantize_gradients`) | Shi, Ke et al., *Quantized Training of Gradient Boosting Decision Trees*, NeurIPS 2022 (LightGBM) |
 | Vector leaves for multiclass, and the random-projection gradient sketch that scores their splits | SketchBoost, Iosipoi & Vakhrushev, NeurIPS 2022; GBDT-MO, Zhang & Jung, IEEE TNNLS 2021 |
@@ -29,6 +30,11 @@ from the paper or the described behaviour; the idea is not.
 | Exact TreeSHAP attributions, interventional formulation | Lundberg & Lee, NeurIPS 2017; Lundberg et al., Nature Machine Intelligence 2020 |
 | Automatic pairwise feature generation (`cross_features`) | OpenFE, Zhang et al., ICML 2023 |
 | Pinball loss | Koenker & Bassett, Econometrica 1978 |
+| One fitted model serving every quantile level | Quantile regression forests, Meinshausen, JMLR 2006 |
+| Labelling each row by which quantile-grid bucket its target falls in, and scoring one shared split across all levels on those labels | Generalized random forests, Athey, Tibshirani & Wager, Annals of Statistics 2019 (the `grf` quantile forest) |
+| Shifted-Legendre contrasts in tau as location, spread and skew | L-moments, Hosking, JRSS-B 1990 |
+| Cycling boosting updates through location and spread, and the greedy variant that instead picks the strongest component each round | gamboostLSS, Mayr, Fenske, Hofner, Kneib & Schmid, JRSS-C 2012; the non-cyclical variant of Thomas et al., Statistics and Computing 2018 |
+| Making a tree's split criterion see spread and not only location | Distributional regression forests, Schlosser, Hothorn, Stauffer & Zeileis, AoAS 2019 |
 | Non-crossing quantiles by monotone rearrangement | Chernozhukov, Fernández-Val & Galichon, Econometrica 2010 |
 | Split-conformal calibration | Papadopoulos et al. 2002; Vovk, Gammerman & Shafer 2005; Lei et al., JASA 2018 |
 | Conformalized quantile regression (`conformalize`) | Romano, Patterson & Candès, NeurIPS 2019 |
@@ -36,8 +42,15 @@ from the paper or the described behaviour; the idea is not.
 | Bagging, subagging, out-of-bag estimation | Breiman 1996; Bühlmann & Yu, Annals of Statistics 2002 |
 | Refitting the selected model on all the data; named quality presets | AutoGluon, Erickson et al. 2020; the CV-then-refit convention in scikit-learn |
 | Refreshing leaf values on a fixed tree structure — the mechanism `refit_full="replay"` uses | XGBoost's `refresh` updater; LightGBM's `Booster.refit()` |
-| Racing candidate configurations under a shared budget and killing the loser early | Hoeffding races, Maron & Moore 1994; Karnin et al., ICML 2013; Jamieson & Talwalkar, AISTATS 2016 |
+| Racing candidate configurations under a shared budget and killing the loser early | Hoeffding races, Maron & Moore, NeurIPS 1993; Karnin et al., ICML 2013; Jamieson & Talwalkar, AISTATS 2016 |
 | CRPS as mean pinball loss over a quantile grid | Gneiting & Raftery, JASA 2007 |
+| Huber loss for outlier-robust regression | Huber, Annals of Mathematical Statistics 1964; as a boosting loss, Friedman 2001 |
+| Log-link Poisson, Gamma and Tweedie losses | generalized linear models, Nelder & Wedderburn, JRSS-A 1972; the compound Poisson-gamma family, Tweedie 1984 and Jorgensen 1987 |
+| Missing values routed to their own bin, so no imputation is needed | XGBoost's sparsity-aware split finding, Chen & Guestrin, KDD 2016; LightGBM's dedicated missing bin |
+| Greedy bin construction that isolates heavy values | LightGBM's `GreedyFindBin` |
+| Split-gain feature importance (`feature_importances_`) | Breiman, Friedman, Olshen & Stone, *CART* 1984; relative influence for boosted ensembles, Friedman 2001 |
+| Early stopping on a held-out split with a patience window | Prechelt 1998, and the automatic-internal-holdout convention of scikit-learn, LightGBM and XGBoost |
+| Compensated summation in the group-mean kernel | Kahan, CACM 1965 |
 | The estimator API — `fit`/`predict`, `get_params`, validation and error conventions | scikit-learn, Buitinck et al., ECML-PKDD 2013 |
 | SplitMix64, the counter-based generator behind stochastic rounding | Steele, Lea & Flood, OOPSLA 2014 |
 | Synthetic data drawn from structural-causal-model priors (the `--synth` screen) | the prior-sampling approach of TabPFN, Hollmann et al., ICLR 2023, and its descendants |
@@ -49,51 +62,54 @@ still belongs upstream.
 
 | What | Borrowed from | What is different here |
 |---|---|---|
-| `adaptive_learning_rate` | CatBoost's automatic learning rate, its one size-dependent default | We found it by diffing CatBoost's resolved parameters across dataset sizes, then measured how much of its small-data advantage the schedule accounts for. The fade curve is ours; the idea that the rate should depend on `n` is entirely theirs |
+| `adaptive_learning_rate` | CatBoost's automatic learning rate — the size-dependent default that showed up when we diffed its resolved parameters | The fade curve is ours; that the rate should depend on `n` at all is theirs |
 | `min_child_weight` on oblivious trees | XGBoost's `min_child_weight` | One sparse child vetoes the whole level, because the split is shared. Empty children are exempt so pure leaves do not cap depth |
 | `refit_members` | The fixed-structure leaf refresh above | Applied per bag member, to recover the data each member gives up to its own out-of-bag split |
 | `cat_combinations` default | CatBoost's feature combinations | The rule that turns them on automatically for all-categorical data is ours |
 | Interval calibration | Conformalized quantile regression | Applied as a per-level multiplicative scale around the predicted median rather than the usual additive widening, so that calibrating cannot reorder the quantile grid. Scaled conformity scores are a known variant of CQR, not something we invented |
-| The multi-quantile head | CatBoost's `MultiQuantile` loss — one model, vector leaves, all levels at once | The split search is ours; see below |
+| The multi-quantile head | CatBoost's `MultiQuantile` loss and Meinshausen's quantile regression forests — one model, all levels at once | Vector leaves hold an exact empirical quantile per level, and the split search scores gains on a projection rather than on class indicators. See below for what is and is not ours in it |
+| Scoring one shared split across all quantile levels | `grf`'s quantile forest, which relabels each row by the grid bucket its target falls in | We score that shared split with a projected second-order gain instead of a multiclass split rule, and never materialise the per-level gradient matrix on the default settings |
+| Rotating the split direction through location and spread contrasts | gamboostLSS's cyclical fitting, on the shifted-Legendre (L-moment) basis | Ours is the measured ratio — two location rounds per spread round — and restricting the greedy `"gram"` variant to that subspace against a no-signal whitener |
+| Reclaiming the early-stopping split | Refitting on all the data once the round count is known: AutoGluon's `refit_full`, and the same pattern packaged elsewhere for LightGBM and XGBoost | We do it as a fixed-structure leaf refresh rather than a from-scratch regrow, and it is on by default rather than an extra step the user asks for |
+| `ordered_boosting` | CatBoost's ordered boosting | CatBoost estimates gradients from a cascade of permutation-ordered supporting models. Ours is a leave-one-out leaf step: a row's update uses its leaf's totals with its own contribution removed. Same goal, far cheaper, weaker guarantee. Off by default — and CatBoost itself resolves to plain boosting at every size we measured |
 | Bag member draws | Subagging and the cluster bootstrap | Group-disjoint draws, so grouped data keeps a usable out-of-bag set |
 
 ## Ours
 
-Written here, by Nathan Walker and Claude. It is a short list, and most of it is
-engineering or small default-setting rather than new learning theory.
+Written here, by Nathan Walker and Claude. This list got considerably shorter once we
+went looking for prior art properly, which is the honest outcome: nearly everything we
+thought of as ours turned out to have a name and a paper. What survives is engineering
+and small default-setting, not new learning theory.
 
-**The multi-quantile split search.** A row's entire K-channel pinball gradient is
-determined by one integer — where its label falls in the predicted quantile grid — so
-the split search never builds the `(n, K)` gradient matrix at all. Gains are scored by
-projecting onto one direction, which for the pinball loss is provably the rank-1
-truncation of the exact gain rather than a heuristic, and the direction cycles through
-low-order polynomial contrasts so that changes in spread are visible and not just
-changes in location. SketchBoost's random projections are the nearest relative we know
-of; the rank-lookup form and the contrast schedule we have not found elsewhere.
+**Not building the per-level gradient matrix.** On the default settings the quantile
+split search collapses each row's whole K-channel pinball gradient to one number in a
+single pass over that row's own scores, so the `(n, K)` gradient is never materialised
+and a K-level head costs roughly what a one-level head costs per round. It is built on
+the `"gram"` and `exact_splits` arms, which need it. The representation this scores —
+one shared split across every level — is `grf`'s, and the projection machinery is
+SketchBoost's; what we have not found elsewhere is scoring that shared split with a
+projected second-order gain that never forms the matrix.
 
-**Structure-transfer refit.** Reusing a donor model's tree structures and refitting only
-the leaves is the borrowed part. Using it to give a fitted model the data its own
-early-stopping split consumed, by default, is the composition we added.
-
-**Small default policies.** Fading `min_child_weight` out as the training set grows;
-defaulting quantile models to shallower trees because tail estimates need more rows per
-leaf; deriving a leaf-size floor from the most extreme quantile level; injecting a donor
-row when a bag member's draw misses a class entirely. Each is a few lines, and each
-exists because a benchmark caught the failure it prevents.
+**Small default policies.** The classifier fades `min_child_weight` out as the training
+set grows, because on an oblivious tree a single sparse child vetoes the whole level.
+Quantile losses default to depth 4 rather than 6, on measurement, for the standard reason
+that tail estimates need more rows per leaf. The multi-quantile head derives its leaf-size
+floor from the most extreme level on the grid, wiring in the usual rule that a tau
+quantile needs on the order of `1/tau` rows to be estimable, so the floor tracks whatever
+grid you ask for. A bag member whose draw collapses to a single class gets one donor row,
+which is a crash guard rather than the stratified draw the imbalanced-bagging literature
+would reach for. Setting a default by a formula in `n` is itself an old idea — `mtry` is
+the textbook case — so what is ours here is which curve, not the shape of the answer.
 
 **Equivalence-preserving engineering.** The fused per-level kernel, the bit-identical
-splice that adds cross features to an already-fitted preprocessor, the audited fast path
-for factorizing numeric categories, and the numerical-identity tests that hold all of it
-in place. Kernel fusion is not new; what is ours is the discipline that every fast path
-must produce bit-identical output to the slow one it replaces, enforced by tests.
+splice that adds cross features to an already-fitted preprocessor, and the audited fast
+path for factorizing numeric categories. Checking an optimized path against a reference
+implementation is standard practice in numerical libraries, not a house invention; what
+is ours is only these particular equivalences and the tests that pin them.
 
 **A cold-start notice.** Detecting that numba is about to spend fifteen seconds
-compiling, and saying so, instead of appearing to hang.
-
-**Two benchmarking methods.** Diffing an opponent's resolved parameters across dataset
-sizes to find which of its defaults depend on `n`; and forcing an opponent to adopt our
-setting to measure what its own choice was worth. Ablation is ordinary science — running
-it on the opponent rather than on ourselves is the part we have not seen done elsewhere.
+compiling, and saying so, instead of appearing to hang. Small, but we have not seen
+another library do it.
 
 ## Benchmarks
 
@@ -106,6 +122,13 @@ The evaluation leans on other people's work too:
 - **TabArena** — the community leaderboard, run by its maintainers on their own defaults.
   It is read and reported, never tuned against.
 - **OpenML** and **Hugging Face** host most of the datasets.
+- Scoring uses the **Brier** score (Brier 1950) in **Murphy**'s (1973) skill-score form,
+  alongside R² and CRPS.
+
+Two things the harness does that are worth stating plainly, with no claim that they are
+new: it diffs a competitor's resolved parameters across dataset sizes to find which of
+its defaults depend on `n`, and it forces a competitor to adopt our setting to measure
+what its own choice was worth.
 
 ## Built on
 

--- a/docs/attribution.md
+++ b/docs/attribution.md
@@ -121,19 +121,6 @@ The representation being scored — one shared split across every level — is `
 the projection machinery is SketchBoost's. What we have not found elsewhere is scoring
 that shared split with a projected second-order gain that never forms the matrix.
 
-### Small default policies
-
-The classifier fades `min_child_weight` out as the training set grows, because on an
-oblivious tree a single sparse child vetoes the whole level. Quantile losses default to
-depth 4 rather than 6, on measurement, for the standard reason that tail estimates need
-more rows per leaf. The multi-quantile head derives its leaf-size floor from the most
-extreme level on the grid, so the floor tracks whatever grid you ask for. A bag member
-whose draw collapses to a single class gets one donor row — a crash guard, not the
-stratified draw the imbalanced-bagging literature would reach for.
-
-Setting a default by a formula in `n` is an old idea; `mtry` is the textbook case. What
-is ours is which curve, not the shape of the answer.
-
 ### Equivalence-preserving engineering
 
 The fused per-level kernel, the bit-identical splice that adds cross features to an
@@ -141,10 +128,6 @@ already-fitted preprocessor, and the audited fast path for factorizing numeric
 categories. Checking an optimized path against a reference implementation is standard
 practice in numerical libraries, not a house invention; ours are these particular
 equivalences and the tests that pin them.
-
-Also a cold-start notice: detecting that numba is about to spend fifteen seconds
-compiling and saying so, rather than appearing to hang. Small, but we have not seen
-another library do it.
 
 ## Benchmarks
 

--- a/docs/attribution.md
+++ b/docs/attribution.md
@@ -11,9 +11,6 @@ the point of writing it down.
 
 ## Borrowed
 
-Taken from published work or from another library. The implementation is ours, written
-from the paper or the described behaviour; the idea is not.
-
 | What | Borrowed from |
 |---|---|
 | Gradient boosting, shrinkage, the terminal-node value override used for MAE and quantile losses | Friedman, *Greedy Function Approximation*, Annals of Statistics 2001; *Stochastic Gradient Boosting*, 2002 |

--- a/docs/attribution.md
+++ b/docs/attribution.md
@@ -22,38 +22,30 @@ from the paper or the described behaviour; the idea is not.
 | Smoothing a category's target estimate toward the prior | Micci-Barreca, SIGKDD Explorations 2001 |
 | Histogram-based split finding on pre-binned features | LightGBM, Ke et al., NeurIPS 2017; earlier in McRank (Li et al. 2007) and pGBRT (Tyree et al. 2011) |
 | Second-order split gain `G²/(H+λ)`, Newton leaf values, `min_child_weight` | XGBoost, Chen & Guestrin, KDD 2016 |
-| Column subsampling (`colsample`) | Breiman, *Random Forests*, 2001; random subspaces, Ho, IEEE TPAMI 1998 — the sources the XGBoost paper itself names for it |
 | Minimum Variance Sampling — the gradient-weighted row draw behind `subsample` | Ibragimov & Gusev, NeurIPS 2019 (CatBoost's MVS) |
 | Quantized gradient histograms (`quantize_gradients`) | Shi, Ke et al., *Quantized Training of Gradient Boosting Decision Trees*, NeurIPS 2022 (LightGBM) |
 | Vector leaves for multiclass, and the random-projection gradient sketch that scores their splits | SketchBoost, Iosipoi & Vakhrushev, NeurIPS 2022; GBDT-MO, Zhang & Jung, IEEE TNNLS 2021 |
 | Linear (ridge) leaves | Shi, Li & Li, IJCAI 2019; model trees back to Quinlan's M5, 1992 |
 | Exact TreeSHAP attributions, interventional formulation | Lundberg & Lee, NeurIPS 2017; Lundberg et al., Nature Machine Intelligence 2020 |
 | Automatic pairwise feature generation (`cross_features`) | OpenFE, Zhang et al., ICML 2023 |
-| Pinball loss | Koenker & Bassett, Econometrica 1978 |
-| One fitted model serving every quantile level | Quantile regression forests, Meinshausen, JMLR 2006 |
-| Labelling each row by which quantile-grid bucket its target falls in, and scoring one shared split across all levels on those labels | Generalized random forests, Athey, Tibshirani & Wager, Annals of Statistics 2019 (the `grf` quantile forest) |
-| Shifted-Legendre contrasts in tau as location, spread and skew | L-moments, Hosking, JRSS-B 1990 |
-| Cycling boosting updates through location and spread, and the greedy variant that instead picks the strongest component each round | gamboostLSS, Mayr, Fenske, Hofner, Kneib & Schmid, JRSS-C 2012; the non-cyclical variant of Thomas et al., Statistics and Computing 2018 |
-| Making a tree's split criterion see spread and not only location | Distributional regression forests, Schlosser, Hothorn, Stauffer & Zeileis, AoAS 2019 |
+| Quantile regression, and one fitted model serving every level at once | Koenker & Bassett, Econometrica 1978; quantile regression forests, Meinshausen, JMLR 2006; CatBoost's `MultiQuantile` |
+| The pieces our multi-quantile split search is built from: one shared split scored across every level, location/spread/skew contrasts in tau, and cycling through them or greedily picking the strongest each round | `grf`, Athey, Tibshirani & Wager, Annals of Statistics 2019; L-moments, Hosking, JRSS-B 1990; gamboostLSS, Mayr et al., JRSS-C 2012, and the non-cyclical variant of Thomas et al. 2018 |
 | Non-crossing quantiles by monotone rearrangement | Chernozhukov, Fernández-Val & Galichon, Econometrica 2010 |
-| Split-conformal calibration | Papadopoulos et al. 2002; Vovk, Gammerman & Shafer 2005; Lei et al., JASA 2018 |
-| Conformalized quantile regression (`conformalize`) | Romano, Patterson & Candès, NeurIPS 2019 |
+| Split-conformal calibration, and its quantile form (`conformalize`) | Vovk, Gammerman & Shafer 2005; Lei et al., JASA 2018; conformalized quantile regression, Romano, Patterson & Candès, NeurIPS 2019 |
 | Temperature scaling of classifier probabilities | Guo, Pleiss, Sun & Weinberger, ICML 2017; Platt 1999 |
-| Bagging, subagging, out-of-bag estimation | Breiman 1996; Bühlmann & Yu, Annals of Statistics 2002 |
-| Refitting the selected model on all the data; named quality presets | AutoGluon, Erickson et al. 2020; the CV-then-refit convention in scikit-learn |
-| Refreshing leaf values on a fixed tree structure — the mechanism `refit_full="replay"` uses | XGBoost's `refresh` updater; LightGBM's `Booster.refit()` |
+| Bagging, out-of-bag estimation, and column subsampling (`colsample`) | Breiman 1996 and 2001; subagging, Bühlmann & Yu, Annals of Statistics 2002; random subspaces, Ho, IEEE TPAMI 1998 — the sources the XGBoost paper itself names for `colsample` |
+| Refitting the selected model on all the data, and refreshing leaf values on a fixed tree structure — the two halves of `refit_full` | AutoGluon, Erickson et al. 2020; XGBoost's `refresh` updater; LightGBM's `Booster.refit()` |
 | Racing candidate configurations under a shared budget and killing the loser early | Hoeffding races, Maron & Moore, NeurIPS 1993; Karnin et al., ICML 2013; Jamieson & Talwalkar, AISTATS 2016 |
-| CRPS as mean pinball loss over a quantile grid | Gneiting & Raftery, JASA 2007 |
-| Huber loss for outlier-robust regression | Huber, Annals of Mathematical Statistics 1964; as a boosting loss, Friedman 2001 |
-| Log-link Poisson, Gamma and Tweedie losses | generalized linear models, Nelder & Wedderburn, JRSS-A 1972; the compound Poisson-gamma family, Tweedie 1984 and Jorgensen 1987 |
 | Missing values routed to their own bin, so no imputation is needed | XGBoost's sparsity-aware split finding, Chen & Guestrin, KDD 2016; LightGBM's dedicated missing bin |
 | Greedy bin construction that isolates heavy values | LightGBM's `GreedyFindBin` |
-| Split-gain feature importance (`feature_importances_`) | Breiman, Friedman, Olshen & Stone, *CART* 1984; relative influence for boosted ensembles, Friedman 2001 |
-| Early stopping on a held-out split with a patience window | Prechelt 1998, and the automatic-internal-holdout convention of scikit-learn, LightGBM and XGBoost |
-| Compensated summation in the group-mean kernel | Kahan, CACM 1965 |
 | The estimator API — `fit`/`predict`, `get_params`, validation and error conventions | scikit-learn, Buitinck et al., ECML-PKDD 2013 |
-| SplitMix64, the counter-based generator behind stochastic rounding | Steele, Lea & Flood, OOPSLA 2014 |
 | Synthetic data drawn from structural-causal-model priors (the `--synth` screen) | the prior-sampling approach of TabPFN, Hollmann et al., ICLR 2023, and its descendants |
+
+Not listed: the textbook. Huber loss, the GLM log links behind Poisson/Gamma/Tweedie,
+CRPS, split-gain importance, early stopping with a patience window, compensated
+summation. These belong to everybody, and citing a 1964 paper because the library
+offers `loss="Huber"` would make the credits above look like padding rather than
+the real debts they are.
 
 ## Adapted
 
@@ -64,51 +56,94 @@ still belongs upstream.
 |---|---|---|
 | `adaptive_learning_rate` | CatBoost's automatic learning rate — the size-dependent default that showed up when we diffed its resolved parameters | The fade curve is ours; that the rate should depend on `n` at all is theirs |
 | `min_child_weight` on oblivious trees | XGBoost's `min_child_weight` | One sparse child vetoes the whole level, because the split is shared. Empty children are exempt so pure leaves do not cap depth |
-| `refit_members` | The fixed-structure leaf refresh above | Applied per bag member, to recover the data each member gives up to its own out-of-bag split |
 | `cat_combinations` default | CatBoost's feature combinations | The rule that turns them on automatically for all-categorical data is ours |
 | Interval calibration | Conformalized quantile regression | Applied as a per-level multiplicative scale around the predicted median rather than the usual additive widening, so that calibrating cannot reorder the quantile grid. Scaled conformity scores are a known variant of CQR, not something we invented |
-| The multi-quantile head | CatBoost's `MultiQuantile` loss and Meinshausen's quantile regression forests — one model, all levels at once | Vector leaves hold an exact empirical quantile per level, and the split search scores gains on a projection rather than on class indicators. See below for what is and is not ours in it |
-| Scoring one shared split across all quantile levels | `grf`'s quantile forest, which relabels each row by the grid bucket its target falls in | We score that shared split with a projected second-order gain instead of a multiclass split rule, and never materialise the per-level gradient matrix on the default settings |
-| Rotating the split direction through location and spread contrasts | gamboostLSS's cyclical fitting, on the shifted-Legendre (L-moment) basis | Ours is the measured ratio — two location rounds per spread round — and restricting the greedy `"gram"` variant to that subspace against a no-signal whitener |
-| Reclaiming the early-stopping split | Refitting on all the data once the round count is known: AutoGluon's `refit_full`, and the same pattern packaged elsewhere for LightGBM and XGBoost | We do it as a fixed-structure leaf refresh rather than a from-scratch regrow, and it is on by default rather than an extra step the user asks for |
+| The multi-quantile head | CatBoost's `MultiQuantile`, Meinshausen's quantile regression forests, and `grf`'s shared-split scoring | Vector leaves hold an exact empirical quantile per level, and the split search scores a projected second-order gain instead of a multiclass split rule. The contrast schedule — two location rounds per spread round — is measured here, on a basis that is Hosking's |
 | `ordered_boosting` | CatBoost's ordered boosting | CatBoost estimates gradients from a cascade of permutation-ordered supporting models. Ours is a leave-one-out leaf step: a row's update uses its leaf's totals with its own contribution removed. Same goal, far cheaper, weaker guarantee. Off by default — and CatBoost itself resolves to plain boosting at every size we measured |
 | Bag member draws | Subagging and the cluster bootstrap | Group-disjoint draws, so grouped data keeps a usable out-of-bag set |
 
 ## Ours
 
-Written here, by Nathan Walker and Claude. This list got considerably shorter once we
-went looking for prior art properly, which is the honest outcome: nearly everything we
-thought of as ours turned out to have a name and a paper. What survives is engineering
-and small default-setting, not new learning theory.
+Written here, by Nathan Walker and Claude. It is mostly engineering rather than new
+learning theory, and two of these carry measured results.
 
-**Not building the per-level gradient matrix.** On the default settings the quantile
-split search collapses each row's whole K-channel pinball gradient to one number in a
-single pass over that row's own scores, so the `(n, K)` gradient is never materialised
-and a K-level head costs roughly what a one-level head costs per round. It is built on
-the `"gram"` and `exact_splits` arms, which need it. The representation this scores —
-one shared split across every level — is `grf`'s, and the projection machinery is
-SketchBoost's; what we have not found elsewhere is scoring that shared split with a
-projected second-order gain that never forms the matrix.
+### Structure-transfer refit — `refit_full="replay"`, on by default
 
-**Small default policies.** The classifier fades `min_child_weight` out as the training
-set grows, because on an oblivious tree a single sparse child vetoes the whole level.
-Quantile losses default to depth 4 rather than 6, on measurement, for the standard reason
-that tail estimates need more rows per leaf. The multi-quantile head derives its leaf-size
-floor from the most extreme level on the grid, wiring in the usual rule that a tau
-quantile needs on the order of `1/tau` rows to be estimable, so the floor tracks whatever
-grid you ask for. A bag member whose draw collapses to a single class gets one donor row,
-which is a crash guard rather than the stratified draw the imbalanced-bagging literature
-would reach for. Setting a default by a formula in `n` is itself an old idea — `mtry` is
-the textbook case — so what is ours here is which curve, not the shape of the answer.
+**The problem.** Early stopping holds rows back to choose the tree count, and those rows
+never reach the model you ship. The standard fix is to retrain on all the data once the
+count is known. It works — and it costs a second full fit. On our own profile that refit
+was 37 to 49% of every default fit, the single largest thing the library did.
 
-**Equivalence-preserving engineering.** The fused per-level kernel, the bit-identical
-splice that adds cross features to an already-fitted preprocessor, and the audited fast
-path for factorizing numeric categories. Checking an optimized path against a reference
-implementation is standard practice in numerical libraries, not a house invention; what
-is ours is only these particular equivalences and the tests that pin them.
+**The observation.** Growing trees is 83 to 85% of a fit. So a from-scratch refit spends
+most of its time rediscovering split structures the first model already found. It does
+not have to.
 
-**A cold-start notice.** Detecting that numba is about to spend fifteen seconds
-compiling, and saying so, instead of appearing to hang. Small, but we have not seen
+**What it does instead.** Replay the winner's splits round by round against gradients
+computed on all the rows, and refit only the leaf values. The held-out rows still reach
+the leaf estimates — which is where the accuracy came from — without paying for the split
+search a second time.
+
+**What it bought.** On Grinsztajn, fit time down **34.8%** and faster on **58 of 59**
+datasets; on the high-cardinality suite, down 15.2% and faster on 12 of 14 — less,
+because replay does not cover multiclass and categorical preprocessing is a fixed cost
+either way. Accuracy is a wash on four independent suites, every median essentially zero:
+Grinsztajn +0.005%, high-card −0.017%, PMLB −0.043%, public −0.114%. Two of those four
+played no part in the decision. `refit_members` applies the same trick per bag member, to
+reclaim what each member gives up to its own out-of-bag split.
+
+**What is borrowed.** Both halves. Refreshing leaf values on a fixed structure is
+XGBoost's `refresh` updater and LightGBM's `refit()`. Retraining on all the data after
+early stopping is AutoGluon's `refit_full`, and is packaged elsewhere for LightGBM and
+XGBoost. Using the first as the implementation of the second, by default, is the part we
+put together.
+
+**One thing worth recording.** The first cut of this leaked the target. Split thresholds
+are bin *indices*, so the donor's preprocessor has to be reused verbatim — a re-fitted
+binner silently moves every threshold underneath the structures it is replaying. Our own
+leakage regression test caught it, and the buggy run's apparent wins turned out to be the
+leak. The headline number above is from the fixed version.
+
+### A quantile split search that never builds the gradient matrix
+
+Each row's whole K-channel pinball gradient collapses to one number in a single pass over
+that row's own scores, so on the default settings the `(n, K)` gradient is never
+materialised and a K-level head costs roughly what a one-level head costs per round. The
+`"gram"` and `exact_splits` arms do build it, because they need it.
+
+It costs accuracy, and the cost is small: the default projection lands within **7%** of
+the exact summed-across-levels gain while building one histogram per round instead of one
+per level. Scoring the levels by simply adding them up — the obvious thing — is much
+worse, and for a reason worth knowing: on a symmetric grid the pushes from tau and
+1 − tau are equal and opposite, so an interval centred correctly but too narrow sums to
+exactly zero. Adding them up is blind to spread.
+
+The representation being scored — one shared split across every level — is `grf`'s, and
+the projection machinery is SketchBoost's. What we have not found elsewhere is scoring
+that shared split with a projected second-order gain that never forms the matrix.
+
+### Small default policies
+
+The classifier fades `min_child_weight` out as the training set grows, because on an
+oblivious tree a single sparse child vetoes the whole level. Quantile losses default to
+depth 4 rather than 6, on measurement, for the standard reason that tail estimates need
+more rows per leaf. The multi-quantile head derives its leaf-size floor from the most
+extreme level on the grid, so the floor tracks whatever grid you ask for. A bag member
+whose draw collapses to a single class gets one donor row — a crash guard, not the
+stratified draw the imbalanced-bagging literature would reach for.
+
+Setting a default by a formula in `n` is an old idea; `mtry` is the textbook case. What
+is ours is which curve, not the shape of the answer.
+
+### Equivalence-preserving engineering
+
+The fused per-level kernel, the bit-identical splice that adds cross features to an
+already-fitted preprocessor, and the audited fast path for factorizing numeric
+categories. Checking an optimized path against a reference implementation is standard
+practice in numerical libraries, not a house invention; ours are these particular
+equivalences and the tests that pin them.
+
+Also a cold-start notice: detecting that numba is about to spend fifteen seconds
+compiling and saying so, rather than appearing to hang. Small, but we have not seen
 another library do it.
 
 ## Benchmarks
@@ -122,8 +157,6 @@ The evaluation leans on other people's work too:
 - **TabArena** — the community leaderboard, run by its maintainers on their own defaults.
   It is read and reported, never tuned against.
 - **OpenML** and **Hugging Face** host most of the datasets.
-- Scoring uses the **Brier** score (Brier 1950) in **Murphy**'s (1973) skill-score form,
-  alongside R² and CRPS.
 
 Two things the harness does that are worth stating plainly, with no claim that they are
 new: it diffs a competitor's resolved parameters across dataset sizes to find which of

--- a/docs/attribution.md
+++ b/docs/attribution.md
@@ -14,7 +14,7 @@ the point of writing it down.
 Taken from published work or from another library. The implementation is ours, written
 from the paper or the described behaviour; the idea is not.
 
-| What | Where it came from |
+| What | Borrowed from |
 |---|---|
 | Gradient boosting, shrinkage, the terminal-node value override used for MAE and quantile losses | Friedman, *Greedy Function Approximation*, Annals of Statistics 2001; *Stochastic Gradient Boosting*, 2002 |
 | Oblivious (symmetric) trees — one shared split per level | CatBoost, Prokhorenkova et al., NeurIPS 2018. The tree type itself goes back to Kohavi & Li, IJCAI 1995 |
@@ -52,7 +52,7 @@ the real debts they are.
 A borrowed idea, changed enough here that the difference is worth stating. The credit
 still belongs upstream.
 
-| What | Borrowed from | What is different here |
+| What | Borrowed from | Our version |
 |---|---|---|
 | `adaptive_learning_rate` | CatBoost's automatic learning rate — the size-dependent default that showed up when we diffed its resolved parameters | The fade curve is ours; that the rate should depend on `n` at all is theirs |
 | `min_child_weight` on oblivious trees | XGBoost's `min_child_weight` | One sparse child vetoes the whole level, because the split is shared. Empty children are exempt so pure leaves do not cap depth |
@@ -67,7 +67,7 @@ still belongs upstream.
 Written here, by Nathan Walker and Claude. It is mostly engineering rather than new
 learning theory, and two of these carry measured results.
 
-### Structure-transfer refit — `refit_full="replay"`, on by default
+### 1. Structure-transfer refit — `refit_full="replay"`, on by default
 
 **The problem.** Early stopping holds rows back to choose the tree count, and those rows
 never reach the model you ship. The standard fix is to retrain on all the data once the
@@ -103,7 +103,7 @@ binner silently moves every threshold underneath the structures it is replaying.
 leakage regression test caught it, and the buggy run's apparent wins turned out to be the
 leak. The headline number above is from the fixed version.
 
-### A quantile split search that never builds the gradient matrix
+### 2. Gradient-matrix free quantile split search
 
 Each row's whole K-channel pinball gradient collapses to one number in a single pass over
 that row's own scores, so on the default settings the `(n, K)` gradient is never
@@ -121,7 +121,7 @@ The representation being scored — one shared split across every level — is `
 the projection machinery is SketchBoost's. What we have not found elsewhere is scoring
 that shared split with a projected second-order gain that never forms the matrix.
 
-### Equivalence-preserving engineering
+### 3. Equivalence-preserving engineering
 
 The fused per-level kernel, the bit-identical splice that adds cross features to an
 already-fitted preprocessor, and the audited fast path for factorizing numeric

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -23,7 +23,7 @@ splits, which matters on clean, high-signal data. Raising `depth` and enabling
 
 Numeric features are bucketed into at most `max_bins` (default 128) bins once, up
 front. Splits are searched over bin edges rather than raw values, which is what makes
-the histogram pass fast — the approach LightGBM introduced. Missing values route to
+the histogram pass fast — the approach LightGBM is built around. Missing values route to
 their own bin, so NaNs are handled directly at fit and predict time, with no imputation.
 
 ## Categorical features

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -2,6 +2,9 @@
 
 ## Oblivious trees
 
+The tree type is CatBoost's, and so is much of what follows on this page — see
+[where the ideas come from](attribution.md).
+
 Every node at a given depth splits on the same `(feature, threshold)`. A depth-`d` tree
 is therefore `d` splits, and a sample's leaf is a `d`-bit number: bit `k` is 1 when the
 sample exceeds the threshold at level `k`. Two things follow:
@@ -20,8 +23,8 @@ splits, which matters on clean, high-signal data. Raising `depth` and enabling
 
 Numeric features are bucketed into at most `max_bins` (default 128) bins once, up
 front. Splits are searched over bin edges rather than raw values, which is what makes
-the histogram pass fast. Missing values route to their own bin, so NaNs are handled
-directly at fit and predict time, with no imputation.
+the histogram pass fast — the approach LightGBM introduced. Missing values route to
+their own bin, so NaNs are handled directly at fit and predict time, with no imputation.
 
 ## Categorical features
 
@@ -42,9 +45,10 @@ greater than x₂" has to be approximated by a staircase of axis-aligned splits,
 costs depth and generalizes poorly. Adding the column `x₁ − x₂` turns that rule into a
 single split.
 
-`cross_features` builds those columns automatically: differences and products for the
-top numeric pairs, plus group-centered columns `x − mean(x | category)` that express
-"above this row's category baseline". The model then fits with and without them and
+`cross_features` builds those columns automatically, following OpenFE's approach to
+automated feature generation: differences and products for the top numeric pairs, plus
+group-centered columns `x − mean(x | category)` that express "above this row's category
+baseline". The model then fits with and without them and
 keeps whichever scores better on validation, so the extra columns cannot hurt beyond
 their fit-time cost. The payoff is largest on data with real geometric or arithmetic
 structure, such as coordinates, prices, and physical units.
@@ -53,7 +57,8 @@ structure, such as coordinates, prices, and physical units.
 
 By default each leaf predicts a single constant value. With `linear_leaves`, a leaf
 instead fits a small ridge **linear model** over the numeric features the tree split
-on, adding local slope where a constant underfits smooth structure. Leaves with too few
+on, adding local slope where a constant underfits smooth structure — piece-wise-linear
+trees, from Shi et al. and the older model-tree literature. Leaves with too few
 rows fall back to constant behavior, which limits overfitting on small datasets. Linear
 leaves are on by default for binary classification. The regression default fits both
 variants and keeps whichever reaches the lower validation loss; set `True` or `False`
@@ -61,8 +66,9 @@ to skip the double fit.
 
 ## Probability calibration
 
-After fitting, the classifier scales its raw scores by a single temperature chosen on
-the validation split to minimize log loss. The scaling is monotonic, so AUC and
+After fitting, the classifier applies temperature scaling (Guo et al.): it scales its
+raw scores by a single temperature chosen on the validation split to minimize log loss.
+The scaling is monotonic, so AUC and
 accuracy are unchanged while the probabilities from `predict_proba` become better
 calibrated. The fitted value is exposed as `temperature_`.
 
@@ -72,9 +78,10 @@ calibrated. The fitted value is exposed as `temperature_`.
 default 0.8, drawn without replacement) and averages them to reduce variance:
 predictions for regression, calibrated probabilities for classification.
 
-Within a single model, `subsample < 1.0` uses Minimum Variance Sampling. Rows are drawn
-with probability tied to gradient magnitude and reweighted to stay unbiased, which
-concentrates effort on the rows that still carry signal.
+Within a single model, `subsample < 1.0` uses Minimum Variance Sampling (Ibragimov &
+Gusev, the row sampler CatBoost uses). Rows are drawn with probability tied to gradient
+magnitude and reweighted to stay unbiased, which concentrates effort on the rows that
+still carry signal.
 
 ## SHAP
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -47,7 +47,8 @@ recompiles. Put `chimeraboost-warmup` in the same script as your `pip install -U
 ## Why oblivious (symmetric) trees?
 
 They make prediction extremely fast and provide strong built-in regularization, at some
-cost to per-tree sharpness. See [How it works](concepts.md#oblivious-trees).
+cost to per-tree sharpness. The design is CatBoost's, not ours. See
+[How it works](concepts.md#oblivious-trees).
 
 ## Does SHAP support multiclass?
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -15,7 +15,7 @@ the [API reference](api/index.md); worked examples live in [Recipes](recipes.md)
 |---|---|---|
 | `n_estimators` | `2000` | Maximum boosting rounds (trees). |
 | `learning_rate` | `None` (auto) | Per-tree shrinkage. With early stopping, `None` resolves to 0.1 on data of about 15,000 training rows or more, and fades to 0.07 at 5,000 rows or fewer — see `adaptive_learning_rate`. Lower values trade more trees for a slightly better fit. |
-| `adaptive_learning_rate` | `True` | Let the auto `learning_rate` depend on how much data it has: a linear fade from 0.07 at 5,000 training rows or fewer up to the historical flat 0.1 at 15,000 or more. Small data is where a lower rate pays, and it is also where the extra trees are cheap. Above the upper threshold this is a no-op and the model is byte-identical to earlier versions. Set `False` for the pre-0.30.0 flat 0.1 everywhere. Only consulted when `learning_rate` is `None` and early stopping is on, so three paths are unaffected: bagged fits (`n_ensembles >= 2`), whose members already carry an explicit member learning rate, fits with `early_stopping=False`, and `ChimeraBoostQuantileRegressor`. |
+| `adaptive_learning_rate` | `True` | Let the auto `learning_rate` depend on how much data it has, as CatBoost's automatic rate does: a linear fade from 0.07 at 5,000 training rows or fewer up to the historical flat 0.1 at 15,000 or more. Small data is where a lower rate pays, and it is also where the extra trees are cheap. Above the upper threshold this is a no-op and the model is byte-identical to earlier versions. Set `False` for the pre-0.30.0 flat 0.1 everywhere. Only consulted when `learning_rate` is `None` and early stopping is on, so three paths are unaffected: bagged fits (`n_ensembles >= 2`), whose members already carry an explicit member learning rate, fits with `early_stopping=False`, and `ChimeraBoostQuantileRegressor`. |
 | `depth` | `None`→auto (reg) / `6` (clf) | Tree depth (a depth-d tree makes d splits). The regressor's `None` resolves to 6 for `"RMSE"` and `"MAE"`, and to 4 for `loss="Quantile"`, where deep leaves overfit the tail. Conservative by default; raise to 8 or 10 for large, interaction-heavy regression. See the User Guide: [interaction-heavy regression](recipes.md#interaction-heavy-regression). |
 | `l2_leaf_reg` | `1.0` | L2 penalty on leaf values. Higher is smoother. |
 | `min_child_weight` | `1.0` (reg) / `None`→auto (clf) | Minimum hessian mass on each side of a split. The classifier's `None` adapts to dataset size: the full veto (1.0) below about 500 training rows, fading linearly to 0 above about 2000. Small data needs the veto, and oblivious trees underfit large data when it stays on. |
@@ -26,13 +26,13 @@ the [API reference](api/index.md); worked examples live in [Recipes](recipes.md)
 | Parameter | Default | Effect |
 |---|---|---|
 | `max_bins` | `128` | Histogram bins per numeric feature. Raising it can improve the fit on some data. |
-| `quantize_gradients` | `True` | Search splits on 15-bit quantized gradients and hessians packed into integer histograms. Fits are 20 to 25% faster at the same accuracy. Leaf values always use exact float gradients, and results stay deterministic for a fixed `random_state`. `False` uses exact float64 histograms. |
+| `quantize_gradients` | `True` | Search splits on 15-bit quantized gradients and hessians packed into integer histograms, the quantized-training technique of Shi, Ke et al. Fits are 20 to 25% faster at the same accuracy. Leaf values always use exact float gradients, and results stay deterministic for a fixed `random_state`. `False` uses exact float64 histograms. |
 
 ## Row and column sampling
 
 | Parameter | Default | Effect |
 |---|---|---|
-| `subsample` | `1.0` | Row fraction per tree. Below 1.0, rows are drawn by Minimum Variance Sampling (gradient-weighted and unbiased) rather than uniformly. |
+| `subsample` | `1.0` | Row fraction per tree. Below 1.0, rows are drawn by Minimum Variance Sampling (Ibragimov & Gusev; gradient-weighted and unbiased) rather than uniformly. |
 | `colsample` | `None` | Feature fraction eligible per tree. `None` means 1.0 for a single model and 0.85 for members inside a bag. See the User Guide: [bagging](recipes.md#bagging). |
 
 ## Categorical features

--- a/docs/quantiles.md
+++ b/docs/quantiles.md
@@ -2,7 +2,8 @@
 
 `ChimeraBoostQuantileRegressor` estimates a whole grid of conditional quantiles from a
 single booster. One tree structure per round serves every level, and each leaf holds a
-K-vector with one entry per level.
+K-vector with one entry per level. CatBoost's `MultiQuantile` loss works the same way;
+one booster for the whole grid is not a design we came up with.
 
 ```python
 import numpy as np

--- a/docs/shap.md
+++ b/docs/shap.md
@@ -11,13 +11,14 @@ base = reg.expected_value_           # baseline, set by the call above
 
 ## Why it can be exact
 
-Most SHAP tooling approximates by sampling feature coalitions, because exact
-computation is expensive on trees of arbitrary shape. ChimeraBoost computes it exactly.
-Oblivious trees split on the same feature at every node of a level, so a depth-`D` tree
-involves at most `D` distinct features. The coalition game therefore has at most `D`
-players, and all `2**D` coalitions or fewer are enumerated directly in a numba kernel
-(64 evaluations per tree at depth 6). This is the interventional formulation of
-TreeSHAP, integrated over a background distribution.
+This is TreeSHAP (Lundberg et al.), in its interventional formulation, integrated over a
+background distribution. TreeSHAP is exact on trees of any shape, so exactness is not
+special here — what oblivious trees buy is that the exact computation is cheap and
+short. A depth-`D` tree splits on at most `D` distinct features, so the coalition game
+has at most `D` players and every one of its `2**D` coalitions can simply be enumerated
+in a numba kernel (64 evaluations per tree at depth 6), with no clever bookkeeping. The
+practical difference for you is that it is built in: no separate `shap` install, and no
+sampling approximation to configure.
 
 ## Efficiency
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,4 +98,5 @@ nav:
           - quantile_metrics: api/quantile-metrics.md
           - warmup: api/warmup.md
       - How it is benchmarked: benchmarks.md
+      - Where the ideas come from: attribution.md
       - FAQ: faq.md


### PR DESCRIPTION
Closes #72.

We borrow heavily and the docs did not say so clearly enough. This adds
`docs/attribution.md` — a feature-by-feature map of borrowed / adapted / ours —
rewrites the README citation list around it, and puts the credit next to the
mechanism on the pages that describe one.

## What was actually wrong

**The citation list was less than half complete.** It credited seven sources.
Missing: gradient boosting itself, Minimum Variance Sampling, quantized
training, vector leaves and the gradient sketch, the pinball loss, monotone
rearrangement, split conformal, temperature scaling, bagging and subagging,
AutoGluon's refit-on-all-data, the scikit-learn API conventions, Huber, the GLM
log-link family, sparsity-aware missing bins, CART split-gain importance, early
stopping, and Kahan summation. Most are described in the docs as if they were
house mechanisms.

**Four credits were wrong.** Column subsampling is Breiman's and Ho's — the
XGBoost paper credits them explicitly, and we were crediting XGBoost. Histogram
split finding predates LightGBM, oblivious trees predate CatBoost, and
Friedman 2002 was in *Computational Statistics & Data Analysis*, not the Annals.

**`docs/shap.md` took credit for exactness.** It said "most SHAP tooling
approximates by sampling feature coalitions … ChimeraBoost computes it exactly."
TreeSHAP is exact, and TreeSHAP is what we implement. The oblivious depth bound
makes the exact computation *cheap*; it was never what made it exact.

## The part worth reading

The first draft of the attribution page still over-claimed, so it went through
an adversarial pass whose job was to refute every "ours". It succeeded on most
of them:

- The multi-quantile split search claimed a representation that is `grf`'s
  quantile forest, on a contrast basis that is Hosking's L-moments, with a
  rotation schedule that maps one-to-one onto gamboostLSS cyclic vs non-cyclic.
- One claim described a PIT-rank lookup that `tree.py` deliberately **removed** —
  leaf vectors may cross during training, so the channel set is not a suffix.
  We were claiming originality for code that no longer exists.
- "Never builds the (n, K) gradient" is false on the `gram` and `exact_splits`
  arms.
- Reclaiming the early-stopping split, the size-faded `min_child_weight`, the
  `1/tau` leaf floor, the donor-row guard and the bit-identical-fast-path
  discipline all have prior art or are standard practice.

The "ours" section is now about a third of its original length, and the page
says so. `adaptive_learning_rate` is recorded as CatBoost's idea, reverse
engineered from its resolved defaults.

## Checks

`mkdocs build --strict` clean; the package imports. No library behaviour is
touched — the only non-docs edit is the `chimeraboost/__init__.py` docstring,
which credited LightGBM's histogram splitting to CatBoost.

If any credit here is still wrong or too generous to us, that is worth an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
