### PR TITLE
Make the code easier to read without changing any of it (#74)

### DIFF
--- a/benchmarks/comment_only_gate.py
+++ b/benchmarks/comment_only_gate.py
@@ -1,0 +1,94 @@
+"""Prove a change touched only comments, docstrings and whitespace.
+
+Parses each module in the package and hashes its AST with every docstring
+blanked out and line numbers dropped. If the hash is unchanged, no executable
+statement moved -- which is the entire claim a readability pass makes, and a
+much stronger check than reading the diff.
+
+Docstrings are blanked rather than compared because they live in the AST as the
+first expression of a module, class or function, so a rewritten docstring would
+otherwise read as a code change. Line numbers are dropped because whitespace
+moves them.
+
+    python benchmarks/comment_only_gate.py snapshot before.json   # before editing
+    python benchmarks/comment_only_gate.py check    before.json   # after editing
+
+Exit code 1 if any module's executable structure changed. Pair it with the test
+suite: this proves nothing MOVED, the goldens prove nothing CHANGED NUMERICALLY.
+"""
+
+import ast
+import hashlib
+import json
+import os
+import sys
+
+PKG = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                   "chimeraboost")
+
+
+class _BlankDocstrings(ast.NodeTransformer):
+    """Replace every docstring with one constant marker."""
+
+    def _strip(self, node):
+        self.generic_visit(node)
+        body = node.body
+        if (body and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)):
+            body[0].value.value = "<docstring>"
+        return node
+
+    visit_Module = _strip
+    visit_ClassDef = _strip
+    visit_FunctionDef = _strip
+    visit_AsyncFunctionDef = _strip
+
+
+def fingerprint(path):
+    with open(path, encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename=path)
+    tree = _BlankDocstrings().visit(tree)
+    ast.fix_missing_locations(tree)
+    dump = ast.dump(tree, annotate_fields=True, include_attributes=False)
+    return hashlib.sha256(dump.encode()).hexdigest()
+
+
+def collect():
+    return {name: fingerprint(os.path.join(PKG, name))
+            for name in sorted(os.listdir(PKG)) if name.endswith(".py")}
+
+
+def main():
+    if len(sys.argv) != 3 or sys.argv[1] not in ("snapshot", "check"):
+        print(__doc__)
+        return 2
+
+    mode, path = sys.argv[1], sys.argv[2]
+    now = collect()
+
+    if mode == "snapshot":
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(now, f, indent=2)
+        print(f"snapshotted {len(now)} modules -> {path}")
+        return 0
+
+    with open(path, encoding="utf-8") as f:
+        before = json.load(f)
+
+    changed = [k for k in sorted(set(before) | set(now))
+               if before.get(k) != now.get(k)]
+    for name in sorted(now):
+        print(f"  {'CODE CHANGED' if name in changed else 'same':12s} {name}")
+
+    if changed:
+        print(f"\n{len(changed)} module(s) changed executable code: "
+              f"{', '.join(changed)}")
+        return 1
+
+    print(f"\nall {len(now)} modules: comments, docstrings and whitespace only")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/chimeraboost/binning.py
+++ b/chimeraboost/binning.py
@@ -1,14 +1,16 @@
 """Quantization of numeric features into integer bins.
 
-Borders are learned once on the training data (quantile based). Every feature
-is mapped to a small integer bin index, which is what the tree builder consumes.
-NaNs are routed to a dedicated bin so a split can isolate missing values, the
-way CatBoost/LightGBM do.
+Borders are learned once on the training data, from quantiles. Every feature
+becomes a small integer bin index, which is what the tree builder consumes.
+NaNs get a bin of their own so a split can isolate missing values, the way
+CatBoost and LightGBM do.
 
 Bin layout per feature:
-    real values -> 0 .. n_borders        (via searchsorted on borders)
-    NaN         -> n_borders + 1          (the highest bin, "missing")
-The histogram width for a feature is therefore (n_borders + 2).
+
+    real values -> 0 .. n_borders        (searchsorted on the borders)
+    NaN         -> n_borders + 1         (the highest bin, "missing")
+
+So a feature's histogram is (n_borders + 2) wide.
 """
 
 from concurrent.futures import ThreadPoolExecutor
@@ -17,8 +19,9 @@ import numpy as np
 from numba import get_num_threads, njit, prange
 
 BIN_DTYPE = np.uint16
-# uint16 max is 65535; we reserve one slot for NaN, so the cap is 65534.
-# In practice 128-256 bins is the useful range; this guard just catches typos.
+
+# uint16 tops out at 65535 and one slot is reserved for NaN, so the cap is
+# 65534. The useful range is 128-256 bins; this guard only catches typos.
 _MAX_SUPPORTED_BINS = np.iinfo(BIN_DTYPE).max - 1
 
 
@@ -26,24 +29,28 @@ _MAX_SUPPORTED_BINS = np.iinfo(BIN_DTYPE).max - 1
 def _bin_matrix(X, borders_flat, offsets, out):
     """Map every (row, feature) of X to its integer bin, in parallel over rows.
 
-    Equivalent to, per feature f with borders b = borders_flat[offsets[f]:offsets[f+1]]:
-        finite v -> np.searchsorted(b, v, side="right")   (count of borders <= v)
-        non-finite v (NaN / +-inf) -> len(b) + 1          (the NaN/missing bin)
-    Parallelised over rows so each thread reads a contiguous X row and writes a
-    contiguous `out` row (cache-friendly on the row-major matrices), replacing the
-    per-column single-threaded np.searchsorted loop.
+    For feature f with borders b = borders_flat[offsets[f]:offsets[f+1]], this is:
+
+        finite v     -> np.searchsorted(b, v, side="right")  (borders <= v)
+        NaN or +-inf -> len(b) + 1                           (the missing bin)
+
+    Splitting the work by row, not by column, lets each thread read a contiguous
+    X row and write a contiguous `out` row, which is cache-friendly on these
+    row-major matrices. It replaces a single-threaded per-column searchsorted.
     """
     n, nf = X.shape
+
     for i in prange(n):
         for f in range(nf):
             lo = offsets[f]
             hi = offsets[f + 1]
-            m = hi - lo                      # number of borders for feature f
+            m = hi - lo                      # borders for feature f
             v = X[i, f]
+
             if not np.isfinite(v):
                 out[i, f] = m + 1            # NaN / inf -> missing bin
             else:
-                # rightmost insertion point == count of borders <= v.
+                # Binary search for the rightmost insertion point.
                 a = lo
                 b = hi
                 while a < b:
@@ -57,17 +64,21 @@ def _bin_matrix(X, borders_flat, offsets, out):
 
 @njit(cache=True)
 def _bin_matrix_serial(X, borders_flat, offsets, out):
-    """Serial twin of `_bin_matrix` for tiny predict batches, where the
-    OpenMP fork/join costs more than the whole pass (~20us vs ~1us for a
-    1-row batch). Every write is independent, so the two are bit-identical;
-    `Binner.transform` dispatches on `_SERIAL_PREDICT_N`."""
+    """Serial twin of `_bin_matrix`, for tiny predict batches.
+
+    On a one-row batch the OpenMP fork/join costs about 20us against about 1us
+    for the whole pass. Every write is independent, so the two kernels are
+    bit-identical; `Binner.transform` picks one on `_SERIAL_PREDICT_N`.
+    """
     n, nf = X.shape
+
     for i in range(n):
         for f in range(nf):
             lo = offsets[f]
             hi = offsets[f + 1]
             m = hi - lo
             v = X[i, f]
+
             if not np.isfinite(v):
                 out[i, f] = m + 1
             else:
@@ -82,13 +93,13 @@ def _bin_matrix_serial(X, borders_flat, offsets, out):
                 out[i, f] = a - lo
 
 
-# Predict batches at or below this many rows take the serial kernels: the
-# fork/join cost exceeds the whole serial pass there.
+# Predict batches this small or smaller take the serial kernels, where
+# fork/join costs more than the whole serial pass.
 #
-# Re-measured 2026-07-30 by forcing each kernel on the same packed forest.
-# The old value of 4 assumed the parallel walk overtakes serial by n~5; it
-# actually overtakes between 32 and 64, so every 5-to-32-row predict was
-# paying fork/join for nothing -- up to 1.26x on a 100-tree forest:
+# Re-measured 2026-07-30 by forcing each kernel on the same packed forest. The
+# old value of 4 assumed parallel overtook serial around n=5; it actually
+# overtakes between 32 and 64, so every 5-to-32-row predict paid fork/join for
+# nothing -- up to 1.26x on a 100-tree forest:
 #
 #   rows   serial   parallel        (100 trees, depth 6, 25 features)
 #      4   38.4us     48.9us   serial 1.27x
@@ -98,23 +109,28 @@ def _bin_matrix_serial(X, borders_flat, offsets, out):
 #     64   56.1us     51.5us   parallel 1.09x
 #
 # 300- and 500-tree forests cross over in the same place. 32 is the last row
-# count serial still wins; the penalty for being wrong at the boundary on a
-# wider machine is the 1.05x there, against the 1.26x recovered below it.
-# Both sides of the dispatch are bit-identical, so this only affects speed.
+# count serial still wins. A wider machine could move the crossover, but being
+# wrong at the boundary costs the 1.05x there, against the 1.26x recovered
+# below it. Both kernels are bit-identical, so this only affects speed.
 _SERIAL_PREDICT_N = 32
 
 
 def _weighted_quantiles(values, weights, qs):
-    """Weighted quantiles at levels ``qs`` (sorted values, midpoint plotting
-    position). Reduces to the ordinary midpoint quantile when weights are
-    equal; used only on the sample-weighted binning path."""
+    """Weighted quantiles at levels ``qs``, using the midpoint plotting position.
+
+    With equal weights this is the ordinary midpoint quantile. Only the
+    sample-weighted binning path uses it.
+    """
     order = np.argsort(values, kind="stable")
     v = values[order]
     w = weights[order]
+
     cumw = np.cumsum(w)
     total = cumw[-1]
+
     # Position of each value on [0, 1]: cumulative weight up to its midpoint.
     pos = (cumw - 0.5 * w) / total
+
     return np.interp(qs, pos, v)
 
 
@@ -122,84 +138,101 @@ def _weighted_quantiles(values, weights, qs):
 def _greedy_border_fill(uniq, mass, heavy, target, budget):
     """Compiled twin of the border-building sweep in `_greedy_borders`.
 
-    A straight transcription of the former Python loop: same statement order,
-    same float64 arithmetic, so the borders are bit-identical. Only the sweep
-    lives here -- the mass sums and heavy-value marking stay in numpy above,
-    because numba's reductions do not match numpy's pairwise summation
-    bit-for-bit and `target` must not move."""
+    A straight transcription of the old Python loop: same statement order, same
+    float64 arithmetic, so the borders come out bit-identical.
+
+    Only the sweep lives here. The mass sums and the heavy-value marking stay in
+    numpy in the caller, because numba's reductions do not match numpy's
+    pairwise summation bit-for-bit and `target` must not move.
+    """
     n = uniq.size
     borders = np.empty(budget, dtype=np.float64)
     nb = 0
     acc = 0.0
+
     for i in range(n):
         if nb >= budget:
             break
+
         if heavy[i]:
             if acc > 0.0:
-                # Close the light run before the heavy value so it gets a
-                # bin of its own.
+                # Close the light run first, so the heavy value gets its own bin.
                 borders[nb] = (uniq[i - 1] + uniq[i]) / 2.0
                 nb += 1
                 acc = 0.0
+
             if i < n - 1 and nb < budget:
                 borders[nb] = (uniq[i] + uniq[i + 1]) / 2.0
                 nb += 1
         else:
             acc += mass[i]
+
             if acc >= target and i < n - 1:
                 borders[nb] = (uniq[i] + uniq[i + 1]) / 2.0
                 nb += 1
                 acc = 0.0
+
     return borders[:nb].copy()
 
 
 def _greedy_borders(uniq, mass, max_bins):
     """Borders over distinct values when even-mass quantiles have collapsed.
 
-    A value holding at least an even bin's share of mass gets isolated between
-    the midpoints to its neighbors, and the budget it does not consume is
-    re-spread over the remaining values by mass. Pure even-mass splitting
-    cannot do this: every quantile level lands on the heavy value, the borders
-    dedup to one edge equal to that value, and (with the "border <= v goes
-    right" convention) that edge separates nothing -- the feature silently
-    dies. Borders always sit strictly between distinct values, like the
-    few-uniques branch."""
+    A value holding at least an even bin's share of mass ("heavy") is isolated
+    between the midpoints to its neighbors, and the budget it does not use is
+    re-spread over the remaining values by mass. As in the few-uniques branch,
+    borders always sit strictly between distinct values.
+
+    Even-mass splitting cannot do this. Every quantile level lands on the heavy
+    value, the borders dedup to a single edge equal to that value, and under the
+    "border <= v goes right" convention that edge separates nothing -- the
+    feature silently dies.
+
+    The light mass keeps its mass-proportional share of the bin budget. That is
+    the allocation plain quantile borders produce, and the one the library
+    defaults are tuned around. Handing the light region the heavy values' whole
+    freed budget instead measurably over-resolves sparse tails (decision-tier
+    A/B 2026-07-30: Grinsztajn 21W-32L, median -0.03%).
+    """
     total = float(mass.sum())
-    # Mark heavy values iteratively: removing one from the pool lowers the
-    # even share of what remains, which can expose the next. Capped so the
-    # border budget below cannot overflow even on pathological mass profiles.
+
+    # Mark heavy values one pass at a time: removing one from the pool lowers
+    # the even share of what remains, which can expose the next. Capped so the
+    # border budget below cannot overflow on a pathological mass profile.
     heavy = np.zeros(uniq.size, dtype=np.bool_)
     max_heavy = (max_bins - 1) // 2
+
     while int(heavy.sum()) < max_heavy:
         rest = total - float(mass[heavy].sum())
         thr = rest / (max_bins - int(heavy.sum()))
         new = (~heavy) & (mass >= thr)
+
         if not new.any():
             break
+
         if int(heavy.sum()) + int(new.sum()) > max_heavy:
             cand = np.where(new)[0]
             room = max_heavy - int(heavy.sum())
             heavy[cand[np.argsort(mass[cand])[::-1][:room]]] = True
             break
+
         heavy |= new
+
     n_heavy = int(heavy.sum())
-    # The light mass keeps its MASS-PROPORTIONAL share of the bin budget --
-    # the allocation plain quantile borders produce, and the one the library
-    # defaults are tuned around -- with a floor so a dominated column can
-    # never collapse to nothing. Redistributing the heavy values' whole freed
-    # budget into the light region instead measurably over-resolves sparse
-    # tails (decision-tier A/B 2026-07-30: Grinsztajn 21W-32L, median -0.03%).
     light_total = total - float(mass[heavy].sum())
-    # Floor of 1: below max_bins=16 the `max_bins // 16` floor is itself 0, and
-    # a column dominated hard enough to round the proportional term to 0 too
-    # divided by zero here. For max_bins >= 16 the // 16 term already dominates,
-    # so every budget that worked before keeps its exact allocation.
+
+    # The floor of 1 keeps a dominated column from collapsing to nothing. Below
+    # max_bins=16 the `max_bins // 16` term is itself 0, and a column dominated
+    # hard enough to round the proportional term to 0 too divided by zero here.
+    # From max_bins=16 up, the // 16 term already dominates, so every budget
+    # that worked before keeps its exact allocation.
     light_bins = max(1, max_bins // 16,
                      int(round((max_bins - n_heavy) * (light_total / total))))
     target = light_total / light_bins
-    # The O(n_distinct) sweep is compiled: in pure Python it made Binner.fit
-    # ~4x slower on zero-inflated columns (1.34 s vs 0.29 s dense at 200k
-    # rows x 30 features).
+
+    # The O(n_distinct) sweep is compiled: in pure Python it made Binner.fit ~4x
+    # slower on zero-inflated columns (1.34 s against 0.29 s dense, at 200k rows
+    # by 30 features).
     return _greedy_border_fill(
         np.ascontiguousarray(uniq, dtype=np.float64),
         np.ascontiguousarray(mass, dtype=np.float64),
@@ -210,62 +243,79 @@ def _feature_borders(col, max_bins, weights=None):
     """Quantile borders for one numeric column, ignoring NaNs.
 
     ``weights`` (per row, aligned with ``col``) makes the borders sample-weight
-    aware: zero-weight rows are dropped outright and fractional weights steer the
-    quantiles, so a row the caller zeroed out cannot place a bin edge. ``None``
-    is the unweighted fast path, unchanged from before this argument existed.
+    aware: zero-weight rows are dropped outright and fractional weights steer
+    the quantiles, so a row the caller zeroed out cannot place a bin edge.
+    ``None`` is the unweighted fast path, unchanged from before this argument
+    existed.
 
-    Columns whose quantile levels all land on distinct borders keep the plain
-    even-mass quantile borders, bit-identical to before. Colliding levels mean
-    a value holds more than an even bin's share of mass; those columns switch
-    to `_greedy_borders`, which isolates such values instead of letting the
-    collapsed edge kill the column."""
+    When every quantile level lands on a distinct border, the column keeps the
+    plain even-mass quantile borders, bit-identical to before. Colliding levels
+    mean some value holds more than an even bin's share of the mass, and the
+    column falls through to `_greedy_borders`, which isolates that value rather
+    than let the collapsed edge kill the feature.
+    """
     finite_mask = np.isfinite(col)
     finite = col[finite_mask]
+
     if weights is None:
         if finite.size == 0:
             return np.array([], dtype=np.float64)
-        # Open-coded np.unique (one sort + a run-start mask) so the greedy
-        # path below can read its per-value mass off the run lengths for
-        # free. np.unique's counts would cost every dense column a little,
-        # and the old searchsorted + np.add.at pass cost the greedy columns
-        # more than the greedy sweep itself. Counts are exact integers any
-        # way they are computed, so borders are bit-identical.
+
+        # np.unique open-coded as one sort plus a run-start mask, so the greedy
+        # path below gets its per-value mass off the run lengths for free.
+        # np.unique's own counts would tax every dense column, and the old
+        # searchsorted + np.add.at pass cost the greedy columns more than the
+        # greedy sweep itself. Counts are exact integers however they are
+        # computed, so borders stay bit-identical.
         sv = np.sort(finite)
         run_start = np.empty(sv.size, dtype=np.bool_)
         run_start[0] = True
         np.not_equal(sv[1:], sv[:-1], out=run_start[1:])
         uniq = sv[run_start]
+
         if uniq.size <= max_bins:
             # Few distinct values: put a border between each pair.
             return ((uniq[:-1] + uniq[1:]) / 2.0).astype(np.float64)
+
         qs = np.linspace(0.0, 1.0, max_bins + 1)[1:-1]
-        # Quantiles of the sorted copy, partitioned in place: identical values
-        # (quantile is order-agnostic), but skips np.quantile's internal copy
-        # and partitions near-instantly. Only sv.size is read below this line,
-        # so scrambling sv is fine.
+
+        # Quantiles are order-agnostic, so partitioning the sorted copy in place
+        # gives identical values while skipping np.quantile's internal copy.
+        # Nothing below reads sv except its size, so scrambling it is safe.
         borders = np.unique(np.quantile(sv, qs, overwrite_input=True))
+
         if borders.size == qs.size:
             return borders.astype(np.float64)
+
         starts = np.nonzero(run_start)[0]
         counts = np.empty(starts.size, dtype=np.float64)
         counts[:-1] = np.diff(starts)
         counts[-1] = sv.size - starts[-1]
+
         return _greedy_borders(uniq, counts, max_bins)
+
     # Weighted path: a zero-weight row does not exist for border purposes.
     fw = weights[finite_mask]
     pos = fw > 0.0
     finite, fw = finite[pos], fw[pos]
+
     if finite.size == 0:
         return np.array([], dtype=np.float64)
+
     uniq = np.unique(finite)
+
     if uniq.size <= max_bins:
         return ((uniq[:-1] + uniq[1:]) / 2.0).astype(np.float64)
+
     qs = np.linspace(0.0, 1.0, max_bins + 1)[1:-1]
     borders = np.unique(_weighted_quantiles(finite, fw, qs))
+
     if borders.size == qs.size:
         return borders.astype(np.float64)
+
     wmass = np.zeros(uniq.size)
     np.add.at(wmass, np.searchsorted(uniq, finite), fw)
+
     return _greedy_borders(uniq, wmass, max_bins)
 
 
@@ -282,11 +332,11 @@ def _feature_borders(col, max_bins, weights=None):
 #  100000x30    3000000   40.24ms    12.23ms   parallel 3.3x
 #  200000x30    6000000   96.0 ms    22.3 ms   parallel 4.3x
 #
-# Zero-inflated columns gain 3.2x at 200k x 30 and the weighted path 5.5x
-# (its argsort/cumsum/interp all release the GIL). 200k cells is the first
-# size parallel wins; the penalty for being wrong near the boundary is a few
-# ms either way. Both dispatch arms run identical per-column code, so the
-# constant only affects speed, never borders.
+# At 200k x 30, zero-inflated columns gain 3.2x and the weighted path 5.5x (its
+# argsort, cumsum and interp all release the GIL). 200k cells is the first size
+# parallel wins, and being wrong near the boundary costs a few ms either way.
+# Both arms run identical per-column code, so this only affects speed, never
+# the borders themselves.
 _PARALLEL_FIT_MIN_CELLS = 200_000
 
 
@@ -294,21 +344,27 @@ class Binner:
     """Learns per-feature borders and maps a float matrix to bins."""
 
     def __init__(self, max_bins=128):
-        # max_bins is a scalar (uniform budget) or a per-feature array (C4
-        # cat-aware binning: a larger budget for target-encoded categorical
-        # columns). Validate either form against the dtype cap and the >=2 floor.
+        # max_bins is either a scalar (one budget for every feature) or a
+        # per-feature array (C4 cat-aware binning gives target-encoded
+        # categorical columns a bigger budget). Both forms get checked against
+        # the dtype cap and the floor of 2.
         arr = np.atleast_1d(np.asarray(max_bins))
+
         if (arr > _MAX_SUPPORTED_BINS).any():
             raise ValueError(
                 f"max_bins={max_bins} exceeds {_MAX_SUPPORTED_BINS} "
                 f"(BIN_DTYPE={BIN_DTYPE.__name__}); use a smaller value."
             )
+
         if (arr.astype(np.int64) < 2).any():
             raise ValueError(f"max_bins={max_bins} must be >= 2.")
-        # Keep a scalar scalar (back-compat) or an int per-feature array.
+
+        # A scalar stays a scalar, for back-compat; anything else becomes an
+        # int array with one entry per feature.
         self.max_bins = (int(max_bins) if np.isscalar(max_bins)
                          or arr.size == 1 and np.ndim(max_bins) == 0
                          else arr.astype(np.int64))
+
         self.borders_ = None       # list of np.ndarray, one per feature
         self.n_bins_ = None        # np.ndarray int, width per feature
         self.bin_centers_ = None   # list of np.ndarray: representative value/bin
@@ -316,8 +372,7 @@ class Binner:
         self._offsets = None       # int64 (n_features+1) prefix offsets into flat
 
     def _max_bins_for(self, f):
-        """Per-feature bin budget: a scalar applies to all features, an array
-        gives feature f its own budget."""
+        """Bin budget for feature f: the scalar, or its own entry of the array."""
         return int(self.max_bins) if np.ndim(self.max_bins) == 0 \
             else int(self.max_bins[f])
 
@@ -325,18 +380,21 @@ class Binner:
     def _centers_for(borders):
         """A representative continuous value for each bin of one feature.
 
-        Bin layout is bins 0..m (the searchsorted buckets for m borders) plus a
-        trailing NaN bin. Interior bins use the midpoint of their border pair;
-        the two edge bins extrapolate by half the adjacent gap; the NaN bin gets
-        NaN (callers using these for a linear term map it to the feature mean).
-        Used by the optional linear-leaf models to evaluate a within-leaf slope.
+        The layout is bins 0..m (the searchsorted buckets for m borders) plus a
+        trailing NaN bin. An interior bin takes the midpoint of its border pair,
+        the two edge bins extrapolate by half the adjacent gap, and the NaN bin
+        gets NaN -- callers building a linear term map that to the feature mean.
+
+        The optional linear-leaf models use these to fit a within-leaf slope.
         """
         m = len(borders)
         centers = np.empty(m + 2, dtype=np.float64)
+
         if m == 0:
             centers[:] = 0.0
             centers[1] = np.nan
             return centers
+
         if m == 1:
             centers[0] = borders[0]
             centers[1] = borders[0]
@@ -344,27 +402,32 @@ class Binner:
             centers[0] = borders[0] - 0.5 * (borders[1] - borders[0])
             centers[1:m] = 0.5 * (borders[:-1] + borders[1:])
             centers[m] = borders[m - 1] + 0.5 * (borders[m - 1] - borders[m - 2])
+
         centers[m + 1] = np.nan                     # NaN bin
         return centers
 
     def fit(self, X, sample_weight=None):
         """Learn quantile borders for each column from training data.
 
-        ``sample_weight`` (per row, ``None`` == uniform) makes the borders
-        weight-aware; ``None`` is bit-identical to the pre-weight behavior."""
+        ``sample_weight`` is per row, ``None`` meaning uniform. Passing ``None``
+        is bit-identical to the behavior from before weights existed.
+
+        A wide enough fit farms the columns out to a thread pool. That is safe
+        because every column's borders are independent -- the same invariant
+        `from_base_with_cross` splices on -- and both arms run the same
+        per-column code. Numpy's sort, partition and argsort release the GIL,
+        and nothing accumulates across features, so the borders match the serial
+        loop bit-for-bit whatever order the threads finish in. The pool is sized
+        from numba's thread count, since fit already runs inside `_thread_limit`
+        and that keeps thread_count=1 and bagged-worker budget shares honored.
+        """
         X = np.asarray(X, dtype=np.float64)
         n_features = X.shape[1]
         w = None if sample_weight is None else np.asarray(
             sample_weight, dtype=np.float64)
-        # Every column's borders are independent (the invariant
-        # from_base_with_cross splices on), so wide-enough fits farm the
-        # columns out to a thread pool running the *same* per-column code --
-        # numpy's sort/partition/argsort release the GIL, and nothing here
-        # accumulates across features, so the borders are bit-identical to
-        # the serial loop regardless of scheduling. Pool width follows
-        # numba's thread count: fit already runs inside _thread_limit, so
-        # thread_count=1 and bagged-worker budget shares are honored.
+
         n_threads = min(get_num_threads(), n_features)
+
         if n_threads > 1 and X.size >= _PARALLEL_FIT_MIN_CELLS:
             with ThreadPoolExecutor(max_workers=n_threads) as ex:
                 self.borders_ = list(ex.map(
@@ -375,21 +438,27 @@ class Binner:
                 _feature_borders(X[:, f], self._max_bins_for(f), w)
                 for f in range(n_features)
             ]
+
         # +1 for the searchsorted upper bucket, +1 for the NaN bucket.
         self.n_bins_ = np.array(
             [len(b) + 2 for b in self.borders_], dtype=np.int64
         )
+
         self.bin_centers_ = [self._centers_for(b) for b in self.borders_]
         self._build_flat_borders()
         return self
 
     def _build_flat_borders(self):
-        """Flatten the ragged per-feature borders into one contiguous array plus
-        offsets, so the numba kernel can index feature f's borders as
-        borders_flat[offsets[f]:offsets[f+1]]. Cached on the instance."""
+        """Flatten the ragged per-feature borders into one contiguous array.
+
+        With the accompanying offsets, the numba kernel reads feature f's
+        borders as borders_flat[offsets[f]:offsets[f+1]]. Cached on the instance.
+        """
         lens = [len(b) for b in self.borders_]
+
         self._offsets = np.zeros(len(self.borders_) + 1, dtype=np.int64)
         self._offsets[1:] = np.cumsum(lens)
+
         self._borders_flat = (np.concatenate(self.borders_).astype(np.float64)
                               if self.borders_ else np.zeros(0, dtype=np.float64))
 
@@ -397,16 +466,20 @@ class Binner:
         """Map a float matrix to integer bin indices; NaNs go to the top bin."""
         X = np.ascontiguousarray(X, dtype=np.float64)
         n_samples, n_features = X.shape
-        # Lazily (re)build the flat border layout if missing — e.g. when borders_
-        # were set without going through fit().
+
+        # Rebuild the flat layout if it is missing or stale, which happens when
+        # borders_ was set directly instead of through fit().
         if getattr(self, "_borders_flat", None) is None or \
                 len(self._offsets) != n_features + 1:
             self._build_flat_borders()
+
         out = np.empty((n_samples, n_features), dtype=BIN_DTYPE)
+
         if n_samples:
             kernel = (_bin_matrix_serial if n_samples <= _SERIAL_PREDICT_N
                       else _bin_matrix)
             kernel(X, self._borders_flat, self._offsets, out)
+
         return out
 
     def fit_transform(self, X, sample_weight=None):

--- a/chimeraboost/booster.py
+++ b/chimeraboost/booster.py
@@ -30,25 +30,33 @@ from .tree import (build_oblivious_tree, replay_oblivious_tree,
 
 
 def _uniform_to_none(w):
-    """Collapse uniform (all-equal) weights to None: they are the unweighted
-    case, and routing them through None keeps every weight-aware path (grad/hess,
-    loss init, target encoder, binner, validation metric) bit-identical to
-    sample_weight=None. None passes through unchanged."""
+    """Collapse all-equal weights to None.
+
+    All-equal weights are the unweighted case, and routing them through None
+    keeps every weight-aware path -- grad/hess, loss init, target encoder,
+    binner, validation metric -- bit-identical to ``sample_weight=None``.
+    None passes through unchanged.
+    """
     if w is None:
         return None
+
     w = np.asarray(w, dtype=np.float64)
     if w.size and np.all(w == w[0]):
         return None
+
     return w
 
 
 def _run_callbacks(callbacks, iteration, train_loss, val_loss, model):
-    """Invoke each fit callback for one boosting round. A callback is
-    ``cb(iteration, train_loss, val_loss, model)``; returning True requests an
-    early stop. Returns True if any callback asked to stop. ``callbacks`` may be
-    a single callable or an iterable of them; None is a no-op."""
+    """Run every fit callback for one boosting round.
+
+    A callback is ``cb(iteration, train_loss, val_loss, model)``; returning True
+    asks for an early stop. ``callbacks`` may be one callable or an iterable of
+    them; None is a no-op. Returns True if any callback asked to stop.
+    """
     if not callbacks:
         return False
+
     cbs = callbacks if isinstance(callbacks, (list, tuple)) else (callbacks,)
     stop = False
     for cb in cbs:
@@ -58,14 +66,17 @@ def _run_callbacks(callbacks, iteration, train_loss, val_loss, model):
 
 
 def _callbacks_need_train_loss(callbacks):
-    """Whether any fit callback wants the per-round train loss. Internal
-    callbacks (selection-race auditions) never read it and are tagged with
-    ``_cb_needs_train_loss = False``; evaluating the loss on the full training
-    set every round is the single biggest non-tree cost of an audition fit, so
-    the fit loop skips it when nobody will look at the value. Untagged (user)
-    callbacks keep receiving the train loss as documented."""
+    """Whether any fit callback wants the per-round train loss.
+
+    Internal callbacks (the selection-race auditions) never read it and are
+    tagged ``_cb_needs_train_loss = False``. Evaluating the loss on the full
+    training set every round is the biggest non-tree cost of an audition fit, so
+    the fit loop skips it when nobody will look. Untagged (user) callbacks keep
+    receiving the train loss as documented.
+    """
     if not callbacks:
         return False
+
     cbs = callbacks if isinstance(callbacks, (list, tuple)) else (callbacks,)
     return any(getattr(cb, "_cb_needs_train_loss", True) for cb in cbs)
 
@@ -79,12 +90,14 @@ def _factorials(n):
     return f
 
 
-# Below this many training rows, per-leaf linear models overfit (noisy small
-# data has too little signal per leaf to support a stable slope), so linear
-# leaves silently fall back to constant leaves. Matches the codebase's recurring
-# "sub-~1k rows is the small-data danger zone" boundary (cf. _auto_min_child_weight,
-# the max_bins sub-1k overfit). Validated: protects kc2 (~313 train) from a -4.6%
-# Brier loss while keeping the wins on larger sets (sick/spambase/electricity).
+# Below this many training rows, per-leaf linear models overfit -- too little
+# signal per leaf for a stable slope -- so linear leaves silently fall back to
+# constant leaves. Same "sub-~1k rows is the small-data danger zone" boundary
+# the rest of the codebase uses (cf. _auto_min_child_weight, the max_bins
+# sub-1k overfit).
+#
+# Validated: it protects kc2 (~313 train rows) from a -4.6% Brier loss while
+# keeping the wins on the larger sets (sick/spambase/electricity).
 LINEAR_LEAVES_MIN_SAMPLES = 1000
 
 # Default number of training rows retained as the SHAP background distribution.
@@ -93,29 +106,34 @@ SHAP_BACKGROUND_SIZE = 200
 
 @contextmanager
 def _thread_limit(thread_count):
-    """Apply an explicit ``thread_count`` for the duration of one fit or
-    predict call, restoring the caller's numba thread setting on exit.
+    """Apply an explicit ``thread_count`` for one fit or predict call, restoring
+    the caller's numba thread setting on exit.
 
-    ``numba.set_num_threads`` is process-global; without the restore, one
-    model's ``thread_count=1`` would silently cap every later numba call in
-    the process (other models' fits and predicts included). ``None`` / ``-1``
-    leaves the ambient setting untouched entirely, so a user's own
-    ``numba.set_num_threads`` (or ``NUMBA_NUM_THREADS``) is respected.
-    Yields the effective thread count so callers can record it.
+    ``numba.set_num_threads`` is process-global. Without the restore, one model's
+    ``thread_count=1`` would silently cap every later numba call in the process,
+    other models' fits and predicts included.
+
+    ``None`` / ``-1`` leaves the ambient setting untouched, so a user's own
+    ``numba.set_num_threads`` (or ``NUMBA_NUM_THREADS``) is respected. Yields the
+    effective thread count so callers can record it.
     """
     import numba
+
     if thread_count is None or int(thread_count) < 0:
         yield numba.get_num_threads()
         return
+
     prev = numba.get_num_threads()
     n = max(1, min(int(thread_count), numba.config.NUMBA_NUM_THREADS))
+
     if n == prev:
-        # Already there: skip the switch entirely. A changed thread count is
-        # NOT free -- the omp layer charges ~1 ms to re-team on the next
-        # parallel region -- so processes that align the ambient setting
-        # (NUMBA_NUM_THREADS / numba.set_num_threads) predict at full speed.
+        # Already there: skip the switch. Changing the count is NOT free -- the
+        # omp layer charges ~1 ms to re-team on the next parallel region -- so
+        # processes that align the ambient setting (NUMBA_NUM_THREADS /
+        # numba.set_num_threads) predict at full speed.
         yield n
         return
+
     numba.set_num_threads(n)
     try:
         yield n
@@ -125,10 +143,12 @@ def _thread_limit(thread_count):
 
 def _eval_advance(Fv, tree, Xvb):
     """Add one tree's eval-set contribution to ``Fv`` in place (scalar path).
+
+    Both arms perform the same elementwise adds as ``Fv += tree.predict(Xvb)``.
     Constant-leaf trees fuse the value gather into `_add_leaf_values` via the
-    parallel leaf assignment; linear-leaf trees keep ``tree.predict`` -- their
-    step lives in ``lin_coef``, not ``values``. Both arms are the same
-    elementwise adds `Fv += tree.predict(Xvb)` performed."""
+    parallel leaf assignment; linear-leaf trees keep ``tree.predict`` because
+    their step lives in ``lin_coef``, not ``values``.
+    """
     if tree.lin_coef is None:
         _add_leaf_values(Fv.reshape(-1, 1), tree.values.reshape(-1, 1),
                          tree.apply(Xvb))
@@ -136,18 +156,19 @@ def _eval_advance(Fv, tree, Xvb):
         np.add(Fv, tree.predict(Xvb), out=Fv)
 
 
-# Size-adaptive auto learning rate (opt-in; see benchmarks/SMALLDATA_PLAN.md).
+# Size-adaptive auto learning rate (see benchmarks/SMALLDATA_PLAN.md).
 #
 # CatBoost's ONLY size-dependent default is its learning rate, and denying it
-# that schedule costs it 57% of its edge over us at quarter size -- the single
-# largest identified cause of the small-data gap. Sweeping our own rate found a
-# sharp knee at 0.07: at quarter size it is +0.275% of the primary metric over
-# the shipped 0.1 (10W-2L) for 1.21x fit, where 0.05 buys no more strength at
-# 1.46x. At full size the same arm is a wash (+0.118%, 8W-4L) that would cost
-# 1.28x, so the fade deliberately returns to 0.1 on large data rather than
-# paying for nothing.
+# that schedule costs it 57% of its edge over us at quarter size -- the largest
+# identified cause of the small-data gap.
 #
-# Thresholds are in rows the BOOSTER trains on, i.e. after the estimator's
+# Sweeping our own rate found a sharp knee at 0.07. At quarter size it is
+# +0.275% of the primary metric over the shipped 0.1 (10W-2L) for 1.21x fit,
+# where 0.05 buys no more strength at 1.46x. At full size the same arm is a wash
+# (+0.118%, 8W-4L) costing 1.28x, so the fade deliberately returns to 0.1 on
+# large data rather than paying for nothing.
+#
+# Thresholds count the rows the BOOSTER trains on, i.e. after the estimator's
 # early-stopping split has taken validation_fraction out. The probe reported
 # pre-split counts, so its measured-positive buckets (up to ~7,500 pre-split)
 # land at ~6,000 here.
@@ -162,27 +183,30 @@ def _auto_learning_rate(n_estimators, early_stopping, n_train=None,
     """Default learning rate when the user did not specify one.
 
     With early stopping, 0.1 (the field-standard default) lets early stopping
-    pick the ensemble size; it converges in ~half the trees of a smaller rate
-    with no measured accuracy cost, which speeds up both fit and predict.
-    Otherwise the rate scales inversely with the iteration budget so short runs
-    still cover enough ground.
+    pick the ensemble size. It converges in about half the trees of a smaller
+    rate at no measured accuracy cost, which speeds up fit and predict alike.
+    Without early stopping the rate scales inversely with the iteration budget,
+    so short runs still cover enough ground.
 
-    ``adaptive`` replaces the flat 0.1 with a linear fade from
-    ``_AUTO_LR_SMALL`` at ``_AUTO_LR_LO`` training rows up to the unchanged
-    ``_AUTO_LR_LARGE`` at ``_AUTO_LR_HI``. It applies ONLY on the
-    early-stopping path: the no-early-stopping branch already scales with the
-    iteration budget, and the small-data measurement was made end-to-end
-    through early stopping plus the full-data refit. The estimators pass
-    ``adaptive=True`` by default since 0.30.0; ``adaptive=False`` keeps this
-    function bit-for-bit what it always was, which is why the argument
-    defaults to False here rather than tracking the estimator default.
+    ``adaptive`` replaces the flat 0.1 with a linear fade from ``_AUTO_LR_SMALL``
+    at ``_AUTO_LR_LO`` training rows up to the unchanged ``_AUTO_LR_LARGE`` at
+    ``_AUTO_LR_HI``. It applies ONLY on the early-stopping path: the other branch
+    already scales with the iteration budget, and the small-data measurement was
+    made end-to-end through early stopping plus the full-data refit.
+
+    The estimators pass ``adaptive=True`` by default since 0.30.0.
+    ``adaptive=False`` keeps this function bit-for-bit what it always was, which
+    is why the argument defaults to False here instead of tracking the estimator
+    default.
     """
     if early_stopping:
         if not adaptive or n_train is None:
             return _AUTO_LR_LARGE
+
         span = float(_AUTO_LR_HI - _AUTO_LR_LO)
         t = float(np.clip((float(n_train) - _AUTO_LR_LO) / span, 0.0, 1.0))
         return float(_AUTO_LR_SMALL + t * (_AUTO_LR_LARGE - _AUTO_LR_SMALL))
+
     return float(np.clip(20.0 / max(n_estimators, 1), 0.03, 0.2))
 
 
@@ -198,16 +222,18 @@ class _EarlyStopper:
         """Record the round-*m* score; return True if training should stop."""
         if not np.isfinite(score):
             # A NaN/inf score never compares below best, so without this guard
-            # best_iter would silently freeze at 0 and the fitted model would
-            # be truncated to a single tree.
+            # best_iter would freeze at 0 and the fitted model would be
+            # truncated to a single tree.
             raise ValueError(
                 f"Validation score at round {m} is {score!r} and cannot drive "
                 "early stopping. Check eval_set y for NaN/inf or values "
                 "outside the loss's domain (e.g. zeros with loss='Gamma'), "
                 "and any custom eval_metric's return value.")
+
         if score < self.best_score - 1e-9:
             self.best_score, self.best_iter = score, m
             return False
+
         return bool(self.patience) and (m - self.best_iter >= self.patience)
 
 
@@ -252,9 +278,11 @@ class _BaseBooster:
         self.cross_pairs = list(cross_pairs) if cross_pairs else []
         self.quantize_gradients = bool(quantize_gradients)
         self.eval_metric = eval_metric
+
         # Size fade for the auto learning rate (_auto_learning_rate), default-on
         # since 0.30.0. False == the historical flat 0.1, byte-identical.
         self.adaptive_learning_rate = bool(adaptive_learning_rate)
+
         # Structure-transfer refit (see tree.replay_oblivious_tree): a
         # (trees, preprocessor) pair whose splits are replayed instead of
         # re-grown. None == ordinary fit, and every path below is unchanged.
@@ -265,49 +293,59 @@ class _BaseBooster:
 
         Float path: (n_features, 2**depth, max_bins, 2); the last axis
         interleaves grad and hess so each scatter write hits one cache line.
-        Quantized path: int64 (n_features, 2**depth, max_bins) — grad and
-        hess ride packed in one cell (see tree._quantize_pack), halving the
-        footprint. Reused for every tree and level (the kernel zeroes the
-        active slice each call), avoiding thousands of reallocations over a
-        long boosting run.
+        Quantized path: int64 (n_features, 2**depth, max_bins) — grad and hess
+        ride packed in one cell (see tree._quantize_pack), halving the footprint.
+
+        One buffer serves every tree and level (the kernel zeroes the active
+        slice each call), which avoids thousands of reallocations over a long
+        boosting run.
         """
         max_leaves = 1 << self.depth
         max_bins = int(n_bins.max()) if len(n_bins) else 1
+
         if self.quantize_gradients:
             return np.zeros((n_features, max_leaves, max_bins),
                             dtype=np.int64)
         return np.zeros((n_features, max_leaves, max_bins, 2))
 
     def _build_centers_std(self, Xb, n_bins):
-        """Per-(feature, bin) table of STANDARDIZED bin-center values for the
-        optional linear-leaf models. Standardizing per feature over the training
-        distribution makes the linear ridge penalty scale-fair across features.
-        Non-numeric (target-encoded) columns get zeros (never used as linear
-        terms); the NaN/missing bin keeps NaN (treated as 0 = mean downstream)."""
+        """Per-(feature, bin) table of STANDARDIZED bin centers for the optional
+        linear-leaf models.
+
+        Standardizing per feature over the training distribution makes the linear
+        ridge penalty scale-fair across features. Non-numeric (target-encoded)
+        columns get zeros, since they are never used as linear terms; the
+        NaN/missing bin keeps NaN, treated downstream as 0 = the mean.
+        """
         n_features = Xb.shape[0]
         max_bins = int(n_bins.max()) if len(n_bins) else 1
         centers_std = np.zeros((n_features, max_bins))
         is_num = self.prep_.is_numeric_binned_
         bc = self.prep_.binner_.bin_centers_
+
         for f in range(n_features):
             if not is_num[f]:
                 continue
+
             c = bc[f]
             per_sample = c[Xb[f]]
             finite = per_sample[np.isfinite(per_sample)]
             if finite.size == 0:
                 continue
+
             mu = float(finite.mean())
             sd = float(finite.std())
             if sd <= 0.0:
                 sd = 1.0
             centers_std[f, :c.shape[0]] = (c - mu) / sd
+
         return centers_std
 
     def _feature_mask(self, n_cols, rng):
         """0/1 mask selecting a random subset of columns for one tree."""
         if self.colsample >= 1.0:
             return None
+
         k = max(1, int(round(self.colsample * n_cols)))
         mask = np.zeros(n_cols, dtype=np.int64)
         mask[rng.choice(n_cols, size=k, replace=False)] = 1
@@ -326,14 +364,17 @@ class _BaseBooster:
             return self._fit_impl(X, y, *args, **kwargs)
 
     def _val_score(self, yv, Fv, wv):
-        """One entry of the validation series (early stopping and the sklearn
-        layer's selections take the min of this). Default: the training loss
-        on raw scores. With a custom ``eval_metric``, the metric on transformed
-        predictions instead — negated when the metric declares
-        ``greater_is_better = True`` so the lower-is-better machinery is
-        untouched (``valid_history_`` then holds the negated values)."""
+        """One entry of the validation series; early stopping and the sklearn
+        layer's selections take the min of it.
+
+        Default is the training loss on raw scores. A custom ``eval_metric``
+        scores transformed predictions instead, negated when the metric declares
+        ``greater_is_better = True`` so the lower-is-better machinery stays
+        untouched (``valid_history_`` then holds the negated values).
+        """
         if self.eval_metric is None:
             return self.loss_.eval(yv, Fv, wv)
+
         pred = self.loss_.transform(Fv)
         # Two-arg call when there are no validation weights, so plain
         # ``lambda y, p: ...`` metrics work.
@@ -344,13 +385,16 @@ class _BaseBooster:
 
     def _round_epilogue(self, m, F, y, w, Fv, yv, wv, stopper, callbacks,
                         cb_train_loss, advance_fv):
-        """Per-round tail shared by the three boosters: train-history append,
-        eval-set scoring with early stopping, the progress print, and the
-        callback hook. ``advance_fv`` adds the new tree's contribution to
-        ``Fv`` in place; it runs only when there is an eval set, so callers
-        must not precompute it. Returns True when training should stop -- the
-        caller breaks, which keeps the ``for/else`` no-break truncation
-        exactly as before."""
+        """Per-round tail shared by the three boosters: append to the train
+        history, score the eval set and check early stopping, print progress,
+        run the callbacks.
+
+        ``advance_fv`` adds the new tree's contribution to ``Fv`` in place. It
+        runs only when there is an eval set, so callers must not precompute it.
+
+        Returns True when training should stop. The caller breaks, which keeps
+        the ``for/else`` no-break truncation exactly as it was.
+        """
         if self.verbose:
             self.train_history_.append(self.loss_.eval(y, F, w))
 
@@ -380,15 +424,17 @@ class _BaseBooster:
 
     def predict_raw(self, X, cat_ctx=None):
         """Predict under this model's thread limit (restored on exit).
+
         ``cat_ctx`` (internal) shares categorical factorizations across the
-        members of a bagged ensemble -- see CatTransformCache."""
+        members of a bagged ensemble -- see CatTransformCache.
+        """
         with _thread_limit(self.thread_count):
             return self._predict_raw_impl(X, cat_ctx)
 
     def __getstate__(self):
-        """Pickle without the lazily-built packed-forest caches: they are
-        redundant with ``trees_`` (roughly doubling the payload) and are
-        rebuilt on the first predict after load."""
+        """Pickle without the lazily-built packed-forest caches. They are
+        redundant with ``trees_`` (roughly doubling the payload) and are rebuilt
+        on the first predict after load."""
         state = self.__dict__.copy()
         for cache in ("_forest_", "_forests_"):
             if cache in state:
@@ -398,24 +444,26 @@ class _BaseBooster:
     def _prep_matrices(self, X, encode_targets, cat_features, eval_set,
                        prep_cache, sample_weight=None):
         """Fit ``self.prep_`` and return the feature-major binned train/eval
-        matrices ``(Xb, Xvb)`` (``Xvb`` is None without an eval set).
-        ``sample_weight`` (mean-1 normalized train weights, ``None`` == uniform)
-        is forwarded to the encoder/binner so zero-weight rows shape neither.
-        ``encode_targets`` is the list of TS-encoding targets: ``[y]`` for the
-        scalar booster, the K one-hot columns for multiclass.
+        matrices ``(Xb, Xvb)``; ``Xvb`` is None without an eval set.
 
-        ``prep_cache`` (internal) is a dict shared across the booster fits of
-        one sklearn-level fit -- the selection auditions, the cross-augmented
-        candidate, and the winner refit -- which all see identical
-        ``(X, y, cat_features, eval_set)`` and identical prep parameters
-        except ``cross_pairs``. Entries are keyed by ``cross_pairs``: a
-        repeat fit reuses the cached preprocessor and matrices outright, and
-        the cross-augmented fit builds on the no-cross base entry, computing
-        only the cross columns (``FeaturePreprocessor.from_base_with_cross``;
-        bit-identical either way because every prep artifact is per-column).
-        Callers that cannot guarantee identical inputs must pass None.
+        ``encode_targets`` is the list of TS-encoding targets: ``[y]`` for the
+        scalar booster, the K one-hot columns for multiclass. ``sample_weight``
+        (mean-1 normalized train weights, ``None`` == uniform) is forwarded to
+        the encoder and binner so zero-weight rows shape neither.
+
+        ``prep_cache`` (internal) is a dict shared across the booster fits of one
+        sklearn-level fit -- the selection auditions, the cross-augmented
+        candidate, the winner refit. They all see the same
+        ``(X, y, cat_features, eval_set)`` and the same prep parameters except
+        ``cross_pairs``, which is the cache key. A repeat fit reuses the cached
+        preprocessor and matrices outright; the cross-augmented fit builds on the
+        no-cross base entry and computes only the cross columns
+        (``FeaturePreprocessor.from_base_with_cross``). Bit-identical either way,
+        because every prep artifact is per-column. Callers that cannot guarantee
+        identical inputs must pass None.
         """
         key = tuple(self.cross_pairs) if self.cross_pairs else ()
+
         if prep_cache is not None and key in prep_cache:
             self.prep_, Xb, Xvb = prep_cache[key]
             if eval_set is not None and Xvb is None:
@@ -424,16 +472,19 @@ class _BaseBooster:
             return Xb, Xvb
 
         base = prep_cache.get(()) if (prep_cache is not None and key) else None
+
         if base is not None:
             base_prep, base_Xb, base_Xvb = base
             self.prep_, cross_binner, crossb = \
                 FeaturePreprocessor.from_base_with_cross(
                     base_prep, list(self.cross_pairs), X, sample_weight)
             nb = len(self.prep_.num_features_)
+
             # Stacked column order is [numeric | cross | TS]; splice the new
             # cross rows into the feature-major base matrix (concatenate
             # returns a fresh C-contiguous array, as the kernels require).
             Xb = np.concatenate([base_Xb[:nb], crossb.T, base_Xb[nb:]], axis=0)
+
             Xvb = None
             if eval_set is not None:
                 Xv = as_model_array(eval_set[0], bool(cat_features))
@@ -446,14 +497,17 @@ class _BaseBooster:
                     Xvb = np.ascontiguousarray(self.prep_.transform(Xv).T)
         else:
             self.prep_ = self._new_preprocessor()
+
             # Tree kernels consume a feature-major matrix; transpose once here.
             Xb = np.ascontiguousarray(
                 self.prep_.fit_transform(
                     X, encode_targets, cat_features, sample_weight).T)
+
             Xvb = None
             if eval_set is not None:
                 Xv = as_model_array(eval_set[0], bool(cat_features))
                 Xvb = np.ascontiguousarray(self.prep_.transform(Xv).T)
+
         if prep_cache is not None:
             prep_cache[key] = (self.prep_, Xb, Xvb)
         return Xb, Xvb
@@ -461,27 +515,32 @@ class _BaseBooster:
     @staticmethod
     def _normalize_weights(sample_weight, n_samples):
         """Scale weights to mean 1 so the gradient magnitude matches the
-        unweighted case. None passes through unchanged. Uniform weights collapse
-        to None so the whole fit takes the exact unweighted path (see
-        ``_uniform_to_none``)."""
+        unweighted case.
+
+        None passes through unchanged. Uniform weights collapse to None so the
+        whole fit takes the exact unweighted path (see ``_uniform_to_none``).
+        """
         if sample_weight is None:
             return None
+
         w = np.asarray(sample_weight, dtype=np.float64)
         return _uniform_to_none(w * (n_samples / w.sum()))
 
     def _resolve_lr(self, eval_set, n_train=None):
         """Resolve the learning rate once per fit.
 
-        ``n_train`` is the row count this booster actually trains on (after any
-        early-stopping split the estimator layer took), and is only consulted
-        when ``adaptive_learning_rate`` is on. Resolving once matters: the
-        full-data refit pins ``winner.lr_`` (see
+        ``n_train`` is the row count this booster actually trains on, after any
+        early-stopping split the estimator layer took. It is consulted only when
+        ``adaptive_learning_rate`` is on.
+
+        Resolving once matters: the full-data refit pins ``winner.lr_`` (see
         ``sklearn_api._refit_on_full``), so the rate that chose the round budget
         is the rate the refit replays at, and the fade cannot drift between the
         two fits just because the refit sees more rows.
         """
         if self.learning_rate is not None:
             return float(self.learning_rate)
+
         es = self.early_stopping_rounds is not None and eval_set is not None
         return _auto_learning_rate(self.n_estimators, es, n_train=n_train,
                                    adaptive=self.adaptive_learning_rate)
@@ -489,53 +548,63 @@ class _BaseBooster:
     def _loo_update(self, tree, leaf, g, h):
         """Leave-one-out leaf step: each row's training update uses its leaf's
         grad/hess totals with its own contribution removed, which curbs the
-        self-reinforcement of plain boosting. ``tree.values`` keeps the standard
-        Newton values for inference; only the training scores use this. Rows
-        subsampled out (g=h=0) reduce to the standard leaf value. `leaf` is the
-        training assignment returned by build_oblivious_tree."""
+        self-reinforcement of plain boosting.
+
+        ``tree.values`` keeps the standard Newton values for inference; only the
+        training scores use this. Rows subsampled out (g=h=0) reduce to the
+        standard leaf value. `leaf` is the training assignment returned by
+        build_oblivious_tree.
+        """
         return _loo_leaf_step(leaf, g, h, tree.values.shape[0],
                               self.l2_leaf_reg, self.lr_)
 
     def _refine_leaf_values(self, tree, leaf, F, y, w):
         """Apply ``leaf_estimation_iterations - 1`` extra Newton steps to a
         tree's leaf values, recomputing grad/hess at the updated residuals after
-        each step. Mutates ``tree.values`` in place. A no-op when
-        ``leaf_estimation_iterations == 1``."""
+        each step.
+
+        Mutates ``tree.values`` in place. A no-op when
+        ``leaf_estimation_iterations == 1``.
+        """
         for _ in range(self.leaf_estimation_iterations - 1):
             F_tmp = F + tree.values[leaf]
             g2, h2 = self.loss_.grad_hess(y, F_tmp)
             if w is not None:
                 g2, h2 = g2 * w, h2 * w
+
             n_lv = tree.values.shape[0]
             tree.values += _leaf_values(leaf, g2, h2, n_lv,
                                         self.l2_leaf_reg, self.lr_)
 
     def _mvs_threshold(self, abs_g, target):
-        """MVS: find threshold λ s.t. sum(min(|g_i|/λ, 1)) = target.
+        """MVS: find the threshold λ where sum(min(|g_i|/λ, 1)) == target.
 
-        Sort once, then hand the cutoff search to `_mvs_lambda_scan`, which
-        fuses the prefix/suffix/argmax pass into one early-exiting loop.
-        Returns λ=0 to signal "use uniform fallback" (degenerate cases).
+        Sort once, then hand the cutoff search to `_mvs_lambda_scan`, which fuses
+        the prefix/suffix/argmax pass into one early-exiting loop. Returns λ=0 to
+        signal "use the uniform fallback" on degenerate input.
 
         The sort and its sum stay here in numpy deliberately: they are the two
-        pairwise-summed operations in this path, and porting them would move λ
-        in the last ulp -- see `_mvs_lambda_scan`'s docstring.
+        pairwise-summed operations in this path, and porting them would move λ in
+        the last ulp -- see `_mvs_lambda_scan`'s docstring.
         """
         n = len(abs_g)
         if target >= n:
             return 0.0
+
         sorted_g = np.sort(abs_g)[::-1]  # descending
         total = sorted_g.sum()
         if total < 1e-12:
             return 0.0
+
         return _mvs_lambda_scan(sorted_g, total, target)
 
     def _mvs_weights_for(self, grad, prob_src, lam):
-        """The shared 1/p weight vector both MVS callers build: importance
+        """The shared 1/p weight vector both MVS callers build: an importance
         weight where the row survives its draw, 0 where it does not.
 
-        `prob_src` is the booster's `rng.random(n)` draw. It is made by the
-        caller so the Generator stream keeps its golden-frozen position."""
+        `prob_src` is the booster's `rng.random(n)` draw. The caller makes it so
+        the Generator stream keeps its golden-frozen position.
+        """
         max_w = 1.0 / max(self.subsample, 1e-3)
         kernel = (_mvs_weights_serial if grad.shape[0] < _SMALL_N
                   else _mvs_weights)
@@ -545,42 +614,51 @@ class _BaseBooster:
         """MVS (Minimum Variance Sampling): gradient-weighted row subsampling.
 
         Rows with larger |grad| are sampled with higher probability and
-        reweighted by 1/p to keep the leaf gradient sum unbiased. Reduces
-        tree-to-tree correlation while concentrating capacity on uncertain
+        reweighted by 1/p to keep the leaf gradient sum unbiased. That reduces
+        tree-to-tree correlation while concentrating capacity on the uncertain
         samples — CatBoost's approach. Falls back to uniform when subsample=1.
         """
         if self.subsample >= 1.0:
             return grad, hess
+
         n = grad.shape[0]
         target = self.subsample * n
         abs_g = np.abs(grad)
         lam = self._mvs_threshold(abs_g, target)
+
         if lam == 0.0:
-            # degenerate or all rows selected: uniform fallback
+            # Degenerate, or every row selected: uniform fallback.
             mask = rng.random(n) < self.subsample
             return np.where(mask, grad, 0.0), np.where(mask, hess, 0.0)
-        # importance weight = 1/p; capped at 1/subsample to avoid blowup on
-        # near-zero-gradient rows (whose effective contribution g_i/p_i = λ)
+
+        # Importance weight 1/p, capped at 1/subsample so near-zero-gradient
+        # rows cannot blow up (their effective contribution g_i/p_i is λ).
         w = self._mvs_weights_for(grad, rng.random(n), lam)
         return grad * w, hess * w
 
     def _mvs_row_weights(self, grad, rng):
         """Per-row MVS weights (1/p importance weights, 0 = dropped), or None
-        when subsample >= 1. The vector-leaf multiclass round derives ONE
-        row selection from its sketched gradient and applies it to the
-        sketch AND the per-class grad/hess (leaf values must see the same
-        rows the split search saw). Shares the threshold and the 1/p weight
-        vector with `_maybe_subsample`; the scalar path differs only in
-        applying that vector to grad/hess itself."""
+        when subsample >= 1.
+
+        The vector-leaf multiclass round derives ONE row selection from its
+        sketched gradient and applies it to the sketch AND to the per-class
+        grad/hess, because the leaf values must see the same rows the split
+        search saw. Shares the threshold and the 1/p weight vector with
+        `_maybe_subsample`; the scalar path differs only in applying that vector
+        to grad/hess itself.
+        """
         if self.subsample >= 1.0:
             return None
+
         n = grad.shape[0]
         target = self.subsample * n
         abs_g = np.abs(grad)
         lam = self._mvs_threshold(abs_g, target)
+
         if lam == 0.0:
-            # degenerate or all rows selected: uniform fallback
+            # Degenerate, or every row selected: uniform fallback.
             return (rng.random(n) < self.subsample).astype(np.float64)
+
         return self._mvs_weights_for(grad, rng.random(n), lam)
 
     @property
@@ -590,22 +668,26 @@ class _BaseBooster:
         Computed lazily from the RETAINED trees, so trees discarded by early
         stopping (built past the best iteration, then truncated) contribute
         nothing. The old running accumulator counted them -- with patience 50,
-        up to 50 dead trees' gains skewed the ranking."""
+        up to 50 dead trees' gains skewed the ranking.
+        """
         feats, gains = [], []
         for item in self.trees_:
-            # scalar booster stores trees; multiclass stores rounds of K trees
+            # The scalar booster stores trees; multiclass stores rounds of K.
             for tree in (item if isinstance(item, list) else (item,)):
                 feats.append(tree.splits_feat)
                 gains.append(tree.gains)
+
         if not feats:
             return np.zeros(self.prep_.n_input_features_)
-        # One bincount over every split in iteration order: its sequential C
-        # accumulation reproduces the old per-split Python loop's addition
-        # order exactly, at none of its interpreter cost.
+
+        # One bincount over every split in iteration order. Its sequential C
+        # accumulation reproduces the old per-split Python loop's addition order
+        # exactly, at none of the interpreter cost.
         fmap = self.prep_.feature_map_
         imp = np.bincount(fmap[np.concatenate(feats)],
                           weights=np.concatenate(gains),
                           minlength=self.prep_.n_input_features_)
+
         s = imp.sum()
         return imp / s if s > 0 else imp
 
@@ -620,13 +702,16 @@ class GradientBoosting(_BaseBooster):
 
     def _fit_impl(self, X, y, cat_features=None, eval_set=None,
                   sample_weight=None, callbacks=None, prep_cache=None):
-        """Fit the additive model. Optionally pass `cat_features` (column indices
-        to target-encode) and `eval_set=(X_val, y_val)` for early stopping.
-        `sample_weight` is a 1-D array of per-sample weights; None means uniform.
-        Weights are normalized to mean 1 internally so the gradient scale stays
-        comparable to the no-weight case. `prep_cache` is internal -- see
-        `_prep_matrices`. (Called via the base ``fit``, which owns the thread
-        limit.)"""
+        """Fit the additive model.
+
+        `cat_features` is the column indices to target-encode; `eval_set` is
+        ``(X_val, y_val)`` for early stopping. `sample_weight` is a 1-D array of
+        per-sample weights, None meaning uniform; weights are normalized to mean
+        1 internally so the gradient scale stays comparable to the no-weight
+        case. `prep_cache` is internal -- see `_prep_matrices`.
+
+        Called via the base ``fit``, which owns the thread limit.
+        """
         X = as_model_array(X, bool(cat_features))
         y = np.asarray(y, dtype=np.float64)
         n_samples = X.shape[0]
@@ -641,30 +726,32 @@ class GradientBoosting(_BaseBooster):
         donor_trees = None
         if self.replay_donor is not None:
             donor_trees, donor_prep = self.replay_donor
+
             # Drop the reference once consumed: the donor holds a whole forest,
             # and this booster is the one that gets pickled.
             self.replay_donor = None
-            # Refit every data-dependent statistic on these rows exactly as a
+
+            # Refit every data-dependent statistic on these rows as a
             # from-scratch refit would -- categories, gdiff group means, ordered
             # target statistics -- but ADOPT THE DONOR'S BINNER, because the
             # replayed split thresholds are bin indices into its borders.
             #
-            # The donor's `transform` would be wrong here, not merely
-            # approximate: it applies the INFERENCE-time target statistics, in
-            # which a category's mean includes the label of the very row being
-            # encoded. On the training matrix that is straight target leakage
-            # (caught by tests/test_chimeraboost.py::test_ordered_ts_resists_
-            # leakage, where it handed a pure-noise 2500-level column 54% of the
-            # model's importance). Ordered TS exists precisely to prevent it.
+            # Never reach for the donor's `transform` here. It applies the
+            # INFERENCE-time target statistics, where a category's mean includes
+            # the label of the very row being encoded -- straight target leakage
+            # on a training matrix. tests/test_chimeraboost.py::
+            # test_ordered_ts_resists_leakage caught it handing a pure-noise
+            # 2500-level column 54% of the model's importance. Ordered TS exists
+            # precisely to prevent that.
             #
-            # `cat_combinations` is pinned to what the donor actually built
-            # rather than re-resolved at the new row count: it decides how many
-            # TS columns exist, and the transferred splits address columns by
-            # position.
+            # `cat_combinations` is pinned to what the donor built rather than
+            # re-resolved at the new row count: it decides how many TS columns
+            # exist, and the transferred splits address columns by position.
             self.prep_ = FeaturePreprocessor(
                 self.max_bins, self.cat_smoothing, self.random_state,
                 self.cat_n_permutations, bool(donor_prep.combo_pairs_),
                 self.cross_pairs)
+
             Xb = np.ascontiguousarray(
                 self.prep_.fit_transform(X, [y], cat_features, w,
                                          binner=donor_prep.binner_).T)
@@ -674,13 +761,16 @@ class GradientBoosting(_BaseBooster):
         else:
             Xb, Xvb = self._prep_matrices(X, [y], cat_features, eval_set,
                                           prep_cache, w)
+
         n_bins = self.prep_.n_bins_
         hist_buffers = self._alloc_hist_buffers(Xb.shape[0], n_bins)
+
         # Packed quantized grad/hess scratch, reused across trees (see
         # build_oblivious_tree's quantize path).
         qbuf = (np.empty(n_samples, dtype=np.int64)
                 if self.quantize_gradients else None)
-        # Keep a small sample of the (binned) training rows as the default SHAP
+
+        # Keep a small sample of the binned training rows as the default SHAP
         # background -- the reference distribution interventional TreeSHAP
         # integrates over. Capped so it never bloats the pickled model.
         bg_n = min(n_samples, SHAP_BACKGROUND_SIZE)
@@ -691,6 +781,7 @@ class GradientBoosting(_BaseBooster):
         yv = Fv = wv = None
         if eval_set is not None:
             yv = np.asarray(eval_set[1], dtype=np.float64)
+
             # eval_set may carry per-row validation weights as a 3rd element
             # (auto-split / OOB folds); uniform or absent -> unweighted metric.
             if len(eval_set) > 2:
@@ -702,14 +793,16 @@ class GradientBoosting(_BaseBooster):
             Fv = np.full(len(yv), self.init_)
 
         adjusts_leaves = getattr(self.loss_, "adjusts_leaves", False)
-        # Linear leaves are incompatible with the median/quantile leaf override
-        # (adjusts_leaves) and with ordered boosting (a linear LOO step is not
-        # implemented); they take over the leaf value otherwise. Below
+
+        # Linear leaves take over the leaf value, so they are incompatible with
+        # the median/quantile leaf override (adjusts_leaves) and with ordered
+        # boosting (no linear LOO step is implemented). Below
         # LINEAR_LEAVES_MIN_SAMPLES rows they overfit, so fall back to constant.
         ll_active = (self.linear_leaves and not adjusts_leaves
                      and n_samples >= LINEAR_LEAVES_MIN_SAMPLES)
         self._centers_std_ = (self._build_centers_std(Xb, n_bins)
                               if ll_active else None)
+
         rng = np.random.default_rng(self.random_state)
         self.trees_ = []
         self._forest_ = None   # packed-forest cache; built lazily on predict
@@ -722,13 +815,16 @@ class GradientBoosting(_BaseBooster):
             grad, hess = self.loss_.grad_hess(y, F)
             if w is not None:
                 grad, hess = grad * w, hess * w
+
             g, h = self._maybe_subsample(grad, hess, rng)
             fmask = self._feature_mask(Xb.shape[0], rng)
-            # Fresh rounding seed per tree: decorrelates the stochastic
-            # rounding noise across boosting rounds (drawn only on the
-            # quantized path, so the float path's rng stream is unchanged).
+
+            # Fresh rounding seed per tree: decorrelates the stochastic rounding
+            # noise across boosting rounds. Drawn only on the quantized path, so
+            # the float path's rng stream is unchanged.
             qseed = (int(rng.integers(1 << 63))
                      if self.quantize_gradients else 0)
+
             if donor_trees is not None and m < len(donor_trees):
                 # Replay round: structure fixed, leaf values (and linear-leaf
                 # coefficients) refit against this round's full-data gradients.
@@ -749,53 +845,60 @@ class GradientBoosting(_BaseBooster):
                     linear_lambda=self.linear_lambda,
                     quantize=self.quantize_gradients,
                     qbuf=qbuf, qseed=qseed)
-            # A depth-0 tree found no legal split; the next round on the same
-            # gradients would too, so stop rather than bank empty trees. Keep
-            # the best prefix exactly as the other exits do -- without this,
-            # trees grown after the validation optimum survived on this path.
+
+            # A depth-0 tree found no legal split, and the next round on the
+            # same gradients would find none either, so stop rather than bank
+            # empty trees. Truncate like the other exits do: without this,
+            # trees grown after the validation optimum survived here.
             if tree.depth == 0:
                 if Fv is not None and stopper.patience:
                     self.trees_ = self.trees_[: stopper.best_iter + 1]
                 break
+
             if adjusts_leaves:
                 self._correct_leaves(tree, leaf, y, F, w)
             self.trees_.append(tree)
-            # Ordered boosting and leaf adjustment are mutually exclusive: the
-            # former rewrites the training step, the latter the leaf value.
+
+            # Exactly one of the three training updates below runs. Ordered
+            # boosting and leaf adjustment are mutually exclusive: the former
+            # rewrites the training step, the latter the leaf value.
             if ll_active and tree.lin_coef is not None:
-                # Linear-leaf path: training update is the leaf's local linear
-                # model (no ordered boosting / no leaf_estimation refinement).
+                # The step is the leaf's own local linear model: no ordered
+                # boosting, no leaf-estimation refinement.
                 F += _linear_predict(leaf, tree.lin_feats, tree.lin_coef,
                                      self._centers_std_, Xb)
             elif self.ordered_boosting and not adjusts_leaves:
-                # Ordered boosting owns the training step (leaf-estimation Newton
-                # refinement is for the plain path only).
+                # Ordered boosting owns the training step; leaf-estimation
+                # Newton refinement belongs to the plain path only.
                 F += self._loo_update(tree, leaf, g, h)
             else:
-                # Additional Newton steps refine the leaf values using the updated
-                # residuals after each step. For constant-hessian losses (RMSE)
-                # this converges in a few steps; for Logloss it reaches a better
-                # per-leaf approximation than the single first-order step. Not
-                # for MAE/Quantile: _correct_leaves already set the exact
+                # Extra Newton steps refine the leaf values against residuals
+                # recomputed after each step. Constant-hessian losses (RMSE)
+                # converge in a few; Logloss reaches a better per-leaf
+                # approximation than the single first-order step.
+                #
+                # Never for MAE/Quantile: _correct_leaves already set the exact
                 # minimizer (median/quantile), and a sign-gradient Newton step
-                # on top would corrupt it -- the sklearn layer's "no effect"
+                # on top would corrupt it. The sklearn layer's "no effect"
                 # warning for those losses is honest only with this guard.
                 if not adjusts_leaves:
                     self._refine_leaf_values(tree, leaf, F, y, w)
+
                 # Fused in-place add: F += tree.values[leaf] without the
                 # n-length gather temporary. The (n, 1) views are C-contiguous,
                 # so this reuses the vector boosters' compiled signature.
                 _add_leaf_values(F.reshape(-1, 1), tree.values.reshape(-1, 1),
                                  leaf)
+
             if self._round_epilogue(
                     m, F, y, w, Fv, yv, wv, stopper, callbacks, cb_train_loss,
                     lambda: _eval_advance(Fv, tree, Xvb)):
                 break
         else:
-            # No break: the tree budget ran out before patience could fire.
-            # Keep the best prefix exactly as the mid-training stop would
-            # have. Callback stops are excluded on purpose -- the selection
-            # auditions read feature_importances_ off callback-capped fits.
+            # No break: the tree budget ran out before patience could fire, so
+            # truncate as a mid-training stop would. Callback stops are excluded
+            # on purpose -- the selection auditions read feature_importances_
+            # off callback-capped fits.
             if Fv is not None and stopper.patience:
                 self.trees_ = self.trees_[: stopper.best_iter + 1]
 
@@ -805,26 +908,30 @@ class GradientBoosting(_BaseBooster):
 
     def _correct_leaves(self, tree, leaf, y, F, sample_weight=None):
         """Override Newton leaf values with the loss-appropriate residual
-        statistic (median for MAE, alpha-quantile for Quantile). The tree
-        structure was chosen by the gradient; this fixes the step size.
+        statistic: the median for MAE, the alpha-quantile for Quantile.
+
+        The tree structure was chosen by the gradient; this fixes the step size.
         `leaf` is the training assignment from build_oblivious_tree.
 
-        The library losses dispatch to the multi-quantile head's compiled
-        leaf kernels with K=1: one parallel quickselect pass replaces a
-        per-round stable argsort plus a Python-level np.quantile per leaf.
-        The values are exactly unchanged -- `_quantile_slice` matches
-        np.quantile bit for bit, `_weighted_quantile_slice` reproduces
-        `losses._weighted_quantile`, `_leaf_row_index` groups rows in the
-        same ascending order the argsort did (all three pinned by
-        tests/test_quantile_head.py and the scalar oracle in
-        tests/test_bitident_refactors.py). Custom adjusts-leaves losses keep
-        the generic path below."""
+        The library losses dispatch to the multi-quantile head's compiled leaf
+        kernels with K=1, so one parallel quickselect pass replaces a per-round
+        stable argsort plus a Python-level np.quantile per leaf. The values are
+        exactly unchanged: `_quantile_slice` matches np.quantile bit for bit,
+        `_weighted_quantile_slice` reproduces `losses._weighted_quantile`, and
+        `_leaf_row_index` groups rows in the same ascending order the argsort
+        did. tests/test_quantile_head.py and the scalar oracle in
+        tests/test_bitident_refactors.py pin all three.
+
+        Custom adjusts-leaves losses keep the generic path below.
+        """
         n_leaves = tree.values.shape[0]
+
         if type(self.loss_) in (MAE, Quantile):
             alpha = 0.5 if type(self.loss_) is MAE else self.loss_.alpha
             taus = np.array([alpha])
             F2 = F[:, None]        # (n, 1) view of contiguous F: C-contiguous
             small = leaf.shape[0] <= _SMALL_N
+
             if sample_weight is None:
                 kern = (_leaf_quantiles_vec_serial if small
                         else _leaf_quantiles_vec)
@@ -834,14 +941,17 @@ class GradientBoosting(_BaseBooster):
                         else _leaf_quantiles_vec_w)
                 vals = kern(leaf, y, F2, sample_weight, taus, n_leaves,
                             self.lr_)
+
             tree.values = vals[:, 0]
             return
+
         residuals = y - F
         order = np.argsort(leaf, kind="stable")
         counts = np.bincount(leaf, minlength=n_leaves)
         stop = np.cumsum(counts)
         r_sorted = residuals[order]
         w_sorted = sample_weight[order] if sample_weight is not None else None
+
         for l in range(n_leaves):
             lo, hi = stop[l] - counts[l], stop[l]
             w = w_sorted[lo:hi] if w_sorted is not None else None
@@ -851,27 +961,33 @@ class GradientBoosting(_BaseBooster):
         """Return raw additive scores (pre-link): the regression prediction, or
         the log-odds for binary classification."""
         X = as_model_array(X, bool(self.prep_.cat_features_))
+
         # The fused predict kernels consume the binner's row-major output
-        # directly (no feature-major transpose; each sample's bins stay in
-        # one or two cache lines for the whole forest walk).
+        # directly. No feature-major transpose, and each sample's bins stay in
+        # one or two cache lines for the whole forest walk.
         Xb = self.prep_.transform(X, cat_ctx)
         if not self.trees_:
             return np.full(Xb.shape[0], self.init_, dtype=np.float64)
-        # Tiny batches take the serial kernel twins: the OpenMP fork/join
-        # costs more than the whole walk there (both sides bit-identical).
+
+        # Tiny batches take the serial kernel twins: the OpenMP fork/join costs
+        # more than the whole walk there. Both sides are bit-identical.
         small = Xb.shape[0] <= _SERIAL_PREDICT_N
+
         if getattr(self, "_centers_std_", None) is not None:
             # Linear-leaf path: a dedicated fused kernel walks the whole forest
             # in one parallel pass (constant trees ride along as k=0).
             if self._forest_ is None:
                 self._forest_ = pack_forest_linear(self.trees_, self.depth)
+
             feats, thrs, depths, lin_k, foff, lidx, coff, coef = self._forest_
             kernel = (_predict_forest_linear_rm_serial if small
                       else _predict_forest_linear_rm)
             return kernel(Xb, feats, thrs, depths, lin_k, foff, lidx, coff,
                           coef, self._centers_std_, self.init_)
+
         if self._forest_ is None:
             self._forest_ = pack_forest(self.trees_, self.depth)
+
         feats, thrs, depths, vals, voff = self._forest_
         kernel = _predict_forest_rm_serial if small else _predict_forest_rm
         return kernel(Xb, feats, thrs, depths, vals, voff, self.init_)
@@ -889,35 +1005,40 @@ class GradientBoosting(_BaseBooster):
                     random_state=0):
         """Exact interventional TreeSHAP, in raw-score (margin) space.
 
-        Returns ``(phi, expected_value)`` where ``phi`` has shape
-        ``(n_samples, n_input_features)`` and, for every row,
+        Returns ``(phi, expected_value)``. ``phi`` has shape
+        ``(n_samples, n_input_features)``, and for every row
         ``phi.sum(axis=1) + expected_value == predict_raw(X)`` to floating-point
         tolerance (Shapley efficiency). Each ``phi[i, f]`` is feature f's signed
-        additive contribution to the raw score of row i -- the regression target,
-        or the binary log-odds. Linear-leaf slope terms are included exactly.
+        additive contribution to row i's raw score -- the regression target, or
+        the binary log-odds. Linear-leaf slope terms are included exactly.
 
-        ``background`` is the reference distribution SHAP integrates over
-        (defaults to the training-data sample captured at fit); ``max_background``
-        subsamples it for speed (cost is linear in the background size)."""
+        ``background`` is the reference distribution SHAP integrates over,
+        defaulting to the training-data sample captured at fit.
+        ``max_background`` subsamples it for speed; cost is linear in the
+        background size.
+        """
         X = as_model_array(X, bool(self.prep_.cat_features_))
         Xb = np.ascontiguousarray(self.prep_.transform(X).T)
         n_orig = self.prep_.n_input_features_
         if not self.trees_:
             return np.zeros((Xb.shape[1], n_orig)), float(self.init_)
+
         if background is None:
             Rb = self._shap_background_
         else:
             bg = as_model_array(background, bool(self.prep_.cat_features_))
             Rb = np.ascontiguousarray(self.prep_.transform(bg).T)
+
         if Rb.shape[1] > max_background:
             sel = np.random.default_rng(random_state).choice(
                 Rb.shape[1], max_background, replace=False)
             Rb = np.ascontiguousarray(Rb[:, sel])
+
         cs = getattr(self, "_centers_std_", None)
         if cs is not None:
-            # Linear-leaf model: predict caches the same linear-packed forest
-            # in _forest_; build it once and share (constant-leaf models cache
-            # the non-linear pack there instead, so those repack here).
+            # Linear-leaf model: predict caches the same linear-packed forest in
+            # _forest_, so build it once and share. Constant-leaf models cache
+            # the non-linear pack there instead, so those repack here.
             if self._forest_ is None:
                 self._forest_ = pack_forest_linear(self.trees_, self.depth)
             feats, thrs, depths, lin_k, foff, lidx, coff, coef = self._forest_
@@ -925,35 +1046,42 @@ class GradientBoosting(_BaseBooster):
             feats, thrs, depths, lin_k, foff, lidx, coff, coef = \
                 pack_forest_linear(self.trees_, self.depth)
             cs = np.zeros((1, 1))   # unused: every tree is constant (k=0)
+
         fact = _factorials(self.depth)
         phi = _shap_forest_linear(Xb, Rb, feats, thrs, depths, lin_k, foff, lidx,
                                   coff, coef, cs, self.prep_.feature_map_, n_orig,
                                   fact)
         base = _predict_forest_linear(Rb, feats, thrs, depths, lin_k, foff, lidx,
                                       coff, coef, cs, self.init_)
+
         return phi, float(base.mean())
 
 
 class MulticlassBoosting(_BaseBooster):
     """Softmax multiclass booster: one VECTOR-LEAF tree per round.
 
-    Each round grows a single oblivious tree whose leaves hold K-vectors
-    (one Newton value per class) on a shared structure. The split search
-    runs on a 1-d sketch of the K gradient columns — a fresh Rademacher
-    (±1) projection per round (benchmarks/A1_PLAN.md; SketchBoost's Random
-    Projections, k=1): g_i = Σ_k r_k·grad_ik, and since r_k² = 1 the
-    projected curvature rᵀdiag(H_i)r is exactly the row hessian sum, so
-    (g, h) is a principled scalar Newton pair and the scalar split kernels
-    (quantized path included) are reused verbatim. Models fitted before
-    0.25.0 stored K trees per round (one per class); `predict_raw` keeps a
-    fallback for those unpickled forests."""
+    Each round grows a single oblivious tree whose leaves hold K-vectors, one
+    Newton value per class, on a shared structure.
+
+    The split search runs on a 1-d sketch of the K gradient columns: a fresh
+    Rademacher (±1) projection per round, g_i = Σ_k r_k·grad_ik (see
+    benchmarks/A1_PLAN.md; SketchBoost's Random Projections, k=1). Since
+    r_k² = 1, the projected curvature rᵀdiag(H_i)r is exactly the row hessian
+    sum, so (g, h) is a principled scalar Newton pair and the scalar split
+    kernels are reused verbatim, quantized path included.
+
+    Models fitted before 0.25.0 stored K trees per round (one per class);
+    `predict_raw` keeps a fallback for those unpickled forests.
+    """
 
     def _fit_impl(self, X, y, cat_features=None, eval_set=None,
                   sample_weight=None, callbacks=None, prep_cache=None):
         """Fit one vector-leaf tree per boosting round under softmax loss.
+
         Same `cat_features` / `eval_set` / `sample_weight` semantics as the
         scalar booster; `prep_cache` is internal -- see `_prep_matrices`.
-        (Called via the base ``fit``, which owns the thread limit.)"""
+        Called via the base ``fit``, which owns the thread limit.
+        """
         X = as_model_array(X, bool(cat_features))
         y = np.asarray(y)
         self.classes_ = np.unique(y)
@@ -972,6 +1100,7 @@ class MulticlassBoosting(_BaseBooster):
                                       cat_features, eval_set, prep_cache, w)
         n_bins = self.prep_.n_bins_
         hist_buffers = self._alloc_hist_buffers(Xb.shape[0], n_bins)
+
         # Packed quantized grad/hess scratch, reused across every class tree.
         qbuf = (np.empty(n_samples, dtype=np.int64)
                 if self.quantize_gradients else None)
@@ -1002,16 +1131,19 @@ class MulticlassBoosting(_BaseBooster):
             grad, hess = self.loss_.grad_hess(Y, F)   # (n, K) each
             if w is not None:
                 grad, hess = grad * w[:, None], hess * w[:, None]
-            # 1-d Newton sketch for the split search: fresh CENTERED
-            # Rademacher projection of the gradient columns. Softmax
-            # gradient rows sum to zero, so the all-ones direction is the
-            # null space — an uncentered all-equal draw (prob 2^(1-K)) gives
-            # an identically-zero sketch and a spurious permanent stop
-            # (caught in the A1 smoke; see A1_PLAN.md implementation log).
-            # Centering removes that dead component; the rescale keeps
-            # sum(r^2) = K so the projected-curvature mass stays on the
-            # row-hessian-sum scale every round (min_child_weight and l2
-            # semantics don't wobble with the draw).
+
+            # 1-d Newton sketch for the split search: a fresh CENTERED
+            # Rademacher projection of the gradient columns.
+            #
+            # Softmax gradient rows sum to zero, so the all-ones direction is
+            # the null space. An uncentered all-equal draw (probability
+            # 2^(1-K)) gives an identically-zero sketch and a spurious
+            # permanent stop -- caught in the A1 smoke, see the A1_PLAN.md
+            # implementation log. Centering removes that dead component.
+            #
+            # The rescale keeps sum(r^2) = K, so the projected-curvature mass
+            # stays on the row-hessian-sum scale every round and
+            # min_child_weight and l2 semantics do not wobble with the draw.
             r = rng.integers(0, 2, size=K).astype(np.float64) * 2.0 - 1.0
             r -= r.mean()
             while not np.any(r):        # all-equal draw centered to zero
@@ -1019,9 +1151,11 @@ class MulticlassBoosting(_BaseBooster):
                 r -= r.mean()
             r *= np.sqrt(K / (r @ r))
             g_s = grad @ r
+
             # Exact projected curvature r^T diag(H_i) r, coupled like the
             # per-class path's hessians.
             h_s = (hess @ (r * r)) * coupling
+
             # One MVS row selection per round, derived from the sketch and
             # applied to the per-class matrices too, so the leaf values see
             # exactly the rows (and importance weights) the split search saw.
@@ -1029,6 +1163,7 @@ class MulticlassBoosting(_BaseBooster):
             if mw is not None:
                 g_s, h_s = g_s * mw, h_s * mw
                 grad, hess = grad * mw[:, None], hess * mw[:, None]
+
             fmask = self._feature_mask(Xb.shape[0], rng)
             qseed = (int(rng.integers(1 << 63))
                      if self.quantize_gradients else 0)
@@ -1039,18 +1174,21 @@ class MulticlassBoosting(_BaseBooster):
                                               hist_buffers=hist_buffers,
                                               quantize=self.quantize_gradients,
                                               qbuf=qbuf, qseed=qseed)
+
             # No legal split on the sketched gradients: stop like the scalar
             # booster, keeping the best prefix exactly as the other exits do.
             if tree.depth == 0:
                 if Fv is not None and stopper.patience:
                     self.trees_ = self.trees_[: stopper.best_iter + 1]
                 break
-            # Replace the sketch's scalar leaf values with the K-vector
-            # Newton values on the shared partition (coupling applied
-            # inside, per element — see _leaf_values_vec).
+
+            # Replace the sketch's scalar leaf values with the K-vector Newton
+            # values on the shared partition. Coupling is applied inside, per
+            # element — see _leaf_values_vec.
             tree.values = _leaf_values_vec(leaf, grad, hess, coupling,
                                            tree.values.shape[0],
                                            self.l2_leaf_reg, self.lr_)
+
             if self.ordered_boosting:
                 # Per-class LOO on the shared leaf assignment.
                 for k in range(K):
@@ -1060,16 +1198,18 @@ class MulticlassBoosting(_BaseBooster):
                         tree.values.shape[0], self.l2_leaf_reg, self.lr_)
             else:
                 _add_leaf_values(F, tree.values, leaf)
+
             self.trees_.append(tree)
+
             if self._round_epilogue(
                     m, F, Y, w, Fv, Yv, wv, stopper, callbacks, cb_train_loss,
                     lambda: _add_leaf_values(Fv, tree.values, tree.apply(Xvb))):
                 break
         else:
-            # No break: the tree budget ran out before patience could fire.
-            # Keep the best prefix exactly as the mid-training stop would
-            # have. Callback stops are excluded on purpose -- the selection
-            # auditions read feature_importances_ off callback-capped fits.
+            # No break: the tree budget ran out before patience could fire, so
+            # truncate as a mid-training stop would. Callback stops are excluded
+            # on purpose -- the selection auditions read feature_importances_
+            # off callback-capped fits.
             if Fv is not None and stopper.patience:
                 self.trees_ = self.trees_[: stopper.best_iter + 1]
 
@@ -1081,16 +1221,20 @@ class MulticlassBoosting(_BaseBooster):
         """Return the (n_samples, n_classes) matrix of raw per-class scores
         (pre-softmax)."""
         X = as_model_array(X, bool(self.prep_.cat_features_))
+
         # Row-major binned matrix straight from the binner (see the scalar
         # predict_raw).
         Xb = self.prep_.transform(X, cat_ctx)
         if not self.trees_:
             return np.tile(self.init_, (Xb.shape[0], 1))
+
         if isinstance(self.trees_[0], list):
             # Pre-0.25.0 pickle: rounds of K per-class trees.
             return self._predict_raw_ktrees(Xb)
+
         if getattr(self, "_forest_", None) is None:
             self._forest_ = pack_forest_vec(self.trees_, self.depth)
+
         feats, thrs, depths, vals, voff, K = self._forest_
         kernel = (_predict_forest_vec_rm_serial
                   if Xb.shape[0] <= _SERIAL_PREDICT_N
@@ -1098,80 +1242,85 @@ class MulticlassBoosting(_BaseBooster):
         return kernel(Xb, feats, thrs, depths, vals, voff, K, self.init_)
 
     def _predict_raw_ktrees(self, Xb):
-        """Legacy predict for models fitted before 0.25.0 (K trees per
-        round): one packed forest per class, K walks over the same rows."""
+        """Legacy predict for models fitted before 0.25.0, which stored K trees
+        per round: one packed forest per class, K walks over the same rows."""
         # Every column is fully overwritten below; no need to tile the init.
         F = np.empty((Xb.shape[0], self.n_classes_), dtype=np.float64)
+
         if getattr(self, "_forests_", None) is None:
             # One packed forest per class: class k's trees are round_trees[k]
             # across every round.
             self._forests_ = [
                 pack_forest([rt[k] for rt in self.trees_], self.depth)
                 for k in range(self.n_classes_)]
+
         kernel = (_predict_forest_rm_serial
                   if Xb.shape[0] <= _SERIAL_PREDICT_N else _predict_forest_rm)
         for k in range(self.n_classes_):
             feats, thrs, depths, vals, voff = self._forests_[k]
             F[:, k] = kernel(Xb, feats, thrs, depths, vals, voff,
                              self.init_[k])
+
         return F
 
 
-# Rows sampled to estimate the gradient covariance for the split direction.
-# The top eigenvector is a direction, not a precise quantity, and it does not
-# need every row; capping keeps the Gram a few percent of round cost on large
-# data instead of growing with n.
+# Rows sampled to estimate the gradient covariance for the split direction. The
+# top eigenvector is a direction, not a precise quantity, so it does not need
+# every row. Capping keeps the Gram at a few percent of round cost on large data
+# instead of growing with n.
 _GRAM_MAX_ROWS = 16384
 
 # Which contrast each round uses under ``split_projection="rotate"``, cycled.
 # Two rounds of location per round of spread: location carries most of the
 # available gain, but a pure location diet is blind to spread entirely.
-# Measured across location-only, spread-only, mixed and extreme
-# heteroscedastic regimes at both K=3 and K=19; this beat uniform cycling,
-# location-only, and every schedule that also spent rounds on skew. See
-# benchmarks/QUANTILE_PLAN.md.
+#
+# Measured across location-only, spread-only, mixed and extreme heteroscedastic
+# regimes at both K=3 and K=19. This beat uniform cycling, location-only, and
+# every schedule that also spent rounds on skew. See benchmarks/QUANTILE_PLAN.md.
 _ROTATE_PATTERN = (0, 0, 1)
 
 
 def _fixed_contrasts(taus, n_basis=2):
-    """Orthonormal split directions for ``split_projection`` of "sum" (the
-    first only) and "rotate" (cycled by `_ROTATE_PATTERN`).
+    """Orthonormal split directions for ``split_projection`` of "sum" (the first
+    only) and "rotate" (cycled by `_ROTATE_PATTERN`).
 
-    Why polynomials in tau. Every row's pinball gradient is
-    ``e(r_i) - taus``, where ``r_i`` is the row's PIT rank -- how many of its
-    own K estimates the target falls above -- and ``e(r)`` is the step vector
-    that turns on at r. A row's whole gradient is therefore one number, so
-    projecting on a direction ``c`` is exactly scoring that rank by
-    ``phi(r) = sum(c[r:])``. Taking c polynomial in tau of degree 0 and 1
-    makes phi degree 1 and 2 in the rank:
+    Why polynomials in tau: every row's pinball gradient is ``e(r_i) - taus``,
+    where ``r_i`` is the row's PIT rank -- how many of its own K estimates the
+    target falls above -- and ``e(r)`` is the step vector that turns on at r. A
+    row's whole gradient is therefore one number, so projecting on a direction
+    ``c`` is exactly scoring that rank by ``phi(r) = sum(c[r:])``. Taking c
+    polynomial in tau of degree 0 and 1 makes phi degree 1 and 2 in the rank:
 
     * degree 1 (c constant) -- location. Finds regions where the whole
-      predictive distribution sits in the wrong place. This is the plain
-      channel sum, and it is the ONLY direction "sum" ever uses.
+      predictive distribution sits in the wrong place. This is the plain channel
+      sum, and it is the ONLY direction "sum" ever uses.
     * degree 2 (c linear) -- spread. Finds regions whose width is wrong, which
       the location contrast cannot see at all: on a symmetric grid the tau and
-      1-tau pushes are equal and opposite, so a correctly-centred but
-      too-narrow region sums to exactly zero.
+      1-tau pushes are equal and opposite, so a correctly-centred but too-narrow
+      region sums to exactly zero.
 
-    A degree-3 (skew) contrast is available by raising ``n_basis`` but is not
-    used by default: across every regime measured it took rounds away from
-    location and spread without paying them back.
+    A degree-3 (skew) contrast is available by raising ``n_basis`` but is off by
+    default: across every regime measured it took rounds away from location and
+    spread without paying them back.
 
     Gram-Schmidt keeps the directions orthonormal on the actual grid (they are
-    already near-orthogonal on a uniform one), and unit norm keeps the
-    projected curvature at exactly 1 per row.
+    already near-orthogonal on a uniform one), and unit norm keeps the projected
+    curvature at exactly 1 per row.
     """
     K = taus.shape[0]
     s = 2.0 * taus - 1.0                       # tau -> [-1, 1]
     raw = [np.ones(K), s, 1.5 * s * s - 0.5]   # Legendre P0, P1, P2
+
     basis = []
     for v in raw[:max(1, n_basis)]:
         v = v.astype(np.float64).copy()
         for b in basis:
             v -= (v @ b) * b
+
         nrm = float(np.sqrt(v @ v))
         if nrm > 1e-9:                # degenerate on very short grids
             basis.append(v / nrm)
+
     return basis
 
 
@@ -1180,21 +1329,24 @@ def _null_whitener(grad, taus):
 
     A row's gradient is ``e(r_i) - taus`` for its PIT rank r, so when the rank
     carries no information about x the covariance is the Brownian-bridge form
-    ``min(p_j, p_k) - p_j p_k`` -- fixed by the realized marginal rates p
-    alone, no fitting involved. Whitening by it is what stops the split
-    direction being chosen by noise: the raw gradient variance in channel k is
-    ``tau_k(1 - tau_k)``, four times larger at the median than at the 5%
-    tail, so the largest-energy direction is the median one whether or not
-    anything about the median depends on x.
+    ``min(p_j, p_k) - p_j p_k`` -- fixed by the realized marginal rates p alone,
+    no fitting involved.
 
-    Estimated from the realized rates rather than from ``taus`` so that a
-    globally miscalibrated model does not leak into the whitener.
+    Whitening by it is what stops noise choosing the split direction. The raw
+    gradient variance in channel k is ``tau_k(1 - tau_k)``, four times larger at
+    the median than at the 5% tail, so the largest-energy direction is the median
+    one whether or not anything about the median depends on x.
+
+    Estimated from the realized rates rather than from ``taus``, so a globally
+    miscalibrated model does not leak into the whitener.
     """
     p = np.clip(grad.mean(axis=0) + taus, 1e-6, 1.0 - 1e-6)
     N = np.minimum(p[:, None], p[None, :]) - np.outer(p, p)
-    # Ridge for a strictly positive-definite factorization; scaled to the
-    # matrix so it is negligible relative to the real structure.
+
+    # Ridge for a strictly positive-definite factorization, scaled to the matrix
+    # so it stays negligible relative to the real structure.
     N += np.eye(p.shape[0]) * (1e-8 * float(np.trace(N)) / p.shape[0] + 1e-300)
+
     try:
         return np.linalg.cholesky(N)
     except np.linalg.LinAlgError:
@@ -1206,17 +1358,16 @@ def _gram_direction(grad, taus, basis, rng):
 
     With unit hessians the exact summed-across-tau split gain is
     ``‖G_L‖²/(n_L+l2) + ‖G_R‖²/(n_R+l2) - ‖G_P‖²/(n_P+l2)``, which by Parseval
-    equals the sum of projected gains over any orthonormal basis. Projecting
-    onto one direction is therefore the rank-1 truncation of the exact gain
-    rather than a different algorithm, and the question is only which
-    direction to keep.
+    equals the sum of projected gains over any orthonormal basis. Projecting onto
+    one direction is therefore the rank-1 truncation of the exact gain, not a
+    different algorithm; the only question is which direction to keep.
 
-    Same subspace "rotate" cycles through -- location, spread, skew (see
-    `_fixed_contrasts`) -- but weighted by what this round's gradients
-    actually show instead of taken in turn. Maximizes ``c'Cc / c'Nc`` over the
-    subspace, C being the centered gradient covariance and N the covariance
-    expected with no x-signal at all (`_null_whitener`). That is a 3x3
-    generalized eigenproblem, solved exactly.
+    This searches the same subspace "rotate" cycles through -- location, spread,
+    skew (see `_fixed_contrasts`) -- but weights it by what this round's
+    gradients show instead of taking each in turn. It maximizes ``c'Cc / c'Nc``
+    over the subspace, C being the centered gradient covariance and N the
+    covariance expected with no x-signal at all (`_null_whitener`). That is a
+    3x3 generalized eigenproblem, solved exactly.
 
     Three corrections separate a useful direction from a useless one, and each
     was measured rather than assumed:
@@ -1224,18 +1375,18 @@ def _gram_direction(grad, taus, basis, rng):
     * Centering. A gradient component shared by every row contributes exactly
       zero gain (``n_L + n_R - n = 0``), so the raw second moment can point
       somewhere no split is able to exploit.
-    * Whitening. Raw energy is dominated by per-row Bernoulli noise, largest
-      at the median; without whitening this collapses onto the location
-      contrast and inherits its blindness to spread.
+    * Whitening. Raw energy is dominated by per-row Bernoulli noise, largest at
+      the median; without whitening this collapses onto the location contrast and
+      inherits its blindness to spread.
     * The subspace. Whitening across all of R^K is ill-conditioned -- the
       Brownian-bridge null has eigenvalues falling like 1/k², so its inverse
       amplifies exactly the high-frequency directions that carry only sampling
-      noise. Restricting to the low-order polynomials keeps the ratio
-      well-posed. Measured: unrestricted whitening was four times worse than
-      cycling on location-driven data.
+      noise. Restricting to the low-order polynomials keeps the ratio well-posed.
+      Measured: unrestricted whitening was four times worse than cycling on
+      location-driven data.
 
-    Returns None on a degenerate covariance, leaving the caller on the
-    location contrast.
+    Returns None on a degenerate covariance, leaving the caller on the location
+    contrast.
     """
     n = grad.shape[0]
     G = grad
@@ -1243,9 +1394,11 @@ def _gram_direction(grad, taus, basis, rng):
         # With replacement: this estimates a direction only, and it avoids the
         # permutation cost of sampling without replacement on large n.
         G = grad[rng.integers(0, n, size=_GRAM_MAX_ROWS)]
+
     L = _null_whitener(G, taus)
     if L is None:
         return None
+
     B = np.stack(basis, axis=1)                  # (K, n_basis), orthonormal
     Gc = G - G.mean(axis=0)
     GB = Gc @ B
@@ -1253,21 +1406,26 @@ def _gram_direction(grad, taus, basis, rng):
     LB = L.T @ B
     Nb = LB.T @ LB                               # B'NB
     Nb += np.eye(Nb.shape[0]) * (1e-12 * float(np.trace(Nb)) + 1e-300)
+
     try:
         M = np.linalg.solve(Nb, Cb)
         vals, vecs = np.linalg.eig(M)
     except np.linalg.LinAlgError:
         return None
+
     w = np.real(vecs[:, int(np.argmax(np.real(vals)))])
     c = B @ w
     nrm = float(np.sqrt(c @ c))
     if nrm < 1e-250:
         return None
+
     c = c / nrm                        # unit norm keeps min_child_weight exact
+
     # Pin the sign (largest-magnitude component positive) so repeated fits are
     # reproducible. Gain is even in the direction, so this changes no split.
     if c[np.argmax(np.abs(c))] < 0.0:
         c = -c
+
     return c
 
 
@@ -1283,48 +1441,46 @@ class MultiQuantileBoosting(_BaseBooster):
       verbatim -- one histogram per round rather than K. `_gram_direction`
       explains why any single projection is the rank-1 truncation of the exact
       summed-across-tau gain rather than a different algorithm;
-      `_fixed_contrasts` explains which directions are worth truncating to,
-      and why the plain channel sum is the worst available choice.
+      `_fixed_contrasts` explains which directions are worth truncating to, and
+      why the plain channel sum is the worst available choice.
     * Leaf values are the EXACT per-tau empirical quantile of the leaf's
       residuals (`tree._leaf_quantiles_vec`), not a Newton step -- the vector
       form of the override the scalar MAE/Quantile path already applies.
 
-    Leaf channels are independent steps and nothing constrains them against one
+    Leaf channels are independent steps; nothing constrains them against one
     another during the fit. Ordering is imposed on DELIVERED predictions, per
-    row, by monotone rearrangement: `_predict_raw_impl` and
-    `staged_predict_raw` sort each row's K-vector before returning it, so
-    predictions cannot cross at any stage. Rearrangement is free of charge in
-    accuracy terms -- Chernozhukov, Fernandez-Val & Galichon (2010) show that
-    sorting a crossing quantile curve never increases pinball loss at any
-    level, for any row -- and it is exact per row rather than a bound that has
-    to hold for every row at once.
+    row, by monotone rearrangement: `_predict_raw_impl` and `staged_predict_raw`
+    sort each row's K-vector before returning it, so predictions cannot cross at
+    any stage. Rearrangement costs no accuracy -- Chernozhukov, Fernandez-Val &
+    Galichon (2010) show that sorting a crossing quantile curve never increases
+    pinball loss at any level, for any row -- and it is exact per row rather than
+    a bound that has to hold for every row at once.
 
     Two rules this class depends on, both learned the expensive way:
 
     * **Never sort ``F`` in place, or anything that feeds back into it.** An
       earlier design sorted each leaf vector as it was committed. Sorted values
-      then re-entered the accumulated scores and self-reinforced, and the fit
-      diverged to a measured pinball of 2.9e7 against an oracle of 0.35.
-      Sorting delivered output has no such path back into training.
+      re-entered the accumulated scores and self-reinforced, and the fit diverged
+      to a measured pinball of 2.9e7 against an oracle of 0.35. Sorting delivered
+      output has no such path back into training.
     * Nothing may assume a row of ``F`` is ordered. The pinball gradient is
       per-channel independent (`losses.MultiQuantile.grad_hess` compares only
       ``F[:, k]`` against ``y``), so crossing scores cost the fit nothing, but
       code that reads a row as if it were sorted is silently wrong -- see the
       scan in `tree._project_pinball`, which used to binary-search a PIT rank.
 
-    The predecessor to all this was a training-time "narrowing budget" charged
-    at the worst-case leaf each round. It was a valid bound and a bad one: one
+    The predecessor was a training-time "narrowing budget" charged at the
+    worst-case leaf each round: a valid bound and a bad one. One
     aggressively-narrowing leaf spent budget on behalf of every row, so it
     saturated within tens of rounds and froze the interval width, leaving bands
     2x to 10x wider than calibrated (benchmarks/LEAFTUNE_PLAN.md, P12).
 
     Known limitation, by construction: within one round, gradient signal
-    orthogonal to the chosen direction cannot drive a split. The exact leaf
-    refit still expresses that shape within whatever partition it is handed,
-    so the failure mode is graceful, and the direction is re-measured every
-    round -- once a mode is fit its energy drops and the next mode takes over
-    without any schedule. ``exact_splits=True`` removes the limitation at K
-    times the histogram cost.
+    orthogonal to the chosen direction cannot drive a split. The failure mode is
+    graceful. The exact leaf refit still expresses that shape within whatever
+    partition it is handed, and the direction is re-measured every round, so once
+    a mode is fit its energy drops and the next takes over with no schedule.
+    ``exact_splits=True`` removes the limitation at K times the histogram cost.
     """
 
     def __init__(self, quantiles=None, split_projection="rotate",
@@ -1341,28 +1497,34 @@ class MultiQuantileBoosting(_BaseBooster):
 
         Unit norm matters beyond tidiness: the pinball hessian is 1, so the
         projected curvature is exactly 1 per row, which keeps
-        ``min_child_weight`` and ``l2_leaf_reg`` meaning precisely what they
-        mean on today's scalar Quantile path.
+        ``min_child_weight`` and ``l2_leaf_reg`` meaning precisely what they mean
+        on the scalar Quantile path.
 
-        "rotate" is the default because it measured best of the cheap arms --
-        see benchmarks/QUANTILE_PLAN.md. Cycling guarantees each contrast a
-        fixed share of rounds; picking the strongest one greedily ("gram")
-        sounds better and is not, because on data whose only signal is spread
-        it drifts onto the location contrast and never comes back."""
+        "rotate" is the default because it measured best of the cheap arms; see
+        benchmarks/QUANTILE_PLAN.md. Cycling guarantees each contrast a fixed
+        share of rounds. Picking the strongest one greedily ("gram") sounds
+        better and is not: on data whose only signal is spread it drifts onto the
+        location contrast and never comes back.
+        """
         basis = self._contrasts_
+
         if self.split_projection == "gram":
             v = _gram_direction(grad, self.quantiles, basis, rng)
             return basis[0] if v is None else v
+
         if self.split_projection == "rotate":
             i = _ROTATE_PATTERN[m % len(_ROTATE_PATTERN)]
             return basis[min(i, len(basis) - 1)]
+
         return basis[0]         # "sum": the literal channel sum
 
     def _fit_impl(self, X, y, cat_features=None, eval_set=None,
                   sample_weight=None, callbacks=None, prep_cache=None):
-        """Fit one vector-leaf quantile tree per boosting round. Same
-        `cat_features` / `eval_set` / `sample_weight` semantics as the scalar
-        booster. (Called via the base ``fit``, which owns the thread limit.)"""
+        """Fit one vector-leaf quantile tree per boosting round.
+
+        Same `cat_features` / `eval_set` / `sample_weight` semantics as the
+        scalar booster. Called via the base ``fit``, which owns the thread limit.
+        """
         X = as_model_array(X, bool(cat_features))
         y = np.ascontiguousarray(y, dtype=np.float64)
         n_samples = X.shape[0]
@@ -1379,8 +1541,9 @@ class MultiQuantileBoosting(_BaseBooster):
         Xb, Xvb = self._prep_matrices(X, [y], cat_features, eval_set,
                                       prep_cache, w)
         n_bins = self.prep_.n_bins_
+
         # The exact arm needs its own K-deep buffers and never touches the
-        # scalar ones; allocate exactly one of the two.
+        # scalar ones, so allocate exactly one of the two.
         if self.exact_splits:
             hist_buffers, qbuf = None, None
             exact_hist = alloc_exact_hist(Xb.shape[0], self.depth, n_bins, K)
@@ -1406,8 +1569,9 @@ class MultiQuantileBoosting(_BaseBooster):
         # stays unchanged).
         g_buf = np.empty(n_samples)
         w_row = np.ones(n_samples) if w is None else w
-        # Only two arms ever need the (n, K) gradient itself: "gram" measures
-        # its covariance, and the exact split search scatters all K channels.
+
+        # Only two arms ever need the (n, K) gradient itself: "gram" measures its
+        # covariance, and the exact split search scatters all K channels.
         need_grad = self.exact_splits or self.split_projection == "gram"
 
         rng = np.random.default_rng(self.random_state)
@@ -1416,11 +1580,12 @@ class MultiQuantileBoosting(_BaseBooster):
         self.train_history_, self.valid_history_ = [], []
         stopper = _EarlyStopper(self.early_stopping_rounds)
         cb_train_loss = _callbacks_need_train_loss(callbacks)
+
         # `_SMALL_N` is the scalar path's fork/join break-even, in units of
         # per-row work. The leaf refit does K quantile selections per leaf, so
-        # the same amount of work is reached at K times fewer rows -- comparing
-        # n alone would leave the parallel kernel unused on every ordinary
-        # dataset. Both branches are bit-identical, so this only moves speed.
+        # the same work is reached at K times fewer rows -- comparing n alone
+        # would leave the parallel kernel unused on every ordinary dataset. Both
+        # branches are bit-identical, so this only moves speed.
         small = n_samples * K <= _SMALL_N
         t0 = time.time()
 
@@ -1433,6 +1598,7 @@ class MultiQuantileBoosting(_BaseBooster):
                 grad, _ = self.loss_.grad_hess(y, F)
                 if w is not None:
                     grad = grad * w[:, None]
+
             direction = self._split_direction(grad, m, rng)
             if grad is not None and self.split_projection == "gram":
                 g_s = grad @ direction
@@ -1440,22 +1606,27 @@ class MultiQuantileBoosting(_BaseBooster):
                 _project_pinball(y, F, direction, float(direction @ taus),
                                  w_row, g_buf)
                 g_s = g_buf
-            # Unit-norm direction + unit hessian => projected curvature is
-            # exactly 1 per row -- times the row's sample weight, exactly as
-            # the projected gradient above is weighted. An unweighted hessian
-            # here would score weighted gradient sums against row counts, so
-            # the structure would optimize a different objective than the
-            # leaf values are fit to (and min_child_weight would count rows
-            # instead of weight mass). w_row already holds exactly these
-            # values, and the build path never writes to its hessian, so the
-            # hoisted buffer is safe to share across rounds.
+
+            # Unit-norm direction plus unit hessian means the projected
+            # curvature is exactly 1 per row -- times the row's sample weight,
+            # exactly as the projected gradient above is weighted.
+            #
+            # An unweighted hessian here would score weighted gradient sums
+            # against row counts, so the structure would optimize a different
+            # objective than the leaf values are fit to, and min_child_weight
+            # would count rows instead of weight mass.
+            #
+            # w_row already holds these values, and the build path never writes
+            # to its hessian, so the hoisted buffer is safe to share.
             h_s = w_row
+
             # One MVS row selection per round, taken from the projection and
-            # reused for the leaf refit, so leaf values see exactly the rows
-            # the split search saw.
+            # reused for the leaf refit, so leaf values see exactly the rows the
+            # split search saw.
             mw = self._mvs_row_weights(g_s, rng)
             if mw is not None:
                 g_s, h_s = g_s * mw, h_s * mw
+
             # Row weight seen by BOTH the split search and the leaf refit:
             # sample weights times any MVS importance weight. None == uniform,
             # which keeps the unweighted path on the fast kernels.
@@ -1479,18 +1650,18 @@ class MultiQuantileBoosting(_BaseBooster):
                     hist_buffers=hist_buffers,
                     quantize=self.quantize_gradients, qbuf=qbuf, qseed=qseed)
 
-            # No legal split: stop like the other boosters, keeping the best
-            # prefix exactly as the other exits do.
+            # No legal split: stop like the other boosters, truncating to the
+            # best prefix exactly as their exits do.
             if tree.depth == 0:
                 if Fv is not None and stopper.patience:
                     self.trees_ = self.trees_[: stopper.best_iter + 1]
                 break
 
-            # Replace the projection's scalar leaf values with the exact
-            # per-tau residual quantiles on the shared partition. Each channel
-            # is its own quantile of the same residuals; they are not
-            # constrained against one another, which is what lets a leaf
-            # narrow its interval as far as its rows warrant.
+            # Replace the projection's scalar leaf values with the exact per-tau
+            # residual quantiles on the shared partition. Each channel is its own
+            # quantile of the same residuals, unconstrained against the others,
+            # which is what lets a leaf narrow its interval as far as its rows
+            # warrant.
             n_lv = tree.values.shape[0]
             if rw is None:
                 kern = (_leaf_quantiles_vec_serial if small
@@ -1503,6 +1674,7 @@ class MultiQuantileBoosting(_BaseBooster):
 
             _add_leaf_values(F, tree.values, leaf)
             self.trees_.append(tree)
+
             if self._round_epilogue(
                     m, F, y, w, Fv, yv, wv, stopper, callbacks, cb_train_loss,
                     lambda: _add_leaf_values(Fv, tree.values, tree.apply(Xvb))):
@@ -1518,22 +1690,27 @@ class MultiQuantileBoosting(_BaseBooster):
 
     def _val_score(self, yv, Fv, wv):
         """Score the eval set on REARRANGED scores, which is what a user
-        receives. Sorting can only lower the pinball loss, so stopping on the
-        raw accumulator would pick the best round for a prediction this class
-        never returns. ``np.sort`` copies -- ``Fv`` itself must stay untouched,
-        since the fit keeps adding to it."""
+        receives.
+
+        Sorting can only lower the pinball loss, so stopping on the raw
+        accumulator would pick the best round for a prediction this class never
+        returns. ``np.sort`` copies, which is required: ``Fv`` itself must stay
+        untouched, since the fit keeps adding to it.
+        """
         return super()._val_score(yv, np.sort(Fv, axis=1), wv)
 
     def _predict_raw_impl(self, X, cat_ctx=None):
-        """Return the (n_samples, n_quantiles) matrix of quantile estimates,
-        each row sorted (see the class docstring: monotone rearrangement is
-        where the non-crossing guarantee is enforced)."""
+        """Return the (n_samples, n_quantiles) matrix of quantile estimates, each
+        row sorted. See the class docstring: monotone rearrangement is where the
+        non-crossing guarantee is enforced."""
         X = as_model_array(X, bool(self.prep_.cat_features_))
         Xb = self.prep_.transform(X, cat_ctx)       # row-major
         if not self.trees_:
             return np.tile(self.init_, (Xb.shape[0], 1))
+
         if getattr(self, "_forest_", None) is None:
             self._forest_ = pack_forest_vec(self.trees_, self.depth)
+
         feats, thrs, depths, vals, voff, K = self._forest_
         kernel = (_predict_forest_vec_rm_serial
                   if Xb.shape[0] <= _SERIAL_PREDICT_N
@@ -1544,15 +1721,16 @@ class MultiQuantileBoosting(_BaseBooster):
     def staged_predict_raw(self, X):
         """Yield the (n, K) quantile matrix after each successive tree.
 
-        Trees are accumulated in the same order as `_predict_forest_vec_rm`,
-        so the final stage equals ``predict_raw``. Each stage is rearranged on
-        the way out and every one of them is non-crossing.
+        Trees are accumulated in the same order as `_predict_forest_vec_rm`, so
+        the final stage equals ``predict_raw``. Each stage is rearranged on the
+        way out, so every one of them is non-crossing.
 
         ``np.sort`` returns a copy, which is load-bearing twice over: it is the
         per-stage copy the caller needs, and it keeps the running ``F`` in raw
         accumulated form. Sorting ``F`` in place would feed rearranged scores
         back into the next stage and reproduce the divergence recorded in the
-        class docstring."""
+        class docstring.
+        """
         X = as_model_array(X, bool(self.prep_.cat_features_))
         Xb = np.ascontiguousarray(self.prep_.transform(X).T)   # feature-major
         F = np.tile(self.init_, (Xb.shape[1], 1))

--- a/chimeraboost/losses.py
+++ b/chimeraboost/losses.py
@@ -29,8 +29,8 @@ def _weighted_quantile(values, weights, alpha):
 
 @njit(cache=True, parallel=True)
 def _sigmoid(z):
-    # Numerically stable logistic, parallelized over rows. Branching on sign
-    # avoids overflow in exp(): exp(-|z|) is always in [0, 1].
+    # Numerically stable logistic, parallel over rows. The sign branch keeps
+    # exp() from overflowing: exp(-|z|) always lands in [0, 1].
     n = z.shape[0]
     out = np.empty(n, dtype=np.float64)
     for i in prange(n):
@@ -47,13 +47,15 @@ class _UnitHessian:
     """Constant-hessian mixin: ``grad_hess`` returns a cached all-ones buffer
     instead of allocating ``np.ones_like`` every boosting round.
 
-    The buffer is SHARED across rounds, so nothing on the fit path may write
-    into a returned hessian -- today nothing does: the weighted paths multiply
-    into fresh arrays (``hess * w``), MVS returns fresh arrays, and every tree
-    kernel only reads it. Keep it that way: in particular, never "optimize"
-    ``hess = hess * w`` into ``np.multiply(hess, w, out=hess)``. The cache is
-    dropped on pickle (``loss_`` is pickled inside fitted boosters, and n
-    floats of ones have no business in the payload)."""
+    The buffer is SHARED across rounds, so nothing on the fit path may write into
+    a returned hessian. Today nothing does: the weighted paths build fresh arrays
+    (``hess * w``), MVS returns fresh arrays, and the tree kernels only read it.
+    Keep it that way -- in particular, never "optimize" ``hess = hess * w`` into
+    ``np.multiply(hess, w, out=hess)``.
+
+    The cache is dropped on pickle: ``loss_`` rides inside fitted boosters, and n
+    floats of ones have no business in the payload.
+    """
 
     def _unit_hess(self, like):
         h = getattr(self, "_hess_cache", None)
@@ -90,7 +92,11 @@ class RMSE(_UnitHessian):
 
 
 class Logloss:
-    """Binary cross-entropy. raw = log-odds, p = sigmoid(raw)."""
+    """Binary cross-entropy. raw = log-odds, p = sigmoid(raw).
+
+    grad = p - y, hess = p * (1 - p), floored at 1e-6 so a saturated row cannot
+    blow up a leaf denominator.
+    """
 
     name = "Logloss"
     is_classification = True
@@ -116,9 +122,11 @@ class Logloss:
 
 
 class MAE(_UnitHessian):
-    """Mean absolute error. The sign gradient only picks the tree structure;
-    leaf values are set to the (weighted) median of the residuals, which is the
-    minimizer of absolute error."""
+    """Mean absolute error. grad = sign(pred - y), hess = 1.
+
+    The sign gradient only picks the tree structure. Leaf values are the
+    (weighted) median of the residuals, which is what minimizes absolute error.
+    """
 
     name = "MAE"
     is_classification = False
@@ -142,7 +150,12 @@ class MAE(_UnitHessian):
 
 
 class Quantile(_UnitHessian):
-    """Pinball loss for quantile regression at level `alpha` in (0, 1)."""
+    """Pinball loss for quantile regression at level `alpha` in (0, 1).
+
+    grad = -alpha where y sits at or above the current estimate, 1 - alpha
+    below; hess = 1. Leaf values are the weighted alpha-quantile of the
+    residuals.
+    """
 
     name = "Quantile"
     is_classification = False
@@ -171,9 +184,9 @@ class Quantile(_UnitHessian):
         return raw
 
 
-# Cap on exponent arguments in the log-link losses: exp(80) ~ 5.5e34 keeps
-# every downstream product finite in float64 while leaving the cap far outside
-# any raw score a sane fit produces (raw = log(mean prediction)).
+# Exponent cap for the log-link losses. exp(80) ~ 5.5e34 keeps every downstream
+# product finite in float64, and no sane fit gets near it: raw = log(mu), so the
+# cap sits far outside any real raw score.
 _EXP_CLIP = 80.0
 
 
@@ -182,9 +195,12 @@ def _exp(z):
 
 
 class Huber(_UnitHessian):
-    """Huber regression: quadratic within `delta` of the target, linear
-    beyond. `delta` is in y units (fixed, not quantile-adaptive), so scale it
-    to the data. hess = 1 in both regions (the standard GBDT treatment)."""
+    """Huber regression: quadratic within `delta` of the target, linear beyond.
+
+    grad = clip(pred - y, -delta, delta); hess = 1 in both regions, the standard
+    GBDT treatment. `delta` is in y units and fixed, not quantile-adaptive, so
+    scale it to the data.
+    """
 
     name = "Huber"
     is_classification = False
@@ -213,7 +229,9 @@ class Huber(_UnitHessian):
 
 class Poisson:
     """Poisson regression for counts with a log link: raw = log(mu).
-    grad = mu - y, hess = mu. Predictions (`transform`) are exp(raw) > 0."""
+
+    grad = mu - y, hess = mu. Predictions (`transform`) are exp(raw) > 0.
+    """
 
     name = "Poisson"
     is_classification = False
@@ -222,9 +240,11 @@ class Poisson:
     def init(self, y, sample_weight=None):
         if np.any(y < 0):
             raise ValueError("loss='Poisson' requires non-negative y.")
+
         mean = np.average(y, weights=sample_weight)
         if mean <= 0:
             raise ValueError("loss='Poisson' requires y with a positive mean.")
+
         return float(np.log(mean))
 
     def grad_hess(self, y, raw):
@@ -234,9 +254,11 @@ class Poisson:
     def eval(self, y, raw, sample_weight=None):
         """Mean Poisson deviance (2 * (y log(y/mu) - (y - mu)); y log y := 0 at 0)."""
         mu = _exp(raw)
+
         ylog = np.zeros_like(mu)
         nz = y > 0
         ylog[nz] = y[nz] * np.log(y[nz] / mu[nz])
+
         return float(np.average(2.0 * (ylog - (y - mu)),
                                 weights=sample_weight))
 
@@ -245,8 +267,10 @@ class Poisson:
 
 
 class Gamma:
-    """Gamma regression for positive, right-skewed targets with a log link:
-    raw = log(mu). grad = 1 - y/mu, hess = y/mu (the gamma NLL curvature)."""
+    """Gamma regression for positive, right-skewed targets. Log link: raw = log(mu).
+
+    grad = 1 - y/mu, hess = y/mu (the gamma NLL curvature).
+    """
 
     name = "Gamma"
     is_classification = False
@@ -272,9 +296,12 @@ class Gamma:
 
 
 class Tweedie:
-    """Tweedie regression (compound Poisson-gamma) with a log link, for
-    non-negative targets with exact zeros plus a long right tail (insurance
-    claims, rainfall). `power` in (1, 2) interpolates Poisson -> Gamma."""
+    """Tweedie regression (compound Poisson-gamma) with a log link: raw = log(mu).
+
+    For non-negative targets with exact zeros plus a long right tail (insurance
+    claims, rainfall). `power` p in (1, 2) interpolates Poisson -> Gamma.
+    grad = mu^(2-p) - y mu^(1-p), hess = (2-p) mu^(2-p) - (1-p) y mu^(1-p).
+    """
 
     name = "Tweedie"
     is_classification = False
@@ -290,9 +317,11 @@ class Tweedie:
     def init(self, y, sample_weight=None):
         if np.any(y < 0):
             raise ValueError("loss='Tweedie' requires non-negative y.")
+
         mean = np.average(y, weights=sample_weight)
         if mean <= 0:
             raise ValueError("loss='Tweedie' requires y with a positive mean.")
+
         return float(np.log(mean))
 
     def grad_hess(self, y, raw):
@@ -323,9 +352,11 @@ class CustomObjective:
     ``eval(y, raw, sample_weight=None)`` -> scalar (lower is better; drives
     early stopping). Optionally override ``init(y, sample_weight=None)`` (the
     starting raw score, default 0.0) and ``transform(raw)`` (raw scores ->
-    predictions, default identity). Pass an *instance* as the regressor's
-    ``loss``. Instances must be stateless across fits and picklable, so define
-    the subclass at module level: bagged members fit in worker processes.
+    predictions, default identity).
+
+    Pass an *instance* as the regressor's ``loss``. Instances must be stateless
+    across fits and picklable, so define the subclass at module level: bagged
+    members fit in worker processes.
 
     Read more in the [User Guide](https://bbstats.github.io/chimeraboost/recipes/).
     """
@@ -354,7 +385,10 @@ def _softmax(F):
 
 
 class MultiSoftmax:
-    """Multinomial logistic loss. Operates on raw scores F of shape (n, K)."""
+    """Multinomial logistic loss. Operates on raw scores F of shape (n, K).
+
+    grad = softmax(F) - Y, hess = p * (1 - p) per class, floored at 1e-6.
+    """
 
     name = "MultiClass"
     is_classification = True
@@ -384,13 +418,14 @@ class MultiSoftmax:
 class MultiQuantile(_UnitHessian):
     """Pinball loss on a shared tau grid: K quantile channels at once.
 
-    Raw scores are an (n, K) matrix, column k holding the estimate of the
-    `taus[k]` conditional quantile. Nothing here couples the channels -- each
-    column is exactly the scalar `Quantile` loss at its own alpha, and a
-    one-element grid reproduces it term for term. Columns of ``F`` may
-    therefore cross during a fit and none of the maths below cares; the
-    coupling lives in the booster, which shares one tree structure per round
-    and rearranges each row before returning it.
+    Raw scores are an (n, K) matrix; column k estimates the `taus[k]`
+    conditional quantile. Nothing here couples the channels -- each column is
+    exactly the scalar `Quantile` loss at its own alpha, and a one-element grid
+    reproduces it term for term.
+
+    Columns of ``F`` may therefore cross during a fit, and none of the maths
+    below cares. The coupling lives in the booster, which shares one tree
+    structure per round and rearranges each row before returning it.
 
     `taus` must be ascending, unique and strictly inside (0, 1); the estimator
     validates that before constructing this.
@@ -408,23 +443,29 @@ class MultiQuantile(_UnitHessian):
         """Global (weighted) quantile at each level -- a (K,) starting vector."""
         q = np.array([_weighted_quantile(y, sample_weight, a)
                       for a in self.taus])
-        # Quantiles of one sample are already monotone in alpha, so this sort
-        # is a no-op. Kept because a starting vector that is ordered costs
-        # nothing and makes the zero-tree prediction trivially well formed.
+
+        # A no-op: quantiles of one sample are already monotone in alpha. Kept
+        # because an ordered starting vector costs nothing and makes the
+        # zero-tree prediction trivially well formed.
         q.sort()
+
         return q
 
     def grad_hess(self, y, F):
         """(n, K) pinball gradient; hessian is 1 everywhere.
 
         Sign convention matches the scalar `Quantile`: -alpha where the target
-        sits at or above the current estimate, 1-alpha below."""
+        sits at or above the current estimate, 1 - alpha below.
+        """
         grad = np.where(y[:, None] >= F, -self.taus, 1.0 - self.taus)
         return grad, self._unit_hess(F)
 
     def eval(self, y, F, sample_weight=None):
-        """Mean pinball loss across the grid -- the CRPS convention used by
-        `chimeraboost.quantile_metrics.crps`, and the early-stopping metric."""
+        """Mean pinball loss across the grid.
+
+        This is the CRPS convention used by `chimeraboost.quantile_metrics.crps`,
+        and the early-stopping metric.
+        """
         r = y[:, None] - F
         pinball = np.maximum(self.taus * r, (self.taus - 1.0) * r)
         return float(np.average(pinball.mean(axis=1), weights=sample_weight))

--- a/chimeraboost/preprocessing.py
+++ b/chimeraboost/preprocessing.py
@@ -1,17 +1,19 @@
 """Shared feature preprocessing for every ChimeraBoost estimator.
 
-Turns a raw (possibly mixed numeric/categorical, possibly object-dtype) matrix
-into integer bins ready for the tree builder, and remembers everything needed to
-reproduce the same transform at predict time.
+Turns a raw matrix -- numeric, categorical, or an object-dtype mixture -- into
+integer bins for the tree builder, and keeps everything needed to reproduce the
+same transform at predict time.
 
 Categoricals are encoded with ordered target statistics. The encoder is fit
 against a *list* of target vectors:
+
   * regression / binary -> one target (y, or the 0/1 label)
   * multiclass          -> K one-hot targets (one ordered-TS column per class)
-This is why a single categorical column can expand into K numeric columns for
-multiclass, exactly like CatBoost's per-class target statistics.
 
-`feature_map_` maps each combined-matrix column back to its original input
+So one categorical column can expand into K numeric columns for multiclass,
+exactly like CatBoost's per-class target statistics.
+
+``feature_map_`` maps each combined-matrix column back to its original input
 column index, so importances can be aggregated in the user's feature space.
 """
 
@@ -25,60 +27,64 @@ from .target_encoding import OrderedTargetEncoder, factorize
 def as_model_array(X, want_object):
     """Convert a raw feature matrix to the numpy array the model consumes.
 
-    ``want_object`` -> object dtype (categoricals present, decoded downstream);
-    otherwise -> float64. pandas nullable dtypes (Int64/Float64/boolean and the
-    ``string`` dtype) store missing values as ``pd.NA``/``NAType``, which neither
-    casts to float nor compares like ``np.nan`` -- a plain
-    ``np.asarray(df, dtype=float)`` raises a cryptic
-    "float() argument must be ... not 'NAType'". Routing through pandas'
-    ``to_numpy(na_value=np.nan)`` maps every flavor of NA to ``np.nan`` (the
-    missing value the binner/encoder already understand). Inputs without a
-    na_value-aware ``to_numpy`` (plain ndarrays, polars frames) fall back to
-    ``np.asarray`` unchanged.
+    ``want_object`` selects object dtype (categoricals present, decoded
+    downstream); otherwise float64.
+
+    pandas nullable dtypes (Int64/Float64/boolean and ``string``) store missing
+    values as ``pd.NA``/``NAType``, which neither casts to float nor compares
+    like ``np.nan``: a plain ``np.asarray(df, dtype=float)`` raises the cryptic
+    "float() argument must be ... not 'NAType'". ``to_numpy(na_value=np.nan)``
+    maps every flavor of NA to ``np.nan``, which the binner and encoder already
+    handle. Inputs with no na_value-aware ``to_numpy`` (plain ndarrays, polars
+    frames) fall back to ``np.asarray``.
     """
     dtype = object if want_object else np.float64
     to_numpy = getattr(X, "to_numpy", None)
+
     if to_numpy is not None and hasattr(X, "dtypes"):  # pandas DataFrame
         try:
             return to_numpy(dtype=dtype, na_value=np.nan)
         except TypeError:
             pass  # older pandas / polars: no na_value kwarg -> plain cast below
+
     return np.asarray(X, dtype=dtype)
 
 
 @njit(cache=True)
 def _grouped_kahan_sum(codes, vals, n_groups):
-    """Per-group Kahan-compensated sums (row order, sequential).
+    """Per-group Kahan-compensated sums, in row order, sequential.
 
-    Kahan matters for reproducibility, not just accuracy: the gdiff group
-    means were historically computed by pandas' groupby, whose kernel is
-    Kahan-compensated, and existing fitted models / identity goldens embed
-    those exact floats. A naive accumulation drifts in the last ulp on large
-    groups, so a bit-identical replacement has to compensate the same way.
+    Kahan is here for reproducibility, not just accuracy. The gdiff group means
+    used to come from pandas' groupby, whose kernel is Kahan-compensated, and
+    fitted models plus the identity goldens embed those exact floats. Naive
+    accumulation drifts in the last ulp on large groups, so a bit-identical
+    replacement has to compensate the same way.
     """
     out = np.zeros(n_groups)
     comp = np.zeros(n_groups)
+
     for i in range(codes.shape[0]):
         c = codes[i]
         y = vals[i] - comp[c]
         t = out[c] + y
         comp[c] = (t - out[c]) - y
         out[c] = t
+
     return out
 
 
 class CatTransformCache:
-    """Canonical factorizations of one input matrix's categorical columns
-    (and combo string columns), computed once per fit/predict call.
+    """Canonical factorizations of one matrix's categorical and combo columns.
 
-    Bagged members each learned their own category->code map on their own
-    bootstrap, so fit-time codes can't be shared across the bag -- but
-    hashing every row of the batch is member-independent. The bagged parent
-    passes one cache into every member's transform; the first member pays the
-    per-row factorize and each further member maps only the ~n_unique
-    canonical categories through its own dict and gathers. Callers must pass
-    one cache only across transforms of the *same* matrix ``X`` (entries are
-    keyed by column index alone).
+    Computed once per fit/predict call, then shared across a bagged ensemble.
+    Each member learns its own category->code map on its own bootstrap, so
+    fit-time codes can't be shared across the bag -- but hashing every row of
+    the batch is member-independent. The parent passes one cache to every
+    member: the first pays the per-row factorize, each later one maps only the
+    ~n_unique canonical categories through its own dict and gathers.
+
+    One cache is valid for one matrix ``X`` only -- entries are keyed by column
+    index alone.
     """
 
     def __init__(self):
@@ -95,15 +101,17 @@ class CatTransformCache:
     def combo(self, X, f_a, f_b):
         """(codes, categories) of the synthetic combo column for a pair.
 
-        A combo category is the PAIR of the parents' canonical categories,
-        not the concatenated string it used to be: "a_x_b" aliased distinct
-        pairs whose values contain the delimiter, stringified NaN to "nan"
-        (bypassing factorize's ``__nan__`` sentinel, so a real missing value
-        merged with the literal string "nan"), and split int/float spellings
-        of one value ("1" vs "1.0"). Pair codes inherit the parents'
-        factorize semantics exactly and skip the per-row string building.
-        Categories are a list of (val_a, val_b) tuples, first-appearance
-        ordered like every factorize."""
+        A combo category is the PAIR of the parents' canonical categories, not
+        the concatenated string it used to be. "a_x_b" aliased distinct pairs
+        whose values contain the delimiter, stringified NaN to "nan" (bypassing
+        factorize's ``__nan__`` sentinel, so a real missing value merged with
+        the literal string "nan"), and split int/float spellings of one value
+        ("1" vs "1.0"). Pair codes inherit the parents' factorize semantics
+        exactly and skip the per-row string building.
+
+        Categories are (val_a, val_b) tuples in first-appearance order, like
+        every factorize.
+        """
         out = self._combos.get((f_a, f_b))
         if out is None:
             ca, cats_a = self.column(X, f_a)
@@ -115,9 +123,11 @@ class CatTransformCache:
         return out
 
     def combo_str(self, X, f_a, f_b):
-        """Legacy string-concat combo factorization, kept only so models
-        pickled before the pair-code change (string-keyed ``combo_maps_``)
-        keep predicting identically."""
+        """Legacy string-concat combo factorization.
+
+        Kept only so models pickled before the pair-code change (string-keyed
+        ``combo_maps_``) keep predicting identically.
+        """
         out = self._combos.get(("str", f_a, f_b))
         if out is None:
             out = self._combos[("str", f_a, f_b)] = factorize(
@@ -127,25 +137,33 @@ class CatTransformCache:
 
 def _factorize_int(vals):
     """First-appearance factorize of an int64 array (combo pair keys).
-    Returns (codes, keys): same contract as ``factorize`` but keys stay a
-    plain list -- wrapping tuples derived from them in ``np.asarray`` would
-    build a 2-D array. Vectorized: np.unique's sorted ids are remapped onto
-    first-appearance ranks (return_index gives each value's FIRST position),
-    which is exactly the insertion order the old dict loop produced."""
+
+    Returns (codes, keys) -- the same contract as ``factorize``, except keys
+    stay a plain list, because wrapping tuples derived from them in
+    ``np.asarray`` would build a 2-D array.
+
+    Vectorized: np.unique's sorted ids are remapped onto first-appearance ranks
+    (return_index gives each value's FIRST position), which is exactly the
+    insertion order the old dict loop produced.
+    """
     su, first, inv = np.unique(vals, return_index=True, return_inverse=True)
+
     order = np.argsort(first, kind="stable")
     rank = np.empty(order.size, dtype=np.int64)
     rank[order] = np.arange(order.size, dtype=np.int64)
+
     codes = np.ascontiguousarray(rank[inv], dtype=np.int64)
     keys = [int(v) for v in su[order]]
     return codes, keys
 
 
 def _remap_codes(categories, mapping, default):
-    """Vectorize a fit-time {category value -> code/float} dict over canonical
-    categories: the returned array, gathered by canonical codes, equals the
-    row-wise dict lookup with ``default`` for unseen categories.
-    ``categories`` is an ndarray (or a plain list, for combo pair tuples)."""
+    """Vectorize a fit-time {category -> code/float} dict over canonical categories.
+
+    The returned array, gathered by canonical codes, equals the row-wise dict
+    lookup, with ``default`` for unseen categories. ``categories`` is an
+    ndarray, or a plain list for combo pair tuples.
+    """
     cats = categories if isinstance(categories, list) else categories.tolist()
     dtype = np.int64 if isinstance(default, int) else np.float64
     return np.fromiter((mapping.get(u, default) for u in cats),
@@ -155,31 +173,34 @@ def _remap_codes(categories, mapping, default):
 class FeaturePreprocessor:
     """Converts raw mixed-type input into integer bins for the tree builder.
 
-    Numeric columns are quantile-binned; categorical columns are ordered-target
-    encoded (one encoded column per target supplied to `fit_transform`) and then
-    binned alongside the numerics. The fitted state needed to reproduce the
-    transform at predict time is retained, along with `feature_map_` mapping each
-    output column back to its original input column for importances.
+    Numeric columns are quantile-binned. Categorical columns are ordered-target
+    encoded -- one encoded column per target passed to ``fit_transform`` -- and
+    then binned alongside the numerics. The state needed to reproduce the
+    transform at predict time is kept, along with ``feature_map_``, which maps
+    each output column back to its original input column for importances.
 
     cat_combinations : bool
-        When True, generate all C(n_cat, 2) pairwise categorical feature
-        combinations as additional synthetic columns (e.g. "buying_x_maint")
-        before target encoding. Mirrors CatBoost's feature combination step;
-        gives the tree access to interaction effects that individual categoricals
-        can't capture. Only active when ≥2 categorical columns are present.
+        Generate all C(n_cat, 2) pairwise categorical combinations as extra
+        synthetic columns (e.g. "buying_x_maint") before target encoding.
+        Mirrors CatBoost's feature combination step: it gives the tree the
+        interaction effects individual categoricals can't capture. Only active
+        with 2 or more categorical columns.
     cross_pairs : list[(int, int, str)] | None
-        Cross features: each (i, j, op) appends the column
-        ``X[:, i] - X[:, j]`` (op="diff"), ``X[:, i] * X[:, j]`` (op="prod"),
-        or ``X[:, i] - mean_fit(X[:, i] | X[:, j])`` (op="gdiff"), binned like
-        any numeric column. Oblivious trees can only approximate an
-        interaction with a depth-limited staircase (the same split is applied
-        to every leaf of a level); a cross column turns e.g. the ``x_i < x_j``
-        boundary -- or "above this row's own category's average" -- into a
-        single split. Indices refer to ORIGINAL input columns; for diff/prod
-        both must be numeric, for gdiff ``i`` is numeric and ``j`` is a
-        ``cat_features`` column. gdiff group means are learned from the fit
-        rows only (they use no target values, so the same map serves fit and
-        predict); unseen categories fall back to the global mean of column i.
+        Cross features. Each (i, j, op) appends one column -- ``X[:, i] -
+        X[:, j]`` (op="diff"), ``X[:, i] * X[:, j]`` (op="prod"), or
+        ``X[:, i] - mean_fit(X[:, i] | X[:, j])`` (op="gdiff") -- binned like
+        any numeric column.
+
+        Oblivious trees can only approximate an interaction with a
+        depth-limited staircase, since the same split is applied to every leaf
+        of a level. A cross column turns e.g. the ``x_i < x_j`` boundary -- or
+        "above this row's own category's average" -- into a single split.
+
+        Indices refer to ORIGINAL input columns. diff/prod need both parents
+        numeric; gdiff needs ``i`` numeric and ``j`` in ``cat_features``. gdiff
+        group means are learned from the fit rows only (they use no target
+        values, so one map serves fit and predict); unseen categories fall back
+        to the global mean of column i.
     """
 
     def __init__(self, max_bins=128, cat_smoothing=1.0, random_state=None,
@@ -193,34 +214,45 @@ class FeaturePreprocessor:
         self.cross_pairs = list(cross_pairs) if cross_pairs else []
 
     # ---- helpers -------------------------------------------------------------
+
     def _numeric_block(self, X):
-        """The numeric columns as float64. When every column is numeric (the
-        no-categoricals case) `num_features_` is exactly range(n_features), so
-        plain asarray suffices — the fancy-index gather `X[:, list]` would copy
-        the whole matrix (a large predict-time tax on wide batches)."""
+        """The numeric columns as float64.
+
+        When every column is numeric, ``num_features_`` is exactly
+        range(n_features), so a plain asarray suffices -- the fancy-index
+        gather ``X[:, list]`` would copy the whole matrix, a large predict-time
+        tax on wide batches.
+        """
         if not self.num_features_:
             return np.empty((X.shape[0], 0))
+
         if len(self.num_features_) == X.shape[1]:
             return np.asarray(X, dtype=np.float64)
+
         return np.asarray(X[:, self.num_features_], dtype=np.float64)
 
     @staticmethod
     def _combo_values(X, f_a, f_b):
         """The synthetic "val_a_x_val_b" string column for a feature pair.
-        LEGACY: only serves models pickled with string-keyed combo maps
-        (see ``CatTransformCache.combo_str``)."""
+
+        LEGACY: only serves models pickled with string-keyed combo maps (see
+        ``CatTransformCache.combo_str``).
+        """
         col_a = np.asarray(X[:, f_a], dtype=str)
         col_b = np.asarray(X[:, f_b], dtype=str)
         return np.char.add(np.char.add(col_a, "_x_"), col_b)
 
     def _split_columns_fit(self, X, cat_features, cat_ctx=None):
-        """Split input into a numeric matrix and an integer-code matrix for the
-        categorical columns, learning the category->code maps on the way.
-        When cat_combinations is True, appends combo codes after the base codes."""
+        """Split input into a numeric matrix and a categorical code matrix.
+
+        Learns the category->code maps on the way. When cat_combinations is
+        True, combo codes are appended after the base codes.
+        """
         n_features = X.shape[1]
         cat_set = set(cat_features or [])
         self.cat_features_ = sorted(cat_set)
         self.num_features_ = [f for f in range(n_features) if f not in cat_set]
+
         if cat_ctx is None:
             cat_ctx = CatTransformCache()
 
@@ -237,13 +269,13 @@ class FeaturePreprocessor:
             codes = np.empty((X.shape[0], 0), dtype=np.int64)
             self.cat_maps_ = []
 
-        # 2-way combinations: each pair becomes a new categorical column whose
+        # 2-way combinations: each pair becomes a categorical column whose
         # categories are (val_a, val_b) pairs, target-encoded like any other
-        # cat column, so the tree sees interaction effects single columns
-        # can't express.
+        # cat column, so the tree sees interactions single columns can't hold.
         self.combo_pairs_ = []
         self.combo_maps_ = []
         n_cat = len(self.cat_features_)
+
         if self.cat_combinations and n_cat >= 2:
             combo_cols = []
             for a in range(n_cat):
@@ -253,28 +285,36 @@ class FeaturePreprocessor:
                     self.combo_pairs_.append((f_a, f_b))
                     self.combo_maps_.append({v: i for i, v in enumerate(cats)})
                     combo_cols.append(c)
+
             if combo_cols:
                 codes = np.hstack(
                     [codes, np.column_stack(combo_cols).astype(np.int64)])
+
         return num, codes
 
     def _fit_gdiff(self, X, sample_weight=None, cat_ctx=None):
-        """Learn the per-category means backing the gdiff cross columns:
-        for each (i, j, "gdiff") pair a {category value -> mean of X[:, i]}
-        map plus the global-mean fallback for categories unseen at fit.
-        Means are computed over rows with a finite X[:, i] (a NaN numeric
-        contributes nothing, mirroring the binner's quantile treatment) and,
-        when ``sample_weight`` is given, weighted by it so zero-weight rows
-        never shape another row's centering."""
+        """Learn the per-category means backing the gdiff cross columns.
+
+        For each (i, j, "gdiff") pair: a {category value -> mean of X[:, i]}
+        map, plus the global-mean fallback for categories unseen at fit.
+
+        Means use only rows with a finite X[:, i] -- a NaN numeric contributes
+        nothing, mirroring the binner's quantile treatment -- and, when
+        ``sample_weight`` is given, are weighted by it so zero-weight rows never
+        shape another row's centering.
+        """
         self.gdiff_maps_ = []
         pairs = [(i, j) for i, j, op in self.cross_pairs if op == "gdiff"]
         if not pairs:
             return
+
         if cat_ctx is None:
             cat_ctx = CatTransformCache()
+
         for i, j in pairs:
             a = np.asarray(X[:, i], dtype=np.float64)
             ok = np.isfinite(a)
+
             if ok.all():
                 codes, cats = cat_ctx.column(X, j)
                 v = a
@@ -283,43 +323,53 @@ class FeaturePreprocessor:
                 # order is first appearance among the contributing rows.
                 codes, cats = factorize(np.asarray(X[:, j], dtype=object)[ok])
                 v = a[ok]
+
             w = (np.ones(v.shape[0]) if sample_weight is None
                  else np.asarray(sample_weight, dtype=np.float64)[ok])
+
             vsum = _grouped_kahan_sum(codes, v * w, len(cats))
             wsum = _grouped_kahan_sum(codes, w, len(cats))
             tot_w = float(np.sum(wsum))
             global_mean = (float(np.sum(vsum) / tot_w) if tot_w > 0 else 0.0)
+
             with np.errstate(invalid="ignore", divide="ignore"):
                 means = vsum / wsum
             means = np.where(np.isfinite(means), means, global_mean)
+
             self.gdiff_maps_.append(
                 (dict(zip(cats.tolist(), means.tolist())), global_mean))
 
     def _cross_block(self, X, cat_ctx=None, num=None):
-        """Compute the cross-feature columns (float64) from raw input. NaN in
-        a numeric parent propagates to the cross (binned to the missing bucket
-        like any numeric NaN); gdiff maps a NaN category to its own "__nan__"
-        group and an unseen category to the global mean.
+        """Compute the cross-feature columns (float64) from raw input.
 
-        Numeric parents are read from ``num`` (the float64 numeric block;
-        pass the one already built for this matrix, else it is computed
-        here): one cast per input column instead of one per pair. On object
-        arrays (categoricals present) the per-pair element-wise casts were
-        the dominant predict-time cost of cross features."""
+        A NaN in a numeric parent propagates to the cross column and bins to
+        the missing bucket like any numeric NaN. gdiff maps a NaN category to
+        its own "__nan__" group and an unseen category to the global mean.
+
+        Numeric parents come from ``num``, the float64 numeric block -- pass the
+        one already built for this matrix, else it is built here. That is one
+        cast per input column instead of one per pair; on object arrays
+        (categoricals present) the per-pair element-wise casts were the dominant
+        predict-time cost of cross features.
+        """
         if not self.cross_pairs:
             return np.empty((X.shape[0], 0))
+
         if cat_ctx is None:
             cat_ctx = CatTransformCache()
         if num is None:
             num = self._numeric_block(X)
+
         pos = {f: k for k, f in enumerate(self.num_features_)}
-        # Write each cross column straight into the output block: the ufunc
-        # ``out=`` forms skip both the per-pair temporary and the final
-        # column_stack copy.
+
+        # Write each cross column straight into the output block: the ``out=``
+        # ufunc form skips both the per-pair temporary and a final column_stack.
         out = np.empty((X.shape[0], len(self.cross_pairs)))
+
         g = 0
         for k, (i, j, op) in enumerate(self.cross_pairs):
             a = num[:, pos[i]]
+
             if op == "gdiff":
                 means, global_mean = self.gdiff_maps_[g]
                 g += 1
@@ -327,36 +377,45 @@ class FeaturePreprocessor:
                 np.subtract(a, _remap_codes(cats, means, global_mean)[codes],
                             out=out[:, k])
                 continue
+
             b = num[:, pos[j]]
             if op == "diff":
                 np.subtract(a, b, out=out[:, k])
             else:
                 np.multiply(a, b, out=out[:, k])
+
         return out
 
     def _codes_for_transform(self, X, cat_ctx=None):
-        """Map categorical columns to the codes learned at fit time; unseen
-        categories get -1 (the encoder then falls back to the prior). Each
+        """Map categorical columns to the codes learned at fit time.
+
+        Unseen categories get -1, and the encoder falls back to the prior. Each
         column is factorized once and only its unique values pass through the
-        fit-time dict; with a shared ``cat_ctx`` the factorization is also
-        reused across bagged members."""
+        fit-time dict; a shared ``cat_ctx`` reuses that factorization across
+        bagged members too.
+        """
         if not self.cat_features_:
             return np.empty((X.shape[0], 0), dtype=np.int64)
+
         if cat_ctx is None:
             cat_ctx = CatTransformCache()
+
         codes = np.empty((X.shape[0], len(self.cat_features_)), dtype=np.int64)
         for j, f in enumerate(self.cat_features_):
             c, cats = cat_ctx.column(X, f)
             codes[:, j] = _remap_codes(cats, self.cat_maps_[j], -1)[c]
+
         return codes
 
     def _combo_codes_for_transform(self, X, cat_ctx=None):
-        """Reconstruct combination codes for transform using stored combo maps.
-        Models pickled before the pair-code change carry string-keyed maps;
-        they keep the legacy string-concat path so their predictions are
-        unchanged."""
+        """Reconstruct combination codes for transform from the stored maps.
+
+        Models pickled before the pair-code change carry string-keyed maps; they
+        stay on the legacy string-concat path so their predictions don't move.
+        """
         if cat_ctx is None:
             cat_ctx = CatTransformCache()
+
         combo_codes = np.empty((X.shape[0], len(self.combo_pairs_)), dtype=np.int64)
         for k, (f_a, f_b) in enumerate(self.combo_pairs_):
             legacy = (self.combo_maps_[k]
@@ -364,15 +423,19 @@ class FeaturePreprocessor:
             c, cats = (cat_ctx.combo_str(X, f_a, f_b) if legacy
                        else cat_ctx.combo(X, f_a, f_b))
             combo_codes[:, k] = _remap_codes(cats, self.combo_maps_[k], -1)[c]
+
         return combo_codes
 
     # ---- fit / transform -----------------------------------------------------
+
     def fit_transform(self, X, encode_targets, cat_features, sample_weight=None,
                       binner=None):
-        """encode_targets: list of 1D arrays used for ordered TS (len T).
+        """Fit on ``X`` and return the binned matrix.
 
-        ``sample_weight`` (mean-1 normalized, ``None`` == uniform) is forwarded to
-        the ordered-target encoder and the binner so zero-weight rows shape
+        ``encode_targets`` is the list of T 1-D arrays used for ordered TS.
+
+        ``sample_weight`` (mean-1 normalized, ``None`` == uniform) is forwarded
+        to the ordered-target encoder and the binner, so zero-weight rows shape
         neither the categorical statistics nor the bin borders. ``None`` is the
         unweighted path, bit-identical to before this argument existed.
 
@@ -382,9 +445,11 @@ class FeaturePreprocessor:
         on ``X``, so the returned matrix carries proper fit-time (non-leaky)
         encodings; only the bin borders are held still, because the replayed
         split thresholds are bin INDICES into them. ``None`` fits a binner as
-        before, bit-identically."""
+        before, bit-identically.
+        """
         cat_ctx = CatTransformCache()
         num, codes = self._split_columns_fit(X, cat_features, cat_ctx)
+
         self._fit_gdiff(X, sample_weight, cat_ctx)
         cross = self._cross_block(X, cat_ctx, num=num)
         if cross.shape[1]:
@@ -405,9 +470,10 @@ class FeaturePreprocessor:
 
         feat = self._stack(num, encoded_blocks)
         self._build_feature_map(len(encode_targets))
+
         # Block order is [numeric | per-target TS]. Only true numeric columns
-        # carry an ordinal meaning usable by linear-leaf models; mark them so the
-        # booster can pick linear-term features (the TS blocks are excluded).
+        # carry an ordinal meaning a linear-leaf model can use, so mark them for
+        # the booster's linear-term selection; the TS blocks are excluded.
         self.is_numeric_binned_ = np.zeros(feat.shape[1], dtype=bool)
         self.is_numeric_binned_[:num.shape[1]] = True
 
@@ -417,19 +483,24 @@ class FeaturePreprocessor:
         else:
             self.binner_ = binner
             X_binned = binner.transform(feat)
+
         self.n_bins_ = self.binner_.n_bins_
         return X_binned
 
     def transform(self, X, cat_ctx=None):
-        """Apply the fitted binning + categorical encoding to new data.
+        """Apply the fitted binning and categorical encoding to new data.
+
         ``cat_ctx`` (internal) shares the per-column canonical factorizations
-        across the members of a bagged ensemble -- see CatTransformCache."""
+        across the members of a bagged ensemble -- see CatTransformCache.
+        """
         if cat_ctx is None:
             cat_ctx = CatTransformCache()
+
         num = self._numeric_block(X)
         cross = self._cross_block(X, cat_ctx, num=num)
         if cross.shape[1]:
             num = np.hstack([num, cross]) if num.shape[1] else cross
+
         encoded_blocks = []
         if self.cat_features_:
             codes = self._codes_for_transform(X, cat_ctx)
@@ -438,30 +509,31 @@ class FeaturePreprocessor:
                 codes = np.hstack([codes, combo_codes])
             for enc in self.encoders_:
                 encoded_blocks.append(enc.transform(codes))
+
         feat = self._stack(num, encoded_blocks)
         return self.binner_.transform(feat)
 
     @classmethod
     def from_base_with_cross(cls, base, cross_pairs, X, sample_weight=None):
-        """A fitted preprocessor equal to refitting ``base``'s configuration
-        with ``cross_pairs`` added, built by reusing ``base``'s fitted state.
+        """Refit ``base``'s configuration with ``cross_pairs`` added, cheaply.
 
-        Every fit artifact is computed independently per column -- category
-        maps, TS encodings, quantile borders, bin indices -- and appending
-        cross columns leaves the base columns' inputs untouched, so the base
-        results are shared by reference and only the cross columns are
-        computed here. Bit-identical to the from-scratch fit with the same
-        ``cross_pairs``; ``base`` must itself have no cross features.
+        Every fit artifact is per-column -- category maps, TS encodings,
+        quantile borders, bin indices -- and appending cross columns leaves the
+        base columns' inputs untouched, so base results are shared by reference
+        and only the cross columns are computed here. Bit-identical to the
+        from-scratch fit with the same ``cross_pairs``; ``base`` must itself
+        have no cross features.
 
         Returns ``(prep, cross_binner, cross_binned)``: the fitted augmented
         preprocessor, the binner covering only the cross columns (for binning
         eval-set cross blocks), and the binned cross block for ``X``'s rows.
         The caller splices ``cross_binned`` into the base binned matrix at
-        column offset ``len(base.num_features_)`` (stacked column order is
-        [numeric | cross | TS blocks]).
+        column offset ``len(base.num_features_)`` -- stacked column order is
+        [numeric | cross | TS blocks].
         """
         if base.cross_pairs:
             raise ValueError("base preprocessor already has cross features")
+
         prep = cls(base.max_bins, base.cat_smoothing, base.random_state,
                    base.cat_n_permutations, base.cat_combinations, cross_pairs)
         prep.cat_features_ = base.cat_features_
@@ -475,6 +547,8 @@ class FeaturePreprocessor:
         prep._fit_gdiff(X, sample_weight, cat_ctx)
         cross = prep._cross_block(X, cat_ctx)
         cross_binner = Binner(base.max_bins).fit(cross, sample_weight)
+
+        # Splice the cross borders in between the base numeric and TS blocks.
         nb = len(base.num_features_)
         bb = base.binner_
         binner = Binner(base.max_bins)
@@ -485,14 +559,17 @@ class FeaturePreprocessor:
         binner.bin_centers_ = (bb.bin_centers_[:nb] + cross_binner.bin_centers_
                                + bb.bin_centers_[nb:])
         binner._build_flat_borders()
+
         prep.binner_ = binner
         prep.n_bins_ = binner.n_bins_
         prep.is_numeric_binned_ = np.zeros(len(binner.borders_), dtype=bool)
         prep.is_numeric_binned_[:nb + cross.shape[1]] = True
         prep._build_feature_map(max(1, len(base.encoders_)))
+
         return prep, cross_binner, cross_binner.transform(cross)
 
     # ---- internals -----------------------------------------------------------
+
     @staticmethod
     def _stack(num, encoded_blocks):
         mats = [m for m in ([num] + encoded_blocks) if m.shape[1]]
@@ -502,15 +579,19 @@ class FeaturePreprocessor:
 
     def _build_feature_map(self, n_targets):
         """Map each combined-matrix column back to its original input column.
+
         Block order is [numeric | cross | per-target (cat + combo)]. Cross and
         combo columns map to the lower-indexed feature of their pair, so their
-        split gains fold into the right importance bucket."""
+        split gains fold into the right importance bucket.
+        """
         combo_orig = [min(i, j) for i, j in self.combo_pairs_]
         fmap = list(self.num_features_)
-        # gdiff is a recentering of its numeric parent i, so its gain belongs
-        # there; diff/prod keep the established min(i, j) convention.
+
+        # gdiff recenters its numeric parent i, so its gain belongs there;
+        # diff/prod keep the established min(i, j) convention.
         fmap.extend(i if op == "gdiff" else min(i, j)
                     for i, j, op in self.cross_pairs)
+
         for _ in range(n_targets):
             fmap.extend(self.cat_features_)
             fmap.extend(combo_orig)

--- a/chimeraboost/quantile_api.py
+++ b/chimeraboost/quantile_api.py
@@ -1,10 +1,9 @@
 """The multi-quantile estimator (benchmarks/QUANTILE_PLAN.md).
 
-Kept out of ``sklearn_api`` because it shares that module's input-validation
-helpers but almost none of its fit machinery: no loss family, no linear
-leaves, no cross features, no bagging, no full-data refit. It reuses the
-validation helpers by importing them, in the same flat, module-function style
-`sklearn_api` already uses.
+Kept out of ``sklearn_api`` because it shares that module's input validation
+but almost none of its fit machinery: no loss family, no linear leaves, no
+cross features, no bagging, no full-data refit. It imports the validation
+helpers and keeps the same flat, module-function style.
 """
 
 import numpy as np
@@ -29,41 +28,51 @@ def _resolve_quantiles(quantiles):
     """Validate and normalize the tau grid."""
     q = DEFAULT_QUANTILES if quantiles is None else np.asarray(
         quantiles, dtype=np.float64).ravel()
+
     if q.size == 0:
         raise ValueError("quantiles must contain at least one level.")
+
     if not np.all(np.isfinite(q)):
         raise ValueError(f"quantiles must all be finite; got {q!r}.")
+
     if np.any(q <= 0.0) or np.any(q >= 1.0):
         raise ValueError(
             f"quantiles must lie strictly inside (0, 1); got {q!r}.")
+
     if q.size > 1 and np.any(np.diff(q) <= 0.0):
         raise ValueError(
             "quantiles must be strictly ascending and unique; got "
             f"{q!r}. The column order of predict() is the order given here, "
             "so sort them first.")
+
     return np.ascontiguousarray(q)
 
 
 def _auto_min_child_weight(taus):
     """Leaf-size floor implied by the most extreme level on the grid.
 
-    A leaf estimating the 5% quantile from fewer than 20 rows is estimating it
-    from under one expected observation in that tail, which is noise. Scaling
-    with the grid keeps that honest for a user who asks for 0.01. It also
-    lands on 20 for the default grid, which happens to match LightGBM's
-    ``min_data_in_leaf`` -- convenient when comparing the two.
+    A leaf estimating the 5% quantile from fewer than 20 rows has under one
+    expected observation in that tail, which is noise. Scaling with the grid
+    keeps that honest for a user who asks for 0.01. On the default grid it
+    lands on 20, which matches LightGBM's ``min_data_in_leaf`` -- convenient
+    when comparing the two.
+
+    Notes
+    -----
+    ``1.0 - taus[-1]`` is not exact in binary. For a symmetric grid such as
+    (0.1, 0.5, 0.9) it lands a couple of ulps below 0.1, so the reciprocal
+    creeps just past 10 and ``ceil`` rounds the floor up to 11. Hence the snap
+    below. Genuine fractions -- the 3.33 of a (0.3, 0.7) grid, say -- are far
+    outside the tolerance and still round up, as intended.
     """
     edge = min(float(taus[0]), 1.0 - float(taus[-1]))
     inv = 1.0 / max(edge, 1e-9)
-    # `1.0 - taus[-1]` is not exact in binary: for a symmetric grid such as
-    # (0.1, 0.5, 0.9) it lands a couple of ulps BELOW 0.1, so the reciprocal
-    # creeps just past 10 and `ceil` rounds the floor up to 11. Snap to a whole
-    # number when we are within rounding noise of one -- genuine fractions like
-    # the 3.33 of a (0.3, 0.7) grid are far outside the tolerance and still
-    # round up, which is the intended behaviour.
+
+    # Snap to a whole number when only float error separates us from one.
     nearest = round(inv)
     if abs(inv - nearest) <= 1e-9 * max(1.0, abs(inv)):
         inv = float(nearest)
+
     return float(np.ceil(inv))
 
 
@@ -73,6 +82,7 @@ def _median_index(taus):
     K = taus.shape[0]
     if K == 1:
         return 0, 0.0
+
     j = int(np.searchsorted(taus, 0.5))
     if j < K and abs(taus[j] - 0.5) < 1e-12:
         return j, 0.0
@@ -80,6 +90,7 @@ def _median_index(taus):
         return 0, 0.0
     if j >= K:
         return K - 1, 0.0
+
     lo, hi = taus[j - 1], taus[j]
     return j - 1, float((0.5 - lo) / (hi - lo))
 
@@ -94,37 +105,35 @@ def _centre(Q, mi, mw):
 def _cqr_scales(Q, y, taus, mi, mw):
     """Conformalized quantile regression as a per-level SCALE about the median.
 
-    For each symmetric pair the conformity score is how far out the point sat
+    For each symmetric pair the conformity score is how far out the point sat,
     in units of the predicted half-interval,
 
         E_i = max((c_i - y_i) / (c_i - q_lo,i), (y_i - c_i) / (q_hi,i - c_i))
 
-    with c the predicted median, and the calibrated factor is that score's
+    with c the predicted median. The calibrated factor is that score's
     ``ceil((n+1)(1-alpha))``-th order statistic -- the standard conformal rank
     (Romano, Patterson & Candes 2019), which gives distribution-free marginal
-    coverage on exchangeable data. Prediction then returns
-    ``c + s * (q - c)``.
+    coverage on exchangeable data. Prediction then returns ``c + s * (q - c)``.
 
-    Why scaling rather than the usual additive widening. The scores this is
-    applied to are already rearranged, so every deviation from the median is
-    sign-correct and ordered outward; multiplying it by a non-negative factor
-    cannot reorder anything, for any row. An additive correction has no such
-    property -- one that SHRINKS an interval is a non-monotone offset vector
-    and can reorder the grid on its own. Scaling also happens to be the
-    correction with the right degree of freedom, since a shrunk fit can be
-    over- or under-dispersed and a factor moves in both directions.
+    Why scale rather than widen additively. These scores are already
+    rearranged, so every deviation from the median is sign-correct and ordered
+    outward, and multiplying by a non-negative factor cannot reorder any row.
+    An additive correction can: one that SHRINKS an interval is a non-monotone
+    offset vector and can reorder the grid on its own. A factor also carries
+    the right degree of freedom, since a shrunk fit can be over- or
+    under-dispersed and a factor moves both ways.
 
     Two constraints are enforced:
 
-    * Outer intervals get a factor at least as large as the ones nested inside
-      them, which is what keeps the rescaled grid ordered.
+    * An outer interval's factor is at least that of the ones nested inside
+      it, which is what keeps the rescaled grid ordered.
     * The rank must exist: ``ceil((n+1)(1-alpha)) <= n`` needs
       ``n >= (1-alpha)/alpha``. Below that the interval is vacuous, and this
       raises rather than quietly returning an uncalibrated model.
 
     Only symmetric pairs (t and 1-t both on the grid) can be calibrated
-    directly; a grid with none raises. Unpaired levels on asymmetric grids
-    get a factor interpolated by distance from the median across the paired
+    directly; a grid with none raises. Unpaired levels on asymmetric grids get
+    a factor interpolated by distance from the median across the paired
     factors -- uncertified, but it keeps the factor profile monotone outward,
     which preserves the non-crossing guarantee.
     """
@@ -132,14 +141,17 @@ def _cqr_scales(Q, y, taus, mi, mw):
     s = np.ones(K)
     n = y.shape[0]
     c = _centre(Q, mi, mw)
+
     # Relative floor for the half-widths: a row whose predicted interval has
     # collapsed to a point would otherwise divide by zero.
     eps = 1e-9 * max(float(np.mean(Q[:, -1] - Q[:, 0])), 1e-12)
+
     pairs = []
     for k in range(K // 2):
         j = K - 1 - k
         if abs((taus[k] + taus[j]) - 1.0) > 1e-9:
             continue                       # not a symmetric pair
+
         alpha = 1.0 - (taus[j] - taus[k])
         need = int(np.ceil((1.0 - alpha) / max(alpha, 1e-12)))
         if n < need:
@@ -149,30 +161,31 @@ def _cqr_scales(Q, y, taus, mi, mw):
                 f"coverage {1 - alpha:.0%}), but the calibration fold holds "
                 f"only {n}. Raise calibration_fraction, supply more data, or "
                 "drop the extreme levels from `quantiles`.")
+
         E = np.maximum((c - y) / np.maximum(c - Q[:, k], eps),
                        (y - c) / np.maximum(Q[:, j] - c, eps))
         rank = int(np.ceil((n + 1) * (1.0 - alpha)))
         pairs.append([k, j, max(0.0, float(np.sort(E)[min(rank, n) - 1]))])
+
     if not pairs:
         raise ValueError(
             "conformalize=True needs at least one symmetric pair of quantile "
             "levels (t and 1-t both on the grid) to calibrate against; got "
             f"{list(np.round(taus, 6))}. Add symmetric levels or set "
             "conformalize=False.")
-    # Outer factor >= inner factor. The deviations from the median already
-    # grow outward, so a non-increasing factor toward the centre keeps their
-    # product monotone -- and calibration naturally lands this way, since an
+
+    # Outer factor >= inner factor. Deviations from the median already grow
+    # outward, so a factor profile that never rises toward the centre keeps
+    # their product monotone. Calibration tends to land here anyway: an
     # over-dispersed model needs the most shrinking near the median.
     for i in range(len(pairs) - 2, -1, -1):
         pairs[i][2] = max(pairs[i][2], pairs[i + 1][2])
     for k, j, sp in pairs:
         s[k] = s[j] = sp
-    # Unpaired levels (custom asymmetric grids) get a factor interpolated by
-    # their distance from the median across the paired levels' factors,
-    # clamped at the ends. Leaving them at 1.0 breaks the non-crossing
-    # guarantee: a shrunk outer pair jumps across an unshrunk inner level.
-    # Interpolation keeps the factor profile monotone outward from the
-    # centre, which is exactly the condition that preserves ordering.
+
+    # Unpaired levels (custom asymmetric grids) are interpolated as the
+    # docstring describes. Leaving them at 1.0 would break non-crossing: a
+    # shrunk outer pair jumps across an unshrunk inner level.
     paired = {k for k, _, _ in pairs} | {j for _, j, _ in pairs}
     if len(paired) < K:
         dp = np.array([0.5 - taus[k] for k, _, _ in pairs])[::-1]
@@ -180,6 +193,7 @@ def _cqr_scales(Q, y, taus, mi, mw):
         for k in range(K):
             if k not in paired:
                 s[k] = float(np.interp(abs(taus[k] - 0.5), dp, sp))
+
     return s
 
 
@@ -187,14 +201,15 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
     """Gradient boosting for a whole predictive distribution at once.
 
     One booster, one tree structure per round, and a K-vector in every leaf,
-    holding one entry per level in ``quantiles``. Against fitting one quantile
-    regressor per level this is roughly K times less split-search work, and
-    the predictions cannot cross: the 30% quantile is never returned above the
-    70%. Ordering is enforced per row by monotone rearrangement of the
-    delivered scores, which is exact for every row and holds at every
-    intermediate stage of ``staged_predict`` too. Rearrangement cannot cost
-    accuracy -- sorting a crossing quantile curve never increases pinball loss
-    at any level (Chernozhukov, Fernandez-Val & Galichon 2010).
+    one entry per level in ``quantiles``. Against one quantile regressor per
+    level that is roughly K times less split-search work, and the predictions
+    cannot cross: the 30% quantile is never returned above the 70%.
+
+    Ordering is enforced per row by monotone rearrangement of the delivered
+    scores. It is exact for every row and holds at every intermediate stage of
+    ``staged_predict``. Rearrangement cannot cost accuracy -- sorting a
+    crossing quantile curve never increases pinball loss at any level
+    (Chernozhukov, Fernandez-Val & Galichon 2010).
 
     Deliberately not a ``RegressorMixin``: ``predict`` returns a matrix, so the
     inherited ``score`` (which assumes one number per row) would be wrong.
@@ -208,17 +223,16 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
         Ascending, unique levels strictly inside (0, 1). Default
         0.05, 0.10, ... 0.95. Column k of ``predict`` is level k.
     split_projection : {"rotate", "sum", "gram"}
-        How the K gradient columns collapse into the single vector the tree
-        grower accepts. ``"rotate"`` cycles a location and a spread contrast,
-        two rounds of the former per round of the latter, and is the default
-        because it measured best; ``"sum"`` is the literal channel sum, which
-        is blind to spread entirely; ``"gram"`` picks the strongest contrast
-        each round and measured no better than cycling. See
-        `booster._fixed_contrasts`.
+        How split gain is scored across the quantile levels. Keep the default
+        unless you are experimenting. ``"rotate"`` alternates a location and a
+        spread contrast, two location rounds per spread round, and measured
+        best. ``"sum"`` adds the levels up, which makes it blind to a change in
+        spread. ``"gram"`` picks the strongest contrast each round and measured
+        no better than rotating.
     exact_splits : bool
-        Score splits on the exact summed-across-level gain instead of a
-        projection. More faithful, and costs K histogram channels per feature
-        instead of one -- a reference arm, not a working default.
+        Score splits exactly across every level instead of on a projection.
+        More faithful, but the fit gets slower and more memory-hungry as the
+        grid grows -- a reference setting, not one for routine use.
     conformalize : bool
         Calibrate the intervals by conformalized quantile regression. Carves
         ``calibration_fraction`` of the rows off BEFORE the early-stopping
@@ -294,6 +308,7 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
         `ChimeraBoostRegressor.fit`."""
         cat_features = _resolve_cat_features(self, cat_features)
         cat_features = _resolve_cat_feature_names(cat_features, X)
+
         _validate_hyperparams(self)
         if self.split_projection not in ("rotate", "sum", "gram"):
             raise ValueError(
@@ -302,11 +317,13 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
         if not 0.0 < self.calibration_fraction < 1.0:
             raise ValueError("calibration_fraction must be in (0, 1); got "
                              f"{self.calibration_fraction!r}.")
+
         y = _validate_fit_input(self, X, y, cat_features, sample_weight,
                                 classification=False)
         if eval_set is not None:
             _check_eval_set(eval_set, self.n_features_in_)
             _check_feature_names_match(self, eval_set[0])
+
         taus = _resolve_quantiles(self.quantiles)
         self.quantiles_ = taus
         self._median_idx_ = _median_index(taus)
@@ -329,6 +346,7 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
                     f"{len(y)} rows at calibration_fraction="
                     f"{self.calibration_fraction}. Supply more rows or lower "
                     "the fraction.")
+
             keep, cal_idx = split
             cal = (X[cal_idx], y[cal_idx])
             X, y = X[keep], y[keep]
@@ -351,6 +369,7 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
                 X, y = X[tr], y[tr]
                 if sample_weight is not None:
                     sample_weight = sample_weight[tr]
+
         es_rounds = self.early_stopping_rounds
         if not es_active:
             es_rounds = None
@@ -360,6 +379,7 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
         depth = 4 if self.depth is None else self.depth
         mcw = (_auto_min_child_weight(taus) if self.min_child_weight is None
                else self.min_child_weight)
+
         cat_combos = self.cat_combinations
         if cat_combos is None:
             cat_combos = _auto_cat_combinations(
@@ -380,10 +400,11 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
             quantize_gradients=self.quantize_gradients,
             # Pinned to the historical flat rate. The size fade became the
             # booster default in 0.30.0 on RMSE and Brier evidence
-            # (benchmarks/SMALLDATA_PLAN.md); it was never measured against
-            # pinball loss, and inheriting it here would ship an unmeasured
-            # default change to the quantile path. Measure before flipping.
+            # (benchmarks/SMALLDATA_PLAN.md), but was never measured against
+            # pinball loss; inheriting it here would ship an unmeasured default
+            # change to the quantile path. Measure before flipping.
             adaptive_learning_rate=False)
+
         self.model_.fit(X, y, cat_features=cat_features, eval_set=eval_set,
                         sample_weight=sample_weight, callbacks=callbacks)
 
@@ -392,6 +413,7 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
             mi, mw = self._median_idx_
             self.conformal_scale_ = _cqr_scales(
                 self.model_.predict_raw(cal[0]), cal[1], taus, mi, mw)
+
         return self
 
     def _conformalize(self, Q):
@@ -399,6 +421,7 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
         no-op (all factors 1) unless ``conformalize=True``."""
         if np.all(self.conformal_scale_ == 1.0):
             return Q
+
         mi, mw = self._median_idx_
         c = _centre(Q, mi, mw)[:, None]
         return c + self.conformal_scale_[None, :] * (Q - c)
@@ -411,20 +434,21 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
 
         ``kind="interval"`` returns (n_samples, 2): the central ``1 - alpha``
         interval, read off the ``alpha/2`` and ``1 - alpha/2`` levels, which
-        must both be on the grid. No interpolation -- an interval the model
-        was not fitted for is an error, not a guess.
+        must both be on the grid. No interpolation -- an interval the model was
+        not fitted for is an error, not a guess.
 
         ``kind="mean"`` returns (n_samples,), the integral of the quantile
-        function over tau: trapezoid across the grid plus flat extension of
-        the edge levels out to 0 and 1. The flat extension is the honest
-        reading of a finite grid, assuming nothing about tails the model never
-        estimated.
+        function over tau: trapezoid across the grid plus flat extension of the
+        edge levels out to 0 and 1. The flat extension is the honest reading of
+        a finite grid, assuming nothing about tails the model never estimated.
         """
         Xv = _check_predict_input(self, X)
         Q = self._conformalize(
             self.model_.predict_raw(X if Xv is None else Xv))
+
         if kind == "quantiles":
             return Q
+
         if kind == "interval":
             if alpha is None:
                 raise ValueError(
@@ -432,6 +456,7 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
                     "alpha=0.1 for a 90% interval.")
             if not 0.0 < alpha < 1.0:
                 raise ValueError(f"alpha must be in (0, 1); got {alpha!r}.")
+
             lo, hi = alpha / 2.0, 1.0 - alpha / 2.0
             taus = self.quantiles_
             i = int(np.argmin(np.abs(taus - lo)))
@@ -442,9 +467,12 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
                     "not on the fitted grid "
                     f"{np.array2string(taus, precision=4)}. Refit with those "
                     "levels in `quantiles`.")
+
             return np.column_stack([Q[:, i], Q[:, j]])
+
         if kind == "mean":
             return self._mean_from_quantiles(Q)
+
         raise ValueError(
             f'kind must be "quantiles", "interval" or "mean"; got {kind!r}.')
 
@@ -459,10 +487,11 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
 
     def staged_predict(self, X):
         """Yield the (n, K) quantile matrix after each successive tree. The
-        conformal rescaling, being a post-fit transform, is applied at every
-        stage so the last one equals ``predict``."""
+        conformal rescaling is a post-fit transform, so it is applied at every
+        stage and the last one equals ``predict``."""
         Xv = _check_predict_input(self, X)
         X = X if Xv is None else Xv
+
         for staged in self.model_.staged_predict_raw(X):
             yield self._conformalize(staged)
 

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -12,12 +12,15 @@ from sklearn.base import BaseEstimator, RegressorMixin, ClassifierMixin
 
 
 def _fit_temperature(raw, y, multiclass, sample_weight=None):
-    """Learn the scalar T > 0 minimizing validation log loss of sigmoid(raw/T)
-    (binary) or softmax(raw/T) (multiclass). Dividing logits by T is monotonic,
-    so predictions are unchanged â€” only their probabilities are recalibrated.
-    `y` is the 0/1 label (binary) or the class index (multiclass).
-    `sample_weight` weights the validation log loss, so a zero-weight holdout
-    row cannot steer the temperature (the sample_weight contract)."""
+    """Learn the scalar T > 0 that minimizes validation log loss.
+
+    The calibrated score is sigmoid(raw/T) for binary, softmax(raw/T) for
+    multiclass. Dividing by T is monotonic, so predictions are unchanged -- only
+    the probabilities are recalibrated. ``y`` is the 0/1 label (binary) or the
+    class index (multiclass). ``sample_weight`` weights the validation log loss,
+    so a zero-weight holdout row cannot steer the temperature (the sample_weight
+    contract).
+    """
     from scipy.optimize import minimize_scalar
 
     raw = np.asarray(raw, dtype=np.float64)
@@ -26,6 +29,7 @@ def _fit_temperature(raw, y, multiclass, sample_weight=None):
         w = np.asarray(sample_weight, dtype=np.float64)
         if not np.any(w > 0):
             return 1.0
+
     if multiclass:
         rows = np.arange(raw.shape[0])
 
@@ -62,34 +66,41 @@ QUALITY_NAMES = {1: "fast", 2: "balanced", 3: "accurate",
 
 
 def _quality_overrides(estimator, level):
-    """The parameters ``quality=level`` pins on this estimator."""
+    """The parameters ``quality=level`` pins on this estimator.
+
+    Rung 1 buys out the model-selection search: one booster fit instead of the
+    default's two-to-four, and no full-data refit on top. Only the regressor pins
+    linear_leaves, where None means "audition const vs linear" -- exactly the
+    search this rung declines to pay for. On the classifier None is already a
+    free auto rule (on for binary, off for multiclass, where an explicit True
+    raises), so it is left alone.
+
+    Rungs 4 and 5 sit on top of the plain defaults, NOT on top of rung 3:
+    refit_full is a deliberate no-op inside bag members (their out-of-bag rows
+    are already an eval set), so the rungs do not stack. See REFIT_PLAN.md.
+    """
     if level == 1:
-        # Buy out the model-selection search: one booster fit instead of the
-        # default's two-to-four, and skip the full-data refit on top. Only
-        # the regressor needs linear_leaves pinned -- there None means
-        # "audition const vs linear", which is precisely the search this rung
-        # declines to pay for. On the classifier None is already an auto rule
-        # (on for binary, off for multiclass, where an explicit True raises),
-        # and it costs no extra fit, so leave it alone.
         ov = {"cross_features": False, "refit_full": False}
         if estimator._QUALITY_PINS_LINEAR_LEAVES:
             ov["linear_leaves"] = True
         return ov
+
     if level == 2:
         # The search, without the full-data refit the default now performs.
         return {"refit_full": False}
+
     if level == 3:
-        # The default. "replay" rather than True: it reaches the same accuracy
-        # for about two thirds of the fit (benchmarks/REPLAY_PLAN.md). Pass
-        # refit_full=True explicitly for the from-scratch refit.
+        # The default. "replay" rather than True: same accuracy for about two
+        # thirds of the fit (benchmarks/REPLAY_PLAN.md). Pass refit_full=True
+        # for the from-scratch refit.
         return {"refit_full": "replay"}
-    # Bagging sits on top of the plain defaults, NOT on top of rung 3:
-    # refit_full is a deliberate no-op inside members (their OOB rows are
-    # already an eval set), so the rungs do not stack -- see REFIT_PLAN.md.
+
     if level == 4:
         return {"n_ensembles": 5}
+
     if level == 5:
         return {"n_ensembles": 8}
+
     return {}
 
 
@@ -110,6 +121,7 @@ def _quality_applied(estimator):
     if level is None:
         yield
         return
+
     overrides = _quality_overrides(estimator, int(level))
     clashes = {k: getattr(estimator, k) for k, v in overrides.items()
                if getattr(estimator, k) != v
@@ -122,9 +134,11 @@ def _quality_applied(estimator):
             + ", ".join(f"{k}={v}" for k, v in clashes.items())
             + " you passed is ignored. Drop quality to set these yourself.",
             UserWarning, stacklevel=3)
+
     saved = {k: getattr(estimator, k) for k in overrides}
     for k, v in overrides.items():
         setattr(estimator, k, v)
+
     try:
         yield
     finally:
@@ -135,13 +149,14 @@ def _quality_applied(estimator):
 def _validate_hyperparams(estimator):
     """Reject malformed constructor parameters with clear, named errors.
 
-    Called at the start of ``fit`` (sklearn's recommended place for parameter
-    validation -- never in ``__init__``). Without this, bad values either fail
-    cryptically deep in numba (e.g. ``depth=-1`` -> "negative shift count"),
-    silently produce a broken model (``learning_rate=-0.1`` diverges to garbage;
-    ``n_estimators=0`` builds an empty model), or OOM (``depth=30`` allocates a
-    2**30-leaf histogram). ``None`` is left to the documented per-parameter
-    default resolution and is not rejected here.
+    Called at the start of ``fit`` -- sklearn's recommended place for parameter
+    validation, never ``__init__``.
+
+    Without it, bad values fail cryptically deep in numba (``depth=-1`` ->
+    "negative shift count"), silently produce a broken model
+    (``learning_rate=-0.1`` diverges to garbage, ``n_estimators=0`` builds an
+    empty model), or OOM (``depth=30`` allocates a 2**30-leaf histogram).
+    ``None`` is left to the documented per-parameter default resolution.
     """
     p = estimator.get_params()
 
@@ -176,36 +191,44 @@ def _validate_hyperparams(estimator):
 
     _pos_int("n_estimators")
     _pos_int("cat_n_permutations")
+
     # None = the classifier's auto default (resolved to 3 at fit); the regressor
     # passes a concrete int.
     _pos_int("leaf_estimation_iterations", allow_none=True)
-    # depth: a depth-d tree allocates 2**d leaves in the histogram buffer, so an
+
+    # A depth-d tree allocates 2**d leaves in the histogram buffer, so an
     # unbounded depth OOMs. 16 matches CatBoost's documented maximum. None is the
     # regressor's loss-adaptive default, resolved at fit.
     v = p.get("depth")
     if v is not None and not (isinstance(v, (int, np.integer))
                               and not isinstance(v, bool) and 1 <= v <= 16):
         raise ValueError(f"depth must be an integer in [1, 16] or None; got {v!r}.")
+
     _in_range("max_bins", 2, 65534)
     _in_range("learning_rate", 0.0, np.inf, lo_incl=False, allow_none=True)
     _in_range("l2_leaf_reg", 0.0, np.inf)
     _in_range("subsample", 0.0, 1.0, lo_incl=False)
     _in_range("colsample", 0.0, 1.0, lo_incl=False, allow_none=True)
+
     # cat_smoothing is a Bayesian pseudocount in the ordered-TS denominator
     # (count + a); a=0 makes the first occurrence of every category divide 0/0.
     _in_range("cat_smoothing", 0.0, np.inf, lo_incl=False)
+
     _in_range("linear_lambda", 0.0, np.inf)
     _in_range("min_child_weight", 0.0, np.inf, allow_none=True)
     _in_range("validation_fraction", 0.0, 1.0, lo_incl=False, hi_incl=False)
     _in_range("early_stopping_rounds", 1, np.inf, allow_none=True)
     _in_range("selection_rounds", 1, np.inf, allow_none=True)
+
     if p.get("n_ensembles") is not None:
         _pos_int("n_ensembles")
     _in_range("max_samples", 0.0, 1.0, lo_incl=False)
+
     v = p.get("refit_full")
     if v is not None and v != "replay" and not isinstance(v, (bool, np.bool_)):
         raise ValueError(
             f'refit_full must be True, False, "replay" or None; got {v!r}.')
+
     v = p.get("quality")
     if v is not None:
         if isinstance(v, (bool, np.bool_)) or v not in QUALITY_NAMES:
@@ -213,6 +236,7 @@ def _validate_hyperparams(estimator):
                 "quality must be None or one of "
                 + ", ".join(f"{k} ({n})" for k, n in QUALITY_NAMES.items())
                 + f"; got {v!r}.")
+
     # Regressor-only loss / alpha (the classifier picks its loss automatically).
     if "loss" in p:
         loss = p["loss"]
@@ -223,6 +247,7 @@ def _validate_hyperparams(estimator):
                 raise ValueError(
                     f"loss must be one of {known} or a custom objective "
                     f"instance; got {loss!r}.")
+
             if loss == "Quantile":
                 _in_range("alpha", 0.0, 1.0, lo_incl=False, hi_incl=False)
             if loss == "Huber":
@@ -231,9 +256,9 @@ def _validate_hyperparams(estimator):
                 _in_range("tweedie_variance_power", 1.0, 2.0,
                           lo_incl=False, hi_incl=False)
         else:
-            # Custom objective: an instance implementing the losses.py
-            # protocol (subclass chimeraboost.CustomObjective for the
-            # optional-method defaults).
+            # Custom objective: an instance implementing the losses.py protocol
+            # (subclass chimeraboost.CustomObjective for the optional-method
+            # defaults).
             missing = [a for a in ("init", "grad_hess", "eval")
                        if not callable(getattr(loss, a, None))]
             if missing:
@@ -242,6 +267,7 @@ def _validate_hyperparams(estimator):
                     f"init/grad_hess/eval (missing: {missing}); subclass "
                     "chimeraboost.CustomObjective. Got "
                     f"{loss!r}.")
+
     if p.get("eval_metric") is not None and not callable(p["eval_metric"]):
         raise ValueError(
             "eval_metric must be a callable metric(y_true, y_pred"
@@ -250,43 +276,51 @@ def _validate_hyperparams(estimator):
 
 
 def _resolve_cat_features(estimator, cat_features):
-    """Resolve the effective cat_features: the ``fit`` argument when given,
-    otherwise the ``cat_features`` constructor argument. The fit argument wins so
-    a one-off call can override, while the constructor form lets sklearn meta-
-    estimators (GridSearchCV/Pipeline) carry it -- a fit-only kwarg cannot. Never
-    mutates ``estimator.cat_features`` (sklearn forbids fit changing init params)."""
+    """The effective cat_features: the ``fit`` argument if given, else the
+    constructor argument.
+
+    The fit argument wins so a one-off call can override. The constructor form
+    exists so sklearn meta-estimators (GridSearchCV/Pipeline) can carry it, which
+    a fit-only kwarg cannot. Never mutates ``estimator.cat_features`` -- sklearn
+    forbids ``fit`` changing init params.
+    """
     if cat_features is not None:
         return cat_features
     return getattr(estimator, "cat_features", None)
 
 
 def _resolve_cat_feature_names(cat_features, X):
-    """Map any column *names* in ``cat_features`` to integer positions using X's
+    """Map column *names* in ``cat_features`` to integer positions using X's
     column metadata, leaving integer indices untouched.
 
-    Lets a user mark categoricals the same way LightGBM/CatBoost do -- either by
-    position (``cat_features=[0, 2]``) or by name (``cat_features=["city",
-    "brand"]``), or a mix. Names are resolved against the DataFrame columns at
-    fit time, so order changes are handled by the existing predict-time feature-
-    name check. Returns ``None`` unchanged; returns the original object when it
-    holds no strings (the downstream integer validation then applies)."""
+    Categoricals can be marked the way LightGBM/CatBoost allow: by position
+    (``[0, 2]``), by name (``["city", "brand"]``), or a mix. Names resolve
+    against the DataFrame columns at fit time, so a later column reordering is
+    caught by the predict-time feature-name check. ``None`` passes through
+    unchanged; a name-free sequence comes back as a plain list for downstream
+    integer validation.
+    """
     if cat_features is None:
         return None
+
     try:
         items = list(cat_features)
     except TypeError:
         return cat_features  # not iterable; let downstream validation report it
+
     if not any(isinstance(c, str) for c in items):
-        # Return the plain list, not the original object: a numpy array here
-        # would crash every downstream ``if cat_features:`` truthiness check
-        # with "ambiguous truth value" before validation can name the problem.
+        # A plain list, not the original object: a numpy array here crashes
+        # every downstream ``if cat_features:`` check with "ambiguous truth
+        # value" before validation can name the problem.
         return items
+
     names = _extract_feature_names(X)
     if names is None:
         raise ValueError(
             "cat_features contains column names (strings), but X has no column "
             "names to resolve them against; pass integer indices instead, or "
             "fit on a DataFrame.")
+
     name_to_idx = {n: i for i, n in enumerate(names)}
     resolved = []
     for c in items:
@@ -303,38 +337,42 @@ def _resolve_cat_feature_names(cat_features, X):
 
 def _check_eval_set(eval_set, n_features, classification=False):
     """Validate a user-passed ``eval_set`` up front with a named error instead of
-    a cryptic IndexError/broadcast failure deep in the booster."""
-    # 2-tuple is the documented form; a 3rd element is optional per-row
-    # validation weights (used internally for weight-aware auto-split / bagged
-    # OOB early stopping, so zero-weight rows don't score the metric).
+    a cryptic IndexError or broadcast failure deep in the booster."""
+    # A 2-tuple is the documented form. The optional 3rd element is per-row
+    # validation weights, used internally by the weight-aware auto-split and by
+    # bagged OOB early stopping so zero-weight rows don't score the metric.
     if not (isinstance(eval_set, (tuple, list)) and len(eval_set) in (2, 3)):
         raise ValueError(
             "eval_set must be a (X_val, y_val) tuple "
             "(optionally (X_val, y_val, sample_weight_val)).")
+
     Xv, yv = eval_set[0], eval_set[1]
     shape = getattr(Xv, "shape", None)
     if shape is None or len(shape) != 2:
         shape = np.asarray(Xv, dtype=object).shape
+
     nfv = shape[1] if len(shape) == 2 else None
     if nfv != n_features:
         raise ValueError(
             f"eval_set X has {nfv} features, but the training data has "
             f"{n_features}; they must match.")
+
     if len(yv) != shape[0]:
         raise ValueError(
             f"eval_set X and y have inconsistent lengths: {shape[0]} vs "
             f"{len(yv)}.")
+
     if len(eval_set) == 3 and eval_set[2] is not None \
             and len(eval_set[2]) != shape[0]:
         raise ValueError(
             f"eval_set sample_weight has length {len(eval_set[2])}, but "
             f"eval_set X has {shape[0]} rows; they must match.")
+
     if not classification:
-        # Training y is rejected on NaN/inf, but a non-finite eval y used to
-        # sail through and turn every validation score into NaN -- early
-        # stopping then silently kept round 0 and the model shipped with one
-        # tree. Classifier labels are validated by _check_eval_labels instead
-        # (string labels do not cast to float).
+        # Past bug: training y was rejected on NaN/inf but eval y was not, so a
+        # non-finite eval y turned every validation score into NaN, early
+        # stopping kept round 0, and the model shipped with one tree. Classifier
+        # labels go to _check_eval_labels instead -- strings don't cast to float.
         yv_arr = np.asarray(yv)
         if yv_arr.dtype.kind in "fc" and not np.isfinite(
                 yv_arr.astype(np.float64, copy=False)).all():
@@ -353,12 +391,14 @@ def _check_eval_labels(eval_set, y):
     """
     classes = np.unique(np.asarray(y))
     yv = np.unique(np.asarray(eval_set[1]))
+
     try:
         unseen = np.setdiff1d(yv, classes)
     except TypeError:   # mixed un-orderable label types
         seen = set(classes.tolist())
         unseen = np.array([v for v in yv.tolist() if v not in seen],
                           dtype=object)
+
     if unseen.size:
         raise ValueError(
             f"eval_set contains label(s) not present in y: {unseen.tolist()}. "
@@ -366,38 +406,46 @@ def _check_eval_labels(eval_set, y):
 
 
 def _is_numeric_dtype(dt):
-    """True if a column dtype is float-castable, across numpy / pandas /
-    polars. Bool counts: it casts to 0/1 cleanly, so a bool column must not
-    be named in the "add these to cat_features" error guidance."""
+    """True if a column dtype is float-castable, across numpy / pandas / polars.
+
+    Bool counts: it casts to 0/1 cleanly, so a bool column must not be named in
+    the "add these to cat_features" error guidance.
+    """
     try:
         npdt = np.dtype(dt)
         return bool(np.issubdtype(npdt, np.number) or npdt == np.bool_)
     except TypeError:
         pass  # not a numpy-castable dtype (e.g. a polars DataType object)
+
     is_num = getattr(dt, "is_numeric", None)  # polars DataType
     if callable(is_num):
         try:
             return bool(is_num())
         except Exception:
             pass
+
     s = str(dt).lower()
     return (any(k in s for k in ("int", "float", "uint", "double", "decimal"))
             and "object" not in s) or s in ("bool", "boolean")
 
 
 def _describe_nonnumeric_columns(X):
-    """Name the non-numeric columns of a DataFrame-like X (pandas/polars) so a
-    user who forgot ``cat_features`` gets "column 'city' (index 2)" instead of
-    a bare ``could not convert string to float: 'NYC'``. Returns [] for inputs
-    without column metadata (plain ndarrays)."""
+    """Name the non-numeric columns of a DataFrame-like X (pandas/polars).
+
+    A user who forgot ``cat_features`` then gets "column 'city' (index 2)"
+    instead of a bare ``could not convert string to float: 'NYC'``. Returns []
+    for input without column metadata (a plain ndarray).
+    """
     cols = getattr(X, "columns", None)
     dtypes = getattr(X, "dtypes", None)
     if cols is None or dtypes is None:
         return []
+
     try:
         col_list, dtype_list = list(cols), list(dtypes)
     except TypeError:
         return []
+
     return [f"'{c}' (index {i})"
             for i, (c, dt) in enumerate(zip(col_list, dtype_list))
             if not _is_numeric_dtype(dt)]
@@ -407,16 +455,20 @@ def _member_oob_eval_indices(idx, n, groups):
     """Out-of-bag row indices usable as a bag member's early-stopping eval set.
 
     Without ``groups`` that is every row outside the member's sample. With
-    ``groups`` it is further restricted to rows whose group never appears in
-    the sample -- otherwise the member's stopping signal comes from rows
-    correlated with its training rows, exactly the leakage the ``groups``
-    argument promises to prevent. Because grouped members draw whole groups
-    (``_member_sample_indices``), the excluded-for-straddling set is normally
-    just the rare-class donor's group; before group draws existed, a typical
-    80% row draw touched essentially every group and this returned zero rows
-    on real data, silently disabling OOB early stopping. May still return an
-    empty array (e.g. a cluster bootstrap that drew every group); the caller
-    then falls back to the member's own auto-split, which is group-aware."""
+    ``groups`` it is further restricted to rows whose group never appears in the
+    sample -- otherwise the member's stopping signal comes from rows correlated
+    with its training rows, exactly the leakage ``groups`` promises to prevent.
+
+    Grouped members draw whole groups (``_member_sample_indices``), so the rows
+    excluded for straddling are normally just the rare-class donor's group.
+    Before group draws existed, a typical 80% row draw touched essentially every
+    group, this returned zero rows on real data, and OOB early stopping was
+    silently disabled.
+
+    May still return an empty array (say a cluster bootstrap that drew every
+    group); the caller then falls back to the member's own auto-split, which is
+    group-aware.
+    """
     oob_mask = np.ones(n, dtype=np.bool_)
     oob_mask[idx] = False
     if groups is not None:
@@ -429,27 +481,29 @@ def _member_sample_indices(n, ms, seed, groups):
 
     Without ``groups``: ``ms`` of the ``n`` rows drawn without replacement
     ("subagging"), or a classic full-size with-replacement bootstrap at
-    ``ms >= 1.0`` -- byte-identical to the draws made before this helper
-    existed (same rng construction, same single call).
+    ``ms >= 1.0``. Byte-identical to the draws made before this helper existed
+    (same rng construction, same single call).
 
-    With ``groups``: the same recipe applied to whole groups -- ``ms`` of the
-    groups without replacement (each contributing all of its rows), or a
-    full-size cluster bootstrap of groups at ``ms >= 1.0``. Drawing rows
-    would leave essentially every group straddling the sample, which both
-    leaks group structure into the member AND empties the group-disjoint OOB
-    set `_member_oob_eval_indices` builds. At least one group is always held
-    out (the draw is capped at ``n_groups - 1``), so the OOB eval set is
-    non-empty by construction. ``ms`` counts groups, not rows, so a member's
-    row count varies with the sizes of the groups it drew. A single all-rows
-    group falls back to the row draw: there is nothing to hold out."""
+    With ``groups``: the same recipe over whole groups -- ``ms`` of the groups
+    without replacement (each contributing all of its rows), or a full-size
+    cluster bootstrap of groups at ``ms >= 1.0``. Drawing rows instead would
+    leave essentially every group straddling the sample, which leaks group
+    structure into the member AND empties the group-disjoint OOB set
+    ``_member_oob_eval_indices`` builds. The draw is capped at ``n_groups - 1``,
+    so at least one group is always held out and the OOB eval set is non-empty
+    by construction. ``ms`` counts groups, not rows, so a member's row count
+    varies with the sizes of the groups it drew. A single all-rows group falls
+    back to the row draw: there is nothing to hold out.
+    """
     rng = np.random.default_rng(seed)
+
     if groups is not None:
         ug = np.unique(groups)
         if ug.size >= 2:
             if ms >= 1.0:
-                # Cluster bootstrap: n_groups draws with replacement; a group
-                # drawn twice appears twice (duplicates are integer weights,
-                # exactly like the row bootstrap).
+                # Cluster bootstrap: n_groups draws with replacement. A group
+                # drawn twice appears twice -- duplicates are integer weights,
+                # exactly like the row bootstrap.
                 drawn = rng.integers(0, ug.size, size=ug.size)
                 order = np.argsort(groups, kind="stable")
                 sg = groups[order]
@@ -457,9 +511,11 @@ def _member_sample_indices(n, ms, seed, groups):
                 ends = np.searchsorted(sg, ug, side="right")
                 return np.concatenate(
                     [order[starts[g]:ends[g]] for g in drawn])
+
             m = max(1, min(ug.size - 1, int(round(ms * ug.size))))
             drawn = rng.choice(ug.size, size=m, replace=False)
             return np.where(np.isin(groups, ug[drawn]))[0]
+
     if ms >= 1.0:
         return rng.integers(0, n, size=n)
     m = max(1, int(round(ms * n)))
@@ -475,21 +531,22 @@ def _fit_bagged(estimator, X, y, cat_features, eval_set, groups, sample_weight):
     ("subagging"; ``max_samples=1.0`` restores the classic full-size
     with-replacement bootstrap). With ``groups`` the same recipe draws whole
     groups instead of rows, so the held-out groups form each member's
-    group-disjoint OOB eval set (see ``_member_sample_indices``). Because a
-    member is the same estimator class,
-    all per-model machinery â€” binary/multiclass dispatch, ``cat_features``,
-    the early-stopping auto-split, temperature scaling â€” is reused unchanged,
-    and ``cat_features``/``sample_weight``/``groups`` forward naturally (which
-    a ``sklearn.ensemble.Bagging`` wrapper would not do).
+    group-disjoint OOB eval set (see ``_member_sample_indices``).
+
+    A member is the same estimator class, so every per-model machine --
+    binary/multiclass dispatch, ``cat_features``, the early-stopping auto-split,
+    temperature scaling -- is reused unchanged, and
+    ``cat_features``/``sample_weight``/``groups`` forward naturally. A
+    ``sklearn.ensemble.Bagging`` wrapper would not do that.
 
     Members are independent, so they fit across ``ensemble_n_jobs`` worker
-    processes (default -1: as many workers as the thread budget supports,
-    capped at K). The thread budget â€” ``thread_count`` if set, else numba's
-    thread count â€” is divided across the workers, so a bagged fit uses the
-    same cores a single fit would (numba's sublinear thread scaling is what
-    makes K members at budget/K threads faster than K sequential full-budget
-    fits: 1.2-2.0x wall-clock on the BAGGING_PLAN.md B4 panel, identical
-    models by construction). ``ensemble_n_jobs=1`` restores sequential fits.
+    processes (default -1: as many workers as the thread budget supports, capped
+    at K). The thread budget -- ``thread_count`` if set, else numba's thread
+    count -- is divided across the workers, so a bagged fit uses the same cores a
+    single fit would. numba's sublinear thread scaling is what makes K members at
+    budget/K threads faster than K sequential full-budget fits: 1.2-2.0x
+    wall-clock on the BAGGING_PLAN.md B4 panel, identical models by construction.
+    ``ensemble_n_jobs=1`` restores sequential fits.
     """
     from sklearn.base import clone
     from joblib import Parallel, delayed
@@ -515,12 +572,14 @@ def _fit_bagged(estimator, X, y, cat_features, eval_set, groups, sample_weight):
         0, 2**31 - 1, size=K)
 
     # Bagged-mode member defaults (benchmarks/BAGGING_PLAN.md B3): averaging
-    # tolerates coarser, cheaper members, so params the user left on auto
-    # resolve to the tuned member values instead of the single-model ones
-    # (PMLB-tuned, holdout-confirmed, decision-suite validated: 54W-17L
-    # +0.28% pooled vs the previous bagged defaults at par fit cost).
-    # Explicit user values always win. Announced once per fit -- an opt-in
-    # bagged fit should never silently train members on different defaults.
+    # tolerates coarser, cheaper members, so params left on auto resolve to the
+    # tuned member values rather than the single-model ones. PMLB-tuned,
+    # holdout-confirmed, decision-suite validated: 54W-17L, +0.28% pooled vs the
+    # previous bagged defaults at par fit cost.
+    #
+    # Explicit user values always win, and the substitution is announced once
+    # per fit -- an opt-in bagged fit should never silently train members on
+    # different defaults.
     member_defaults = {}
     if estimator.learning_rate is None:
         member_defaults["learning_rate"] = 0.15
@@ -535,35 +594,33 @@ def _fit_bagged(estimator, X, y, cat_features, eval_set, groups, sample_weight):
             UserWarning, stacklevel=3)
 
     def _fit_one(seed):
-        # quality=None on members: the recipe has already been resolved on the
-        # bag itself, and rungs 4/5 set n_ensembles -- leaving quality on a
-        # member would re-apply it and recurse into another bag.
+        # quality=None on members: the recipe is already resolved on the bag
+        # itself, and rungs 4/5 set n_ensembles -- leaving quality on a member
+        # would re-apply it and recurse into another bag.
         member = clone(estimator).set_params(
             n_ensembles=None, quality=None, random_state=int(seed),
             thread_count=member_threads, **member_defaults)
+
         # Members receive internally-constructed inputs (ndarray rows, OOB eval
-        # sets), so the strict user-facing input checks that assume "the caller
-        # chose this" are relaxed for them -- see _fit_single.
+        # sets), so the strict user-facing checks that assume "the caller chose
+        # this" are relaxed for them -- see _fit_single.
         member._is_bag_member = True
-        # Member sample (benchmarks/BAGGING_PLAN.md B-samp): draw
-        # max_samples*n rows WITHOUT replacement ("subagging"). A full-size
-        # bootstrap gives a member only ~0.632n unique rows at n rows of
-        # compute (duplicates are just integer weights); 0.8n unique rows at
-        # 0.8n compute is more effective data AND less work — measured
-        # stronger and faster on both decision suites (gr 54W-5L +0.94%,
-        # Brier 23W-0L, fit 0.87x; hc Brier 8W-0L, fit 0.73x).
-        # max_samples=1.0 restores the classic full-size bootstrap. With
-        # ``groups`` the draw is over whole groups instead of rows, so the
-        # held-out groups give the member a non-empty group-disjoint OOB
-        # eval set (see _member_sample_indices).
+
+        # Member sample (benchmarks/BAGGING_PLAN.md B-samp). Why subagging beats
+        # the classic bootstrap: a full-size bootstrap leaves a member only
+        # ~0.632n unique rows at n rows of compute (duplicates are just integer
+        # weights), while 0.8n unique rows cost 0.8n compute -- more effective
+        # data and less work. Measured stronger and faster on both decision
+        # suites (gr 54W-5L +0.94%, Brier 23W-0L, fit 0.87x; hc Brier 8W-0L,
+        # fit 0.73x).
         ms = float(estimator.max_samples)
         idx = _member_sample_indices(n, ms, seed, groups)
-        # A rare class can be missed by the draw entirely, and a member cannot
-        # fit on a single class ("Need at least 2 classes" would crash the
-        # whole bag on data whose y plainly has two). Inject one row of the
-        # most frequent missing class in that case; draws that already hold
-        # two classes -- every non-crashing fit before this guard -- are
-        # byte-identical.
+
+        # The draw can miss a rare class entirely, and a member cannot fit on a
+        # single class ("Need at least 2 classes" would crash the whole bag on
+        # data whose y plainly has two). Inject one row of the most frequent
+        # missing class. Draws that already hold two classes -- every
+        # non-crashing fit before this guard -- are byte-identical.
         classes = getattr(estimator, "classes_", None)
         if classes is not None and np.unique(y[idx]).size < 2:
             patch_rng = np.random.default_rng([int(seed), 1])
@@ -579,51 +636,57 @@ def _fit_bagged(estimator, X, y, cat_features, eval_set, groups, sample_weight):
                 # spare: overwriting it just swaps which single class the
                 # member sees, and it crashes again. Grow to two rows instead.
                 idx = np.append(idx, donor)
+
         wb = None if sample_weight is None else np.asarray(sample_weight)[idx]
         gb = None if groups is None else groups[idx]
-        # Use OOB rows as the early-stopping eval set when no explicit eval_set
-        # was provided. The alternative (auto-splitting the bootstrap) contaminates
-        # the validation set: ~57% of auto-split val rows are duplicates of
-        # training rows, so val loss is optimistically low, early stopping fires
-        # late, and each member builds ~38% more trees than it should.
-        # OOB rows are guaranteed unseen by the member, giving a clean signal.
+
+        # OOB rows are the member's early-stopping eval set when the caller gave
+        # no explicit one. Auto-splitting the sample instead contaminates the
+        # validation set: ~57% of auto-split val rows are duplicates of training
+        # rows, so val loss reads optimistically low, early stopping fires late,
+        # and each member builds ~38% more trees than it should. OOB rows are
+        # guaranteed unseen by the member.
         if eval_set is None:
             oob_idx = _member_oob_eval_indices(idx, n, groups)
-            # Degenerate case: every row drawn (possible for tiny n). Fall back
-            # to letting the member auto-split rather than training with no eval.
-            # Carry OOB-row weights so zero-weight rows don't score the member's
-            # early-stopping metric (H3).
+
+            # Carry the OOB rows' weights so zero-weight rows don't score the
+            # member's early-stopping metric (H3). If every row was drawn
+            # (possible for tiny n) let the member auto-split rather than train
+            # with no eval set at all.
             sw_oob = (np.asarray(sample_weight)[oob_idx]
                       if sample_weight is not None else None)
             member_eval = ((X[oob_idx], y[oob_idx], sw_oob)
                            if len(oob_idx) > 0 else None)
         else:
             member_eval = eval_set
+
         # Member-level full-data refit (benchmarks/BREAKTHROUGH_PLAN.md C1):
-        # after early stopping has used the OOB rows, replay this member's own
+        # once early stopping has used the OOB rows, replay this member's own
         # structure against gradients from EVERY row, so its leaf values stop
-        # being estimated from max_samples*n. Only the leaf values move -- the
-        # splits stay exactly as this member's bag grew them, which is the
-        # diversity the bag actually trades on. Off by default; nothing below
-        # runs and the member is byte-identical when refit_members is False.
+        # being estimated from max_samples*n. Only the leaf values move; the
+        # splits stay exactly as this member's sample grew them, which is the
+        # diversity the bag trades on. Off by default -- with refit_members
+        # False nothing here fires and the member is byte-identical.
         if getattr(estimator, "refit_members", False) and eval_set is None:
             member._bag_refit_rows_ = (X, y, sample_weight, ms)
+
         member.fit(X[idx], y[idx], cat_features=cat_features, eval_set=member_eval,
                    groups=gb, sample_weight=wb)
         member._bag_refit_rows_ = None
-        # Members train on bare ndarray rows, so they would otherwise warn
-        # "fitted without feature names" on every DataFrame predict; give them
-        # the parent's captured names so the column-order guard applies
-        # uniformly at the member level too.
+
+        # Members train on bare ndarray rows, so without this they warn "fitted
+        # without feature names" on every DataFrame predict. The parent's
+        # captured names also make the column-order guard apply per member.
         names = getattr(estimator, "feature_names_in_", None)
         if names is not None:
             member.feature_names_in_ = names
+
         # member_threads (the fit-time per-worker share of the thread budget)
         # must not outlive the fit: members predict sequentially, so a member
-        # capped at budget/K threads would walk its forest on a sliver of the
-        # machine. Restore the parent's thread setting for everything after
-        # fit. Per-row tree walks don't depend on thread count, so predictions
-        # are unchanged.
+        # left capped at budget/K threads would walk its forest on a sliver of
+        # the machine. Restore the parent's setting for everything after fit.
+        # Per-row tree walks don't depend on thread count, so predictions are
+        # unchanged.
         member.thread_count = estimator.thread_count
         member.model_.thread_count = estimator.thread_count
         return member
@@ -640,14 +703,14 @@ def _make_eval_split(X, y, validation_fraction, random_state,
     stratify : array-like or None
         Class labels for stratified splitting (pass for classification tasks).
     groups : array-like or None
-        Group membership array (e.g. ``df['subject_id']``).  When supplied,
-        groups are kept intact across the split boundary.  For classification,
-        ``StratifiedGroupKFold`` is used so class proportions are preserved;
-        for regression ``GroupShuffleSplit`` is used.
+        Group membership array (e.g. ``df['subject_id']``). When supplied,
+        groups are kept intact across the split boundary. Classification uses
+        ``StratifiedGroupKFold`` so class proportions are preserved; regression
+        uses ``GroupShuffleSplit``.
 
     Returns ``None`` when the data is too small to carve a valid validation set
-    (e.g. tiny ``n``, or a class with too few members for a stratified split).
-    The caller treats ``None`` as "train on all rows, early stopping disabled"
+    -- a tiny ``n``, or a class with too few members for a stratified split. The
+    caller treats ``None`` as "train on all rows, early stopping disabled"
     rather than crashing on a degenerate split.
     """
     from sklearn.model_selection import (
@@ -669,12 +732,12 @@ def _make_eval_split(X, y, validation_fraction, random_state,
         if groups is not None:
             groups = np.asarray(groups)
             if stratify is not None:
-                # StratifiedGroupKFold approximates the desired val fraction via
-                # n_splits = round(1 / validation_fraction). Shuffle when a
-                # random_state is given so it selects the fold like every other
-                # branch here honors the seed (unshuffled, the holdout is always
-                # the same deterministic first fold and random_state is inert);
-                # random_state=None keeps the historical unshuffled split.
+                # StratifiedGroupKFold approximates the wanted val fraction with
+                # n_splits = round(1 / validation_fraction). Shuffle only when a
+                # random_state was given, so the seed picks the fold the way
+                # every other branch here honors it. Unshuffled, the holdout is
+                # always the same first fold and random_state is inert;
+                # random_state=None keeps that historical behaviour.
                 n_splits = max(2, round(1.0 / validation_fraction))
                 splitter = StratifiedGroupKFold(
                     n_splits=n_splits,
@@ -713,14 +776,17 @@ def _make_eval_split(X, y, validation_fraction, random_state,
 
 
 def _auto_es_split(est, X, y, sample_weight, eval_set, groups, stratify):
-    """Resolve ``early_stopping=True`` into an explicit ``eval_set`` by holding
-    out ``validation_fraction`` of the rows. Shared by the regressor
-    (``stratify=None``) and the classifier (``stratify=y``); the classifier's
-    lost-class check runs at its call site. Returns
-    ``(es_active, auto_split, X, y, sample_weight, eval_set)``; the caller
-    keeps the pre-split arrays for the optional full-data refit."""
+    """Resolve ``early_stopping=True`` into an explicit ``eval_set``, holding out
+    ``validation_fraction`` of the rows.
+
+    Shared by the regressor (``stratify=None``) and the classifier
+    (``stratify=y``); the classifier's lost-class check runs at its call site.
+    Returns ``(es_active, auto_split, X, y, sample_weight, eval_set)``. The
+    caller keeps the pre-split arrays for the optional full-data refit.
+    """
     es_active = bool(est.early_stopping)
     auto_split = False
+
     if es_active and eval_set is None:
         split = _make_eval_split(
             X, y, est.validation_fraction, est.random_state,
@@ -731,11 +797,13 @@ def _auto_es_split(est, X, y, sample_weight, eval_set, groups, stratify):
         else:
             auto_split = True
             train_idx, val_idx = split
+
             if est.verbose and not getattr(est, "_is_bag_member", False):
                 print(f"early_stopping=True: holding out {len(val_idx)} "
                       f"of {len(X)} rows as a validation set (pass "
                       "eval_set to choose it, or early_stopping=False "
                       "to train on all rows)")
+
             # Carry the val rows' weights so zero-weight rows split off into
             # the auto holdout don't score the early-stopping metric (H3).
             sw_val = (sample_weight[val_idx]
@@ -744,26 +812,30 @@ def _auto_es_split(est, X, y, sample_weight, eval_set, groups, stratify):
             X, y = X[train_idx], y[train_idx]
             if sample_weight is not None:
                 sample_weight = sample_weight[train_idx]
+
     return es_active, auto_split, X, y, sample_weight, eval_set
 
 
 def _extract_feature_names(X):
     """Return X's column names as a 1-D object array, or None.
 
-    Handles the trap that ``pyarrow.Table.columns`` is the column *data* (a list
-    of arrays), not names -- which would otherwise pollute ``feature_names_in_``
-    with the data itself. Prefer ``.column_names`` (pyarrow) over ``.columns``
-    (pandas/polars), and reject anything that isn't a flat sequence of scalar
-    names (e.g. arrays, or pandas MultiIndex tuples)."""
+    The trap: ``pyarrow.Table.columns`` is the column *data* (a list of arrays),
+    not the names, and would pollute ``feature_names_in_`` with the data itself.
+    So prefer ``.column_names`` (pyarrow) over ``.columns`` (pandas/polars), and
+    reject anything that isn't a flat sequence of scalar names -- arrays, or
+    pandas MultiIndex tuples.
+    """
     names = getattr(X, "column_names", None)        # pyarrow.Table
     if names is None:
         names = getattr(X, "columns", None)          # pandas / polars
     if names is None:
         return None
+
     try:
         arr = np.asarray(list(names), dtype=object)
     except Exception:
         return None
+
     if arr.ndim != 1 or any(not isinstance(v, str) and hasattr(v, "__len__")
                             for v in arr):
         return None                                  # data masquerading as names
@@ -771,9 +843,11 @@ def _extract_feature_names(X):
 
 
 def _reject_masked(X, where):
-    """Masked arrays silently drop the mask under ``np.asarray`` (the hidden
-    values are used), inverting the user's "these are missing" intent. Reject
-    with guidance instead of misbehaving silently."""
+    """Reject masked arrays with guidance.
+
+    ``np.asarray`` silently drops the mask and uses the hidden values, inverting
+    the user's "these are missing" intent.
+    """
     if np.ma.isMaskedArray(X):
         raise TypeError(
             f"Masked arrays are not supported ({where}). Convert with "
@@ -782,28 +856,33 @@ def _reject_masked(X, where):
 
 def _validate_fit_input(estimator, X, y, cat_features, sample_weight, *,
                         classification):
-    """Shared fit-time input validation + feature-metadata capture.
+    """Shared fit-time input validation and feature-metadata capture.
 
     Returns the (possibly raveled) ``y`` and sets ``n_features_in_`` (and
     ``feature_names_in_`` for DataFrame input) on ``estimator``. Raises clear
     errors for the common malformed inputs rather than letting them fail
-    cryptically deep in numpy/numba. NaN in X is intentionally allowed (treated
-    as missing, routed to its own bin); inf, complex, multi-output y, and
-    scipy.sparse input are not -- see the README "scikit-learn compatibility" note.
+    cryptically deep in numpy/numba.
+
+    NaN in X is deliberately allowed -- it is treated as missing and routed to
+    its own bin. inf, complex, multi-output y and scipy.sparse input are not; see
+    the README "scikit-learn compatibility" note.
     """
     import scipy.sparse as sp
     from sklearn.exceptions import DataConversionWarning
+
     if not getattr(estimator, "_is_bag_member", False):
         # Members fit in worker processes; without this a cold bagged fit
         # would print the notice once per member.
         from .warmup import _maybe_notice_cold_compile
         _maybe_notice_cold_compile()
+
     if y is None:
         raise ValueError(
             "This estimator requires y to be passed, but the target y is None.")
     if sp.issparse(X):
         raise TypeError("Sparse input is not supported; pass a dense array.")
     _reject_masked(X, "fit")
+
     feature_names = _extract_feature_names(X)
     shape = getattr(X, "shape", None)
     Xc = None
@@ -814,6 +893,7 @@ def _validate_fit_input(estimator, X, y, cat_features, sample_weight, *,
         raise ValueError(
             f"Expected a 2D array for X; got {len(shape)}D. Reshape your data, "
             "e.g. X.reshape(-1, 1) for a single feature.")
+
     n, nf = int(shape[0]), int(shape[1])
     if nf == 0:
         raise ValueError(
@@ -821,6 +901,7 @@ def _validate_fit_input(estimator, X, y, cat_features, sample_weight, *,
     if n == 0:
         raise ValueError(
             f"X has 0 sample(s) (shape=(0, {nf})) while a minimum of 1 is required.")
+
     if cat_features:
         ci = np.asarray(list(cat_features))
         if ci.size:
@@ -840,24 +921,28 @@ def _validate_fit_input(estimator, X, y, cat_features, sample_weight, *,
                     f"column(s): {sorted(set(ci.tolist()))}.")
             if len(set(ci.tolist())) != ci.size:
                 raise ValueError("cat_features contains duplicate indices.")
+
     if not cat_features:
-        # Check complex BEFORE the float64 cast (which would raise its own
-        # TypeError on complex input instead of our clear ValueError).
+        # Check complex BEFORE the float64 cast, which would raise its own
+        # TypeError on complex input instead of our clear ValueError.
         Xraw = Xc if Xc is not None else np.asarray(X)
         if np.iscomplexobj(Xraw):
             raise ValueError("Complex data not supported.")
+
         try:
-            # Convert from the original X (not the object-dtype Xraw) so a pandas
-            # DataFrame's nullable NA is mapped to np.nan rather than crashing the
-            # float cast as an NAType object.
+            # Convert from the original X, not the object-dtype Xraw, so a
+            # pandas DataFrame's nullable NA maps to np.nan instead of crashing
+            # the float cast as an NAType object.
             Xc = as_model_array(X if Xc is None else Xc, want_object=False)
         except (ValueError, TypeError) as e:
-            # A non-numeric column (string/category/datetime) in a DataFrame with
-            # no cat_features: name the offending columns and point at
-            # cat_features. (pandas nullable NA no longer lands here -- it maps to
-            # np.nan in as_model_array.) For bare arrays (no column metadata) keep
-            # the original numpy error -- some sklearn estimator checks rely on
-            # its exact type/message.
+            # A non-numeric column (string/category/datetime) in a DataFrame
+            # with no cat_features: name the offending columns and point at
+            # cat_features. pandas nullable NA no longer lands here -- it maps
+            # to np.nan in as_model_array.
+            #
+            # For bare arrays (no column metadata) keep the original numpy
+            # error: some sklearn estimator checks rely on its exact
+            # type/message.
             bad = _describe_nonnumeric_columns(X)
             if bad:
                 raise ValueError(
@@ -866,16 +951,17 @@ def _validate_fit_input(estimator, X, y, cat_features, sample_weight, *,
                     f"positions in cat_features=[...], or encode them first."
                 ) from e
             raise
+
         if np.isinf(Xc).any():
             raise ValueError(
                 "X contains infinity. NaN is accepted (treated as missing), but "
                 "inf is not -- clip or clean it first.")
     else:
-        # cat_features present: cat columns are decoded as strings, but the
-        # remaining numeric columns must still be finite. Without this, inf in a
-        # numeric column slips silently to the missing bin (binning treats inf as
-        # NaN), contradicting the no-cat path's explicit rejection. Check only the
-        # numeric columns; the cat columns are not float-castable.
+        # Categorical columns are decoded as strings, but the remaining numeric
+        # ones must still be finite. Without this check, inf in a numeric column
+        # slips silently into the missing bin (binning treats inf as NaN),
+        # contradicting the no-cat path's explicit rejection. Only the numeric
+        # columns are checked -- the categorical ones are not float-castable.
         cat_set = set(int(c) for c in cat_features)
         num_idx = [i for i in range(nf) if i not in cat_set]
         num_block = _numeric_block(Xc if Xc is not None else X, num_idx)
@@ -883,11 +969,13 @@ def _validate_fit_input(estimator, X, y, cat_features, sample_weight, *,
             raise ValueError(
                 "X contains infinity. NaN is accepted (treated as missing), "
                 "but inf is not -- clip or clean it first.")
+
     y = np.asarray(y)
     if y.shape[0] != n:
         raise ValueError(
             f"X and y have inconsistent lengths: X has {n} samples, "
             f"y has {y.shape[0]}.")
+
     # Ravel a column-vector y (n, 1) with a warning, like sklearn estimators;
     # reject genuine multi-output y.
     if y.ndim == 2:
@@ -901,6 +989,7 @@ def _validate_fit_input(estimator, X, y, cat_features, sample_weight, *,
             raise ValueError(
                 "Multi-output y is not supported; pass a 1D y of shape "
                 "(n_samples,).")
+
     if classification:
         from sklearn.utils.multiclass import type_of_target
         if type_of_target(y) in ("continuous", "continuous-multioutput"):
@@ -912,14 +1001,16 @@ def _validate_fit_input(estimator, X, y, cat_features, sample_weight, *,
             raise ValueError("y contains NaN or infinity.")
     elif not np.isfinite(np.asarray(y, np.float64)).all():
         raise ValueError("y contains NaN or infinity; targets must be finite.")
+
     if sample_weight is not None:
         sw = np.asarray(sample_weight, dtype=np.float64)
         if sw.ndim != 1 or sw.shape[0] != n:
             raise ValueError(
                 f"sample_weight must be 1D of length {n}; got shape {sw.shape}.")
+
         # Non-finite or negative weights, or an all-zero vector, otherwise fit
-        # without error and silently yield an all-NaN model (mean-1 weight
-        # normalization divides by the weight sum).
+        # without error and silently yield an all-NaN model: mean-1 weight
+        # normalization divides by the weight sum.
         if not np.isfinite(sw).all():
             raise ValueError("sample_weight contains NaN or infinity.")
         if (sw < 0).any():
@@ -927,16 +1018,18 @@ def _validate_fit_input(estimator, X, y, cat_features, sample_weight, *,
         if sw.sum() <= 0:
             raise ValueError("sample_weight sums to zero; at least one weight "
                              "must be positive.")
+
     estimator.n_features_in_ = nf
     if feature_names is not None:
         estimator.feature_names_in_ = feature_names
     elif hasattr(estimator, "feature_names_in_"):
-        # Refitting on name-less input must not keep a previous fit's names:
-        # the stale set makes the column-order guard raise on the new fit's
-        # valid input -- and pass on stale-matching input, the exact silent
-        # wrong-prediction case it exists to stop. Mirrors sklearn's
-        # _check_feature_names, which deletes the attribute on such refits.
+        # A refit on name-less input must not keep the previous fit's names. A
+        # stale set makes the column-order guard raise on the new fit's valid
+        # input -- and pass on stale-matching input, the exact silent
+        # wrong-prediction case it exists to stop. sklearn's
+        # _check_feature_names deletes the attribute on such refits too.
         del estimator.feature_names_in_
+
     return y
 
 
@@ -947,19 +1040,24 @@ def _check_feature_names_match(estimator, X):
     otherwise yields silently-wrong predictions, since the booster consumes
     columns positionally. Mirrors sklearn: warn when names are present on only
     one side, raise when they disagree. Uses the same ``X.columns`` extraction
-    as fit-time capture so the two are directly comparable (pandas/polars)."""
+    as the fit-time capture, so the two are directly comparable (pandas/polars).
+    """
     train_names = getattr(estimator, "feature_names_in_", None)
     x_names = _extract_feature_names(X)
+
     if train_names is None and x_names is None:
         return
+
     if train_names is None:
         warnings.warn("X has feature names, but this estimator was fitted "
                       "without feature names.", UserWarning, stacklevel=3)
         return
+
     if x_names is None:
         warnings.warn("This estimator was fitted with feature names, but X was "
                       "passed without feature names.", UserWarning, stacklevel=3)
         return
+
     if not np.array_equal(np.asarray(train_names, dtype=object), x_names):
         raise ValueError(
             "The feature names of X do not match those seen during fit. "
@@ -968,10 +1066,12 @@ def _check_feature_names_match(estimator, X):
 
 
 def _assume_finite():
-    """Honor scikit-learn's global ``assume_finite`` config. When a user sets
-    ``sklearn.set_config(assume_finite=True)`` (or uses ``config_context``), the
+    """Honor scikit-learn's global ``assume_finite`` config.
+
+    Under ``sklearn.set_config(assume_finite=True)`` (or ``config_context``) the
     O(n) predict-time finiteness scan is skipped for maximum inference
-    throughput -- the same escape hatch sklearn's own ``check_array`` offers."""
+    throughput -- the same escape hatch sklearn's own ``check_array`` offers.
+    """
     try:
         from sklearn import get_config
         return bool(get_config().get("assume_finite", False))
@@ -980,13 +1080,17 @@ def _assume_finite():
 
 
 def _numeric_block(X, num_idx):
-    """The numeric columns of X (positions ``num_idx``) as a float64 array, or
-    None if they aren't float-castable. Used for the inf check when categoricals
-    are present: it selects *only* the numeric columns so the (often string-
-    heavy) categorical columns aren't dragged through an expensive object
-    conversion. Maps pandas nullable NA to np.nan like the model's own path."""
+    """The numeric columns of X (positions ``num_idx``) as float64, or None if
+    they aren't float-castable.
+
+    Used for the inf check when categoricals are present. It selects *only* the
+    numeric columns, so the often string-heavy categorical ones aren't dragged
+    through an expensive object conversion. Maps pandas nullable NA to np.nan
+    like the model's own path.
+    """
     if not num_idx:
         return None
+
     try:
         iloc = getattr(X, "iloc", None)
         if iloc is not None and hasattr(X, "dtypes"):     # pandas DataFrame
@@ -1017,36 +1121,48 @@ def _was_fit_with_cats(estimator):
 
 
 def _bag_predict_context(estimator, X):
-    """Per-call predict state shared across the members of a bagged ensemble:
-    the raw-matrix conversion and a categorical-factorization cache, computed
-    once instead of once per member. The caller has already validated ``X``
-    (``_check_predict_input``), so members skip re-validation entirely -- each
-    member's prediction is unchanged, only the redundant per-member conversion,
-    hashing, and input checks are gone."""
+    """Per-call predict state shared across the members of a bagged ensemble.
+
+    The raw-matrix conversion and a categorical-factorization cache, computed
+    once instead of once per member. The caller has already validated ``X`` via
+    ``_check_predict_input``, so members skip re-validation entirely. Each
+    member's prediction is unchanged -- only the redundant per-member
+    conversion, hashing and input checks are gone.
+    """
     Xc = as_model_array(X, _was_fit_with_cats(estimator))
     return Xc, CatTransformCache()
 
 
 def _check_predict_input(estimator, X):
-    """Raise NotFittedError if unfitted, then validate X is 2D with the same
-    number of features as training -- preventing silently-wrong predictions on
-    mismatched input. Messages match scikit-learn's wording for compatibility."""
+    """Validate X at predict time; return the converted model array, or None.
+
+    Raises NotFittedError if unfitted, then checks that X is 2D with the same
+    number of features as training -- mismatched input would otherwise give
+    silently-wrong predictions. Messages match scikit-learn's wording.
+
+    The returned array is the model-array conversion the inf check already had
+    to perform. Callers thread it through so a DataFrame is materialized once
+    per predict instead of twice. It is None when no full conversion happened:
+    under ``assume_finite``, or after a conversion failure whose descriptive
+    error the booster raises.
+    """
     from sklearn.utils.validation import check_is_fitted
     check_is_fitted(estimator)
+
     # A process that only unpickles a model and serves it never calls fit, so
     # the predict path needs its own notice.
     from .warmup import _maybe_notice_cold_compile
     _maybe_notice_cold_compile()
-    # Enforce feature-name agreement with fit (reuse sklearn's logic): a
-    # DataFrame whose columns are renamed or *reordered* relative to training
-    # otherwise produces silently-wrong predictions. Warns when names are
-    # present on only one side, raises when they disagree -- like every sklearn
-    # estimator.
+
+    # A DataFrame whose columns are renamed or *reordered* relative to training
+    # otherwise produces silently-wrong predictions.
     _check_feature_names_match(estimator, X)
+
     import scipy.sparse as sp
     if sp.issparse(X):
         raise TypeError("Sparse input is not supported; pass a dense array.")
     _reject_masked(X, "predict")
+
     shape = getattr(X, "shape", None)
     if shape is None or len(shape) != 2:
         shape = np.asarray(X, dtype=object).shape
@@ -1058,19 +1174,15 @@ def _check_predict_input(estimator, X):
         raise ValueError(
             f"X has {shape[1]} features, but {type(estimator).__name__} is "
             f"expecting {estimator.n_features_in_} features as input.")
-    # Reject inf at predict for the numeric path, mirroring fit (which rejects
-    # it). Without this, an inf serving value is silently routed to the missing
-    # bin and returns the "missing" prediction with no error. This is the only
-    # O(n) check on the hot predict path, so it is skippable via sklearn's
-    # ``assume_finite`` config for latency-critical serving.
-    #
-    # The model-array conversion the check needs is the same one the booster
-    # would redo immediately after; return it so callers thread it through
-    # (one full DataFrame materialization per predict instead of two).
-    # Returns None when no full conversion happened (assume_finite, or a
-    # conversion failure whose descriptive error the booster raises).
+
+    # Reject inf at predict for the numeric path, mirroring fit. Without it an
+    # inf serving value is silently routed to the missing bin and returns the
+    # "missing" prediction with no error. This is the only O(n) check on the hot
+    # predict path, hence the assume_finite escape hatch for latency-critical
+    # serving.
     if _assume_finite():
         return None
+
     if not _was_fit_with_cats(estimator):
         try:
             Xc = as_model_array(X, want_object=False)
@@ -1088,6 +1200,7 @@ def _check_predict_input(estimator, X):
                 "X contains infinity. NaN is accepted (treated as missing), but "
                 "inf is not -- clip or clean it first.")
         return Xc
+
     if np.isinf(Xc).any():
         raise ValueError(
             "X contains infinity. NaN is accepted (treated as missing), but "
@@ -1098,57 +1211,64 @@ def _check_predict_input(estimator, X):
 def _auto_min_child_weight(n_train):
     """Size-adaptive ``min_child_weight`` used when the classifier leaves it None.
 
-    Oblivious trees UNDERFIT large data at the historical mcw=1: the shared-split
-    veto amplifies the min-leaf constraint (one sparse leaf among 2**depth vetoes
-    the whole level), so they want a lower min-leaf than leaf-wise trees -- which
-    is why CatBoost uses min_data_in_leaf=1. But mcw~0 OVERFITS small data,
-    because (unlike CatBoost) we run plain boosting without ordered-boosting
-    regularization. So fade the veto by training size: keep the full veto below
-    ~500 rows, drop it above ~2000, linear between. The midpoint (~1250 rows ->
-    ~20 samples/leaf at depth 6) lines up with the field-standard
-    min_data_in_leaf=20.
+    Oblivious trees UNDERFIT large data at the historical mcw=1: the shared split
+    amplifies the min-leaf constraint, since one sparse leaf among 2**depth
+    vetoes the whole level. They want a lower min-leaf than leaf-wise trees --
+    which is why CatBoost uses min_data_in_leaf=1. But mcw~0 OVERFITS small data,
+    because unlike CatBoost we run plain boosting with no ordered-boosting
+    regularization.
+
+    So the veto fades with training size: full below ~500 rows, gone above ~2000,
+    linear between. The midpoint (~1250 rows, about 20 samples per leaf at depth
+    6) lines up with the field-standard min_data_in_leaf=20.
     """
     return float(np.clip((2000.0 - n_train) / 1500.0, 0.0, 1.0))
 
 
 # Pairwise categorical combinations help when the target depends on categorical
-# INTERACTIONS, but on mixed data the synthetic combo columns crowd out the
-# numeric features that want to split (sign-tested: all-categorical car/kr-vs-kp
-# gain +60%+, mixed sets regress). So the auto-default enables them ONLY when the
-# data is entirely categorical -- the precise condition under which they help
-# without a downside. The two caps below are resource guards (a wide all-cat
+# INTERACTIONS. On mixed data the synthetic combo columns crowd out the numeric
+# features that want to split: sign-tested, the all-categorical car and kr-vs-kp
+# gain +60% or more while mixed sets regress. So the auto-default turns them on
+# ONLY for entirely categorical data -- the one condition where they help with
+# no downside.
+#
+# The two caps below are resource guards, not accuracy knobs: a wide all-cat
 # dataset generates C(n_cat, 2) combo columns, each target-encoded over every
-# row), NOT accuracy knobs: above them the user can still opt in explicitly.
+# row. Above them the user can still opt in explicitly.
 _AUTO_CAT_COMBO_MAX_PAIRS = 1000        # ceiling on C(n_cat, 2) combo columns
 _AUTO_CAT_COMBO_MAX_CELLS = 5e7         # ceiling on pairs * n_samples (memory)
 
 
 def _auto_cat_combinations(cat_features, n_features, n_samples):
-    """Resolve ``cat_combinations=None``: True only for (tractable) all-categorical
-    data. ``cat_features`` is the resolved integer-index list (or None)."""
+    """Resolve ``cat_combinations=None``: True only for tractable all-categorical
+    data. ``cat_features`` is the resolved integer-index list, or None."""
     if cat_features is None or len(cat_features) == 0:
         return False
+
     n_cat = len(cat_features)
     if n_cat < 2 or n_cat != n_features:
         return False
+
     n_pairs = n_cat * (n_cat - 1) // 2
     if n_pairs > _AUTO_CAT_COMBO_MAX_PAIRS:
         return False
     if n_pairs * n_samples > _AUTO_CAT_COMBO_MAX_CELLS:
         return False
+
     return True
 
 
-# Numeric cross features: pair the CROSS_TOP_M most important numeric columns
-# of the base fit; each pair contributes a difference and a product column.
-# Selection (base vs augmented, on the ES validation split) needs enough rows
-# for the val signal to be trustworthy -- below CROSS_MIN_SAMPLES the val set
-# is too small to referee and small data overfits extra columns first.
+# Numeric cross features: pair the CROSS_TOP_M most important numeric columns of
+# the base fit; each pair contributes a difference and a product column.
+# Selection (base vs augmented, on the ES validation split) needs enough rows for
+# the validation signal to be trustworthy -- below CROSS_MIN_SAMPLES the val set
+# is too small to referee, and small data overfits extra columns first.
 CROSS_TOP_M = 6
 CROSS_MIN_SAMPLES = 2000
+
 # Group-centered (gdiff) candidates: top numerics x top categoricals. A gdiff
-# column x_i - mean(x_i | c_j) makes "above this row's own category's
-# baseline" one split -- the num x cat analog of the diff/prod staircase fix.
+# column x_i - mean(x_i | c_j) makes "above this row's own category's baseline"
+# one split -- the num x cat analog of the diff/prod staircase fix.
 CROSS_GDIFF_TOP_NUM = 4
 CROSS_GDIFF_TOP_CAT = 3
 
@@ -1156,22 +1276,27 @@ CROSS_GDIFF_TOP_CAT = 3
 def _cross_candidate_pairs(importances, cat_features, n_features):
     """Candidate (i, j, op) cross features from base-fit importances.
 
-    Oblivious trees approximate interactions with a depth-limited staircase
-    (one shared split per level); a difference column makes the ``x_i < x_j``
-    boundary one split, a product column captures multiplicative structure,
-    and a group-centered column makes a within-category deviation one split.
-    Numeric pairs are the C(m, 2) combinations of the top-m numeric features
-    by split-gain importance; gdiff pairs cross the top numerics with the top
+    Oblivious trees can only approximate an interaction with a depth-limited
+    staircase, one shared split per level. A difference column makes the
+    ``x_i < x_j`` boundary a single split, a product column captures
+    multiplicative structure, and a group-centered column makes a within-category
+    deviation a single split.
+
+    Numeric pairs are the C(m, 2) combinations of the top-m numeric features by
+    split-gain importance; gdiff pairs cross the top numerics with the top
     categoricals. Interactions among features the trees already use are the
-    plausible ones, and irrelevant crosses cost only fit time (split search
-    ignores them; the validation race referees the whole block)."""
+    plausible ones, and an irrelevant cross costs only fit time -- the split
+    search ignores it, and the validation race referees the whole block.
+    """
     cat = set(cat_features or [])
     num_idx = [i for i in range(n_features) if i not in cat]
     if not num_idx:
         return []
+
     imp = np.asarray(importances, dtype=np.float64)
     key = np.zeros(n_features)
     key[:imp.shape[0]] = imp
+
     pairs = []
     if len(num_idx) >= 2:
         top = sorted(num_idx, key=lambda i: -key[i])[:CROSS_TOP_M]
@@ -1180,10 +1305,12 @@ def _cross_candidate_pairs(importances, cat_features, n_features):
                 i, j = top[a], top[b]
                 pairs.append((i, j, "diff"))
                 pairs.append((i, j, "prod"))
+
     if cat:
         gnum = sorted(num_idx, key=lambda i: -key[i])[:CROSS_GDIFF_TOP_NUM]
         gcat = sorted(cat, key=lambda i: -key[i])[:CROSS_GDIFF_TOP_CAT]
         pairs.extend((i, j, "gdiff") for i in gnum for j in gcat)
+
     return pairs
 
 
@@ -1202,9 +1329,12 @@ def _stop_after(k):
 
 def _stop_if_behind(k, target_best):
     """Fit callback killing a challenger at round k unless its best validation
-    loss has beaten ``target_best`` by then (the raced-selection rule: the
-    winner at the shared budget continues, the loser stops). A best-so-far
-    only improves, so a challenger ahead at k is never stopped later."""
+    loss has beaten ``target_best`` by then.
+
+    The raced-selection rule: the winner at the shared budget continues, the
+    loser stops. A best-so-far only improves, so a challenger ahead at k is never
+    stopped later.
+    """
     state = {"best": np.inf}
 
     def cb(iteration, train_loss, val_loss, model):
@@ -1220,45 +1350,50 @@ def _bag_refit_rows(est):
     None when this is not a member of a refitting bag.
 
     A member trains on ``max_samples`` of the rows and early-stops on the
-    out-of-bag complement, so `auto_split` is False and the ordinary full-data
-    refit never fires: every member's leaf values come from 0.8n rows and
-    nothing reclaims the rest. REFIT_PLAN's "bag members have no data tax" is
-    true of the ENSEMBLE — every row is in some member's bag — but not of any
-    individual member.
+    out-of-bag complement, so ``auto_split`` is False and the ordinary full-data
+    refit never fires: every member's leaf values come from 0.8n rows and nothing
+    reclaims the rest. REFIT_PLAN's "bag members have no data tax" is true of the
+    ENSEMBLE -- every row is in some member's bag -- but not of any individual
+    member.
 
     Replaying the member's own structure against all-row gradients is safe for
     the ensemble because bag lift is STRUCTURAL diversity, measured in the LRE
     post-mortem ("leaf-only diversity is dead, structural diversity is the
-    value"): the structures stay exactly as each member's own bag grew them,
-    and only the leaf values change. See benchmarks/BREAKTHROUGH_PLAN.md."""
+    value"). The structures stay exactly as each member's own bag grew them, and
+    only the leaf values change. See benchmarks/BREAKTHROUGH_PLAN.md.
+    """
     return getattr(est, "_bag_refit_rows_", None)
 
 
 def _refit_on_full(est, winner, X_full, y_full, sw_full, cat_features, kw,
                    loss_kwargs=None, replay=False, train_frac=None):
-    """Retrain ``winner``'s configuration on all rows (benchmarks/
-    REFIT_PLAN.md): rounds scaled by the train-size ratio, resolved learning
-    rate pinned so the early-stopped budget keeps its meaning, selected
-    linear-leaf variant and cross pairs carried over. The winner's ES curves
-    are copied so ``validation_history_`` keeps reporting the curve that
-    chose the budget. Size-adaptive autos (the classifier's min_child_weight,
-    cat_combinations) re-resolve at the full row count; user callbacks
-    observed the ES fits and are not re-run.
+    """Retrain ``winner``'s configuration on all rows (benchmarks/REFIT_PLAN.md).
 
-    ``train_frac`` is the fraction of ``X_full`` the winner actually trained
-    on, which sets how far the round budget scales up. It defaults to the
+    Rounds scale by the train-size ratio and the resolved learning rate is
+    pinned, so the early-stopped budget keeps its meaning; the selected
+    linear-leaf variant and cross pairs carry over. The winner's early-stopping
+    curves are copied so ``validation_history_`` still reports the curve that
+    chose the budget. Size-adaptive autos (the classifier's min_child_weight,
+    cat_combinations) re-resolve at the full row count. User callbacks already
+    observed the early-stopping fits and are not re-run.
+
+    ``train_frac`` is the fraction of ``X_full`` the winner actually trained on,
+    which sets how far the round budget scales up. It defaults to the
     auto-split's ``1 - validation_fraction``; a bag member passes its
     ``max_samples`` instead, since what its leaf values never saw is the
-    out-of-bag complement rather than a validation holdout."""
+    out-of-bag complement rather than a validation holdout.
+    """
     t_star = len(winner.trees_)
     frac = (1.0 - est.validation_fraction) if train_frac is None \
         else float(train_frac)
     rounds = min(int(np.ceil(t_star / max(frac, 1e-9))),
                  int(est.n_estimators))
+
     rkw = dict(kw)
     rkw["n_estimators"] = rounds
     rkw["early_stopping_rounds"] = None
     rkw["learning_rate"] = float(winner.lr_)
+
     # The classifier's auto min_child_weight is size-adaptive (the regressor
     # resolves None to a flat 1.0 before kw is built).
     if est.min_child_weight is None and loss_kwargs is None:
@@ -1267,10 +1402,11 @@ def _refit_on_full(est, winner, X_full, y_full, sw_full, cat_features, kw,
         rkw["cat_combinations"] = _auto_cat_combinations(
             cat_features, est.n_features_in_, len(X_full))
     rkw.pop("linear_leaves", None)
+
     # Structure-transfer refit: replay the winner's splits against full-data
-    # gradients instead of re-growing them. The scalar booster only -- the
-    # multiclass round grows one vector-leaf tree through a separate loop, so
-    # it keeps the from-scratch refit.
+    # gradients instead of re-growing them. Scalar booster only -- the multiclass
+    # round grows one vector-leaf tree through a separate loop, so it keeps the
+    # from-scratch refit.
     multiclass = getattr(est, "_multiclass", False)
     donor = ((winner.trees_, winner.prep_)
              if (replay and not multiclass and winner.trees_) else None)
@@ -1278,6 +1414,7 @@ def _refit_on_full(est, winner, X_full, y_full, sw_full, cat_features, kw,
         # The donor's preprocessor is reused verbatim, so the cross columns and
         # the encoder come with it; passing cross_pairs again would rebuild them.
         rkw["replay_donor"] = donor
+
     if loss_kwargs is not None:      # scalar regressor path
         b = GradientBoosting(loss=est.loss, loss_kwargs=loss_kwargs,
                              linear_leaves=winner.linear_leaves,
@@ -1289,9 +1426,11 @@ def _refit_on_full(est, winner, X_full, y_full, sw_full, cat_features, kw,
         b = GradientBoosting(loss="Logloss",
                              linear_leaves=winner.linear_leaves,
                              cross_pairs=winner.cross_pairs, **rkw)
+
     if est.verbose:
         print(f"refit_full: retraining on all {len(X_full)} rows for "
               f"{rounds} rounds (early stopping chose {t_star})")
+
     b.fit(X_full, y_full, cat_features=cat_features, sample_weight=sw_full)
     b.train_history_ = winner.train_history_
     b.valid_history_ = winner.valid_history_
@@ -1300,7 +1439,7 @@ def _refit_on_full(est, winner, X_full, y_full, sw_full, cat_features, kw,
 
 def _add_callback(callbacks, extra):
     """Compose the user callbacks argument (None, a callable, or a sequence)
-    with one internal callback; extra=None returns callbacks unchanged."""
+    with one internal callback. ``extra=None`` returns callbacks unchanged."""
     if extra is None:
         return callbacks
     base = ([] if callbacks is None else list(callbacks)
@@ -1405,7 +1544,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         quantile loss. ``None`` (the default) = validation-selected: both
         variants are fit and the one with the lower validation loss is kept
         (~2x fit time; requires an early-stopping split or ``eval_set``, RMSE
-        loss, and >= 1000 rows â€” otherwise constant leaves are used). Set
+        loss, and >= 1000 rows -- otherwise constant leaves are used). Set
         ``True``/``False`` to force one variant and skip the double fit.
     linear_lambda : float, default 1.0
         Ridge penalty on per-leaf linear slopes; larger is closer to a constant.
@@ -1465,33 +1604,35 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
     refit_full : "replay", bool, default "replay"
         After the automatic early-stopping split has chosen the tree budget
         (and model selection / calibration have used it), retrain the winning
-        configuration on 100% of the rows — rounds scaled by the train-size
-        ratio, learning rate pinned — so the final model does not pay the
+        configuration on 100% of the rows -- rounds scaled by the train-size
+        ratio, learning rate pinned -- so the final model does not pay the
         holdout data tax. Only affects fits that used the automatic split
         (an explicit ``eval_set`` or ``early_stopping=False`` is unchanged);
         ``loss="Quantile"`` ignores it to keep its conformal holdout honest.
-        ``validation_history_`` keeps the early-stopped fit's curve. Costs
-        refitting on since 0.25.0: it is the strongest single-model setting
-        measured (benchmarks/SELECT_PLAN.md). Set ``False``, or ``quality=2``,
-        for the faster pre-0.25 behaviour.
+        ``validation_history_`` keeps the early-stopped fit's curve. Costs one
+        extra refit; on by default since 0.25.0, as the strongest single-model
+        setting measured (benchmarks/SELECT_PLAN.md). Set ``False``, or
+        ``quality=2``, for the faster pre-0.25 behaviour.
 
         **The default is** ``"replay"``, which gets the same thing for about
         two thirds of the cost. Growing trees is 83-85% of a fit and is a
         SEARCH; ``"replay"`` reuses the winner's tree structures and refits
         only the leaf values against full-data gradients, so the held-out rows
         still shape every leaf value while the split search is not paid for
-        twice. Measured against ``True`` at 3 seeds: on Grinsztajn accuracy was
-        flat (27W-32L over 59 datasets, mean +0.005%) and fit time fell 34% on
-        all 59; on high-cardinality categorical data it ran slightly behind
-        (mean −0.256%) for 17% less fit time. Pass ``True`` for the
-        from-scratch refit — marginally stronger on high-card data, and the
-        setting benchmarked in REFIT_PLAN.md. Multiclass ignores ``"replay"``
-        and always uses the from-scratch refit (benchmarks/REPLAY_PLAN.md).
+        twice.
+
+        Measured against ``True`` at 3 seeds: on Grinsztajn accuracy was flat
+        (27W-32L over 59 datasets, mean +0.005%) and fit time fell 34% on all
+        59; on high-cardinality categorical data it ran slightly behind (mean
+        -0.256%) for 17% less fit time. Pass ``True`` for the from-scratch
+        refit -- marginally stronger on high-card data, and the setting
+        benchmarked in REFIT_PLAN.md. Multiclass ignores ``"replay"`` and
+        always uses the from-scratch refit (benchmarks/REPLAY_PLAN.md).
     refit_members : bool, default False
         The bagged analogue of ``refit_full``, and off by default. A bag member
         trains on ``max_samples`` of the rows and early-stops on its
         out-of-bag complement, so its leaf values never see the rows it stopped
-        on — the full-data refit that helps a single model has never fired for
+        on -- the full-data refit that helps a single model has never fired for
         it. With ``True`` each member replays its own tree structure against
         gradients from every row once early stopping is done. Only the leaf
         values move; the splits stay exactly as that member's own sample grew
@@ -1630,19 +1771,19 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
             here overrides the constructor value. (The constructor form lets
             ``GridSearchCV``/``Pipeline`` carry it, which a fit-only kwarg can't.)
         eval_set : (X_val, y_val) tuple or None
-            Explicit validation set.  When provided, automatic splitting is
+            Explicit validation set. When provided, automatic splitting is
             skipped regardless of the *early_stopping* setting.
         groups : array-like of shape (n_samples,) or None
-            Group labels for the samples (e.g. ``df['subject_id']``).  When
+            Group labels for the samples (e.g. ``df['subject_id']``). When
             supplied and *early_stopping* triggers an automatic split, groups
             are kept intact across the train/validation boundary using
             ``GroupShuffleSplit``.
         sample_weight : array-like of shape (n_samples,) or None
-            Per-sample weights.  Normalized to mean 1 internally.  Applied
+            Per-sample weights, normalized to mean 1 internally. Applied
             throughout: the gradient/leaf fit, the categorical target encoder,
             the quantile bin borders, and the early-stopping metric on an
             automatically split (or bagged out-of-bag) validation set, so a
-            zero-weight row never influences the model.  An explicitly passed
+            zero-weight row never influences the model. An explicitly passed
             ``eval_set`` carries no weights and is scored unweighted.
         callbacks : callable or list of callable, or None
             Per-round fit hooks ``cb(iteration, train_loss, val_loss, model)``;
@@ -1655,14 +1796,17 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         _validate_hyperparams(self)
         y = _validate_fit_input(self, X, y, cat_features, sample_weight,
                                 classification=False)
+
         if eval_set is not None:
             _check_eval_set(eval_set, self.n_features_in_)
-            # A reordered/renamed eval DataFrame is consumed positionally and
-            # silently wrecks early stopping (and everything calibrated on the
-            # holdout). Bag members skip this: their eval sets are built
+
+            # A reordered or renamed eval DataFrame is consumed positionally and
+            # silently wrecks early stopping, and everything calibrated on the
+            # holdout. Bag members skip this: their eval sets are built
             # internally from already-validated parent input.
             if not getattr(self, "_is_bag_member", False):
                 _check_feature_names_match(self, eval_set[0])
+
         with _quality_applied(self):
             if self.n_ensembles and self.n_ensembles > 1:
                 if callbacks is not None:
@@ -1671,6 +1815,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                 self.estimators_ = _fit_bagged(self, X, y, cat_features,
                                                eval_set, groups, sample_weight)
                 return self
+
             self.estimators_ = None
             return self._fit_single(X, y, cat_features, eval_set, groups,
                                     sample_weight, callbacks)
@@ -1692,16 +1837,18 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         y = np.asarray(y, dtype=np.float64)
         if sample_weight is not None:
             sample_weight = np.asarray(sample_weight, dtype=np.float64)
-        # linear_leaves is silently dropped by the booster for MAE/Quantile
-        # (their leaf values are the residual median/quantile, not a Newton step
-        # a ridge slope could refine). Warn so it isn't mistaken for active.
+
+        # The booster silently drops linear_leaves for MAE/Quantile: their leaf
+        # values are the residual median or quantile, not a Newton step a ridge
+        # slope could refine. Warn so it isn't mistaken for active.
         if self.linear_leaves and self.loss in ("MAE", "Quantile"):
             warnings.warn(
                 f"linear_leaves is not supported with loss={self.loss!r} and "
                 "will be ignored.", UserWarning, stacklevel=2)
-        # Same inert-setting honesty for the other shadowed knobs: MAE/Quantile
-        # re-estimate leaf values directly (the booster's adjusts_leaves path),
-        # which owns the training step.
+
+        # Same honesty for the other knobs MAE/Quantile shadow: they re-estimate
+        # leaf values directly (the booster's adjusts_leaves path), which owns
+        # the training step.
         if self.loss in ("MAE", "Quantile"):
             if self.ordered_boosting:
                 warnings.warn(
@@ -1720,9 +1867,9 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
             self, X, y, sample_weight, eval_set, groups, stratify=None)
 
         # Mirror the classifier's inert-setting warnings: an explicit
-        # linear_leaves=True shadows ordered boosting / leaf refinement once
-        # the booster activates it (>= LINEAR_LEAVES_MIN_SAMPLES train rows;
-        # the None auto-audition is exempt -- it decides on validation loss).
+        # linear_leaves=True shadows ordered boosting and leaf refinement once
+        # the booster activates it, at >= LINEAR_LEAVES_MIN_SAMPLES train rows.
+        # The None auto-audition is exempt -- it decides on validation loss.
         ll_shadows = (self.linear_leaves is True
                       and self.loss not in ("MAE", "Quantile")
                       and len(X) >= LINEAR_LEAVES_MIN_SAMPLES)
@@ -1737,9 +1884,9 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                 "are active; set linear_leaves=False to use it.",
                 UserWarning, stacklevel=2)
 
-        # If early stopping is active but patience not explicitly set, use 50.
-        # 50 beat 10 on 25/34 benchmark datasets when measured (lr=0.1 keeps
-        # improving past a 10-round plateau).
+        # Default patience when early stopping is on: 50 beat 10 on 25 of 34
+        # benchmark datasets when measured, because lr=0.1 keeps improving past
+        # a 10-round plateau.
         es_rounds = self.early_stopping_rounds
         if es_active and es_rounds is None:
             es_rounds = 50
@@ -1751,45 +1898,53 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
             loss_kwargs["delta"] = self.delta
         elif self.loss == "Tweedie":
             loss_kwargs["power"] = self.tweedie_variance_power
+
         kw = {k: v for k, v in self.get_params().items()
               if k not in {"loss", "alpha", "delta",
                            "tweedie_variance_power"} | _SKLEARN_ONLY}
         kw["early_stopping_rounds"] = es_rounds
-        # Resolve the loss-adaptive depth default (see the `depth` docstring):
-        # 6 for RMSE/MAE (unchanged), 4 for Quantile, where deep leaves overfit
-        # the tail quantile and predictions collapse toward the median.
+
+        # Loss-adaptive depth default (see the `depth` docstring): 6 for
+        # RMSE/MAE, 4 for Quantile, where deep leaves overfit the tail quantile
+        # and predictions collapse toward the median.
         if kw.get("depth") is None:
             kw["depth"] = 4 if self.loss == "Quantile" else 6
-        # min_child_weight is a no-op for regression in [0, 1] (a non-empty child
-        # always holds >=1 sample = hess >= 1); resolve an explicit None to 1.0.
+
+        # min_child_weight is a no-op for regression in [0, 1] -- a non-empty
+        # child always holds >= 1 sample, so hess >= 1. Resolve None to 1.0.
         if kw.get("min_child_weight") is None:
             kw["min_child_weight"] = 1.0
-        # The regressor default is a concrete 1, but the shared validator accepts
-        # None (the classifier's auto default); resolve an explicit None to 1.
+
+        # The regressor default is a concrete 1, but the shared validator also
+        # accepts None (the classifier's auto default); resolve that to 1.
         if kw.get("leaf_estimation_iterations") is None:
             kw["leaf_estimation_iterations"] = 1
+
         # colsample None = auto: full columns for a single model (the bagged
         # path resolves members to 0.85 before this runs; see _fit_bagged).
         if kw.get("colsample") is None:
             kw["colsample"] = 1.0
-        # Auto-resolve cat_combinations: on only for tractable all-categorical data.
+
+        # cat_combinations auto: on only for tractable all-categorical data.
         if kw.get("cat_combinations") is None:
             kw["cat_combinations"] = _auto_cat_combinations(
                 cat_features, self.n_features_in_, len(X))
-        # linear_leaves=None -> validation-selected: fit constant-leaf and
+
+        # linear_leaves=None means validation-selected: fit the constant-leaf and
         # linear-leaf variants and keep whichever reaches the lower validation
-        # loss. Full-Grinsztajn breadth showed fixed linear leaves are a wash
-        # for regression (16W/12L) with real casualties; per-dataset selection
-        # on the already-held-out ES split banks the wins without them (the
-        # same post-fit-decision pattern as temperature scaling / conformal
-        # quantiles). Selection needs a validation set, RMSE (MAE/Quantile
+        # loss. Full-Grinsztajn breadth showed fixed linear leaves are a wash for
+        # regression (16W/12L) with real casualties; per-dataset selection on the
+        # already-held-out early-stopping split banks the wins without them --
+        # the same post-fit-decision pattern as temperature scaling and conformal
+        # quantiles. Selection needs a validation set, RMSE (MAE and Quantile
         # override leaf values), and enough rows for linear leaves to engage.
         ll = kw.pop("linear_leaves")
         select_ll = (ll is None and self.loss == "RMSE" and eval_set is not None
                      and len(X) >= LINEAR_LEAVES_MIN_SAMPLES)
-        # Cross-features applicability, decidable before any fit: pair
-        # candidates exist iff there are >= 2 numeric columns (diff/prod) or
-        # >= 1 numeric and >= 1 categorical (gdiff group-centering).
+
+        # Cross-features applicability, decidable before any fit: pair candidates
+        # exist iff there are >= 2 numeric columns (diff/prod), or >= 1 numeric
+        # and >= 1 categorical (gdiff group-centering).
         n_cats = len(cat_features) if cat_features else 0
         n_nums = X.shape[1] - n_cats
         cross_ok = (self.cross_features is not False and self.loss == "RMSE"
@@ -1815,17 +1970,20 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         self.linear_leaves_selected_ = None
         self.cross_features_selected_ = None
         self.cross_pairs_ = None
+
         if self.selection_rounds is not None and (select_ll or cross_ok):
             # Cheap selection (benchmarks/PARETO_PLAN.md step 2, fallback
-            # design): every selection fit runs as a short audition; the
-            # cross-augmented candidate -- which wins the full selection on
-            # the vast majority of datasets -- gets the one full fit, and the
-            # audition winner is refit in full only when the augmented model
-            # loses or cross features do not apply.
+            # design). Every selection fit runs as a short audition. The
+            # cross-augmented candidate wins the full selection on the vast
+            # majority of datasets, so it gets the one full fit; the audition
+            # winner is refit in full only when the augmented model loses or
+            # cross features do not apply.
             stop = _stop_after(self.selection_rounds)
+
             if select_ll:
                 const = _fit_booster(False, stop=stop)
                 lin = _fit_booster(True, stop=stop)
+
                 # Tie goes to constant leaves, as in the full selection.
                 self.linear_leaves_selected_ = _best_val(lin) < _best_val(const)
                 audition = lin if self.linear_leaves_selected_ else const
@@ -1833,22 +1991,24 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
             else:
                 base_linear = bool(ll)
                 audition = _fit_booster(base_linear, stop=stop)
+
             # An audition that early-stopped on its own BEFORE the cap already
-            # IS the full fit (same config/seed/curve) -- refitting it would
-            # only re-pay for the identical model. Refit only when truncated.
+            # IS the full fit -- same config, seed and curve -- so refitting it
+            # would only re-pay for an identical model. Refit only if truncated.
             capped = len(audition.valid_history_) >= self.selection_rounds
+
             pairs = (_cross_candidate_pairs(audition.feature_importances_,
                                             cat_features, X.shape[1])
                      if cross_ok else [])
             if pairs:
-                # Symmetric race at the shared budget (the rule the step-0
-                # race sim validated): both candidates are judged on their
-                # best val loss within the first selection_rounds; a trailing
-                # augmented fit is killed at the budget, a leading one
-                # continues to its own full early stop. Comparing the
-                # augmented fit's FULL best against a capped audition would
-                # bias the selection toward it (its extra rounds are not
-                # evidence the audition couldn't have matched).
+                # Symmetric race at the shared budget, the rule the step-0 race
+                # simulation validated: both candidates are judged on their best
+                # validation loss within the first selection_rounds, a trailing
+                # augmented fit is killed at the budget, and a leading one
+                # continues to its own full early stop. Comparing the augmented
+                # fit's FULL best against a capped audition would bias selection
+                # toward it -- its extra rounds are not evidence the audition
+                # couldn't have matched.
                 base_best = _best_val(audition)
                 aug = _fit_booster(base_linear, cross_pairs=pairs,
                                    stop=_stop_if_behind(self.selection_rounds,
@@ -1868,6 +2028,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         elif select_ll:
             const = _fit_booster(False)
             lin = _fit_booster(True)
+
             # Each variant early-stops itself; compare the best validation loss
             # reached. Tie goes to constant leaves (cheaper predictions).
             best_const = min(const.valid_history_) if const.valid_history_ else np.inf
@@ -1877,15 +2038,15 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         else:
             self.model_ = _fit_booster(bool(ll))
 
-        # Numeric cross features (default-on auto): refit with
-        # difference/product columns for the top numeric feature pairs of the
-        # base fit and keep whichever model reaches the lower validation loss
-        # -- the same selection-on-the-ES-split pattern as linear_leaves
-        # above. Evidence and rationale: oblivious trees staircase numeric
-        # interactions (benchmarks/probe_cross_features.py; Grinsztajn A/B
-        # 51W/8L, mean +1.5%); selection dodges the variance cases. RMSE-only
-        # (the probed loss). None (auto) and True behave the same here.
-        # (Already handled above when a selection_rounds audition ran.)
+        # Numeric cross features (default-on auto): refit with difference and
+        # product columns for the top numeric feature pairs of the base fit, and
+        # keep whichever model reaches the lower validation loss -- the same
+        # selection-on-the-validation-split pattern as linear_leaves above.
+        # Oblivious trees can only staircase a numeric interaction
+        # (benchmarks/probe_cross_features.py; Grinsztajn A/B 51W/8L, mean
+        # +1.5%), and selection dodges the variance cases. RMSE only, the probed
+        # loss; None (auto) and True behave the same. A selection_rounds audition
+        # already handled this above.
         if (self.selection_rounds is None and cross_ok):
             pairs = _cross_candidate_pairs(
                 self.model_.feature_importances_, cat_features, X.shape[1])
@@ -1897,19 +2058,21 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                 if self.cross_features_selected_:
                     self.model_ = aug
                     self.cross_pairs_ = pairs
-        # The winner is chosen; free the cached binned matrices now rather
-        # than holding them through the conformal step below.
+
+        # The winner is chosen; free the cached binned matrices now rather than
+        # holding them through the conformal step below.
         prep_cache.clear()
 
         # Conformal quantile correction on the validation split -- the
-        # regression analog of the classifier's temperature scaling. Boosting
-        # under-disperses quantiles: each round's per-leaf quantile step is
-        # shrunk by the learning rate, so the additive model converges to the
-        # tail slowly and early stopping cuts it short (predictions collapse
-        # toward the median). The fix is the split-conformal step: shift every
-        # prediction by the k-th order statistic of the validation residuals,
-        # k = ceil((n+1) * alpha) -- the standard conformal rank, which also
-        # minimizes pinball loss over all constant shifts, so accuracy and
+        # regression analog of the classifier's temperature scaling.
+        #
+        # Boosting under-disperses quantiles: each round's per-leaf quantile step
+        # is shrunk by the learning rate, so the additive model converges to the
+        # tail slowly and early stopping cuts it short, collapsing predictions
+        # toward the median. The split-conformal fix shifts every prediction by
+        # the k-th order statistic of the validation residuals,
+        # k = ceil((n+1) * alpha). That is the standard conformal rank, and it
+        # also minimizes pinball loss over all constant shifts, so accuracy and
         # coverage improve together. Distribution-free marginal coverage on
         # exchangeable data (Romano, Patterson & Candes 2019).
         self.quantile_offset_ = 0.0
@@ -1919,6 +2082,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
             w_val = (np.asarray(eval_set[2], dtype=np.float64)
                      if len(eval_set) > 2 and eval_set[2] is not None
                      else None)
+
             if w_val is None:
                 resid = np.sort(resid)
                 k = min(int(np.ceil((resid.shape[0] + 1) * self.alpha)),
@@ -1927,10 +2091,10 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                     self.quantile_offset_ = float(resid[k - 1])
             else:
                 # Weighted conformal rank: each row contributes its weight of
-                # mass, so a zero-weight holdout row cannot set the offset
-                # (the sample_weight contract). With uniform weights the
-                # threshold is alpha*(n+1) over unit masses -- exactly the
-                # unweighted k-th order statistic above.
+                # mass, so a zero-weight holdout row cannot set the offset (the
+                # sample_weight contract). Under uniform weights the threshold is
+                # alpha*(n+1) over unit masses -- exactly the unweighted k-th
+                # order statistic above.
                 keep = w_val > 0
                 resid, w_val = resid[keep], w_val[keep]
                 if resid.shape[0] >= 1:
@@ -1943,13 +2107,13 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
                                             side="left"))
                     self.quantile_offset_ = float(resid[min(j, n_eff - 1)])
 
-        # Full-data refit (benchmarks/REFIT_PLAN.md): the auto-split holdout
-        # is a pure data tax once early stopping, selection and calibration
-        # have consumed it — retrain the winning configuration on 100% of the
-        # rows at the selected budget, rounds scaled by the train-size ratio,
-        # the resolved learning rate pinned so the budget keeps its meaning.
-        # Only the auto-split path ever paid the tax (explicit eval_set /
-        # early_stopping=False are untouched); Quantile keeps its genuine
+        # Full-data refit (benchmarks/REFIT_PLAN.md). Once early stopping,
+        # selection and calibration have consumed the auto-split holdout it is a
+        # pure data tax, so retrain the winning configuration on 100% of the rows
+        # at the selected budget: rounds scaled by the train-size ratio, the
+        # resolved learning rate pinned so the budget keeps its meaning. Only the
+        # auto-split path ever paid the tax -- an explicit eval_set or
+        # early_stopping=False is untouched -- and Quantile keeps its genuine
         # conformal holdout instead.
         if (self.refit_full and auto_split and self.loss != "Quantile"
                 and self.model_.trees_):
@@ -1962,24 +2126,28 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
             self.model_ = _refit_on_full(
                 self, self.model_, bx, byy, bsw, cat_features, kw,
                 loss_kwargs=loss_kwargs, replay=True, train_frac=bfrac)
+
         return self
 
     def _transform_raw(self, raw):
-        """Map raw additive scores to predictions through the loss link --
-        identity for RMSE/MAE/Quantile/Huber (returns ``raw`` unchanged, so
-        those paths stay bit-identical), ``exp`` for Poisson/Gamma/Tweedie,
-        the custom loss's ``transform`` when it defines one."""
+        """Map raw additive scores to predictions through the loss link.
+
+        Identity for RMSE/MAE/Quantile/Huber -- ``raw`` is returned unchanged, so
+        those paths stay bit-identical. ``exp`` for Poisson/Gamma/Tweedie, and a
+        custom loss's ``transform`` when it defines one.
+        """
         tf = getattr(self.model_.loss_, "transform", None)
         return raw if tf is None else tf(raw)
 
     def predict(self, X):
         Xv = _check_predict_input(self, X)
         X = X if Xv is None else Xv
+
         if self.estimators_ is not None:
-            # One shared conversion + factorization cache for the whole bag;
-            # each member applies its own link + conformal offset (the bag
-            # prediction is the mean of member predictions). One thread-limit
-            # switch for the whole bag (members' re-entries are no-ops).
+            # One shared conversion and factorization cache for the whole bag,
+            # and one thread-limit switch (members' re-entries are no-ops). Each
+            # member applies its own link and conformal offset; the bag
+            # prediction is the mean of the member predictions.
             with _thread_limit(self.thread_count):
                 Xc, ctx = _bag_predict_context(self, X)
                 return np.mean(
@@ -1990,14 +2158,18 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
             + self.quantile_offset_
 
     def staged_predict(self, X):
-        """Yield the prediction after each successive tree (the conformal
-        quantile offset, a post-fit constant, is included in every stage so the
-        final stage equals ``predict``)."""
+        """Yield the prediction after each successive tree.
+
+        The conformal quantile offset is a post-fit constant and is included in
+        every stage, so the final stage equals ``predict``.
+        """
         Xv = _check_predict_input(self, X)
         X = X if Xv is None else Xv
+
         if self.estimators_ is not None:
             raise NotImplementedError("staged_predict is not defined for a "
                                       "bagged ensemble (n_ensembles > 1).")
+
         for staged in self.model_.staged_predict_raw(X):
             yield self._transform_raw(staged) + self.quantile_offset_
 
@@ -2009,13 +2181,16 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
 
     @property
     def validation_history_(self):
-        """Per-round validation score recorded during ``fit`` -- the training
-        loss (RMSE-space for regression), or the custom ``eval_metric`` when
-        one was set (negated when the metric declares
-        ``greater_is_better = True``, so lower is always better here). A list
-        whose length is the number of rounds run; empty when no ``eval_set`` /
-        early-stopping split was available; for a bagged model
-        (``n_ensembles > 1``) a list of the members' histories."""
+        """Per-round validation score recorded during ``fit``.
+
+        The training loss (RMSE space for regression), or the custom
+        ``eval_metric`` when one was set -- negated if the metric declares
+        ``greater_is_better = True``, so lower is always better here.
+
+        A list as long as the number of rounds run. Empty when no ``eval_set``
+        or early-stopping split was available; a list of the members' histories
+        for a bagged model (``n_ensembles > 1``).
+        """
         if self.estimators_ is not None:
             return [m.model_.valid_history_ for m in self.estimators_]
         return self.model_.valid_history_
@@ -2035,28 +2210,33 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         attribute by this call) is the mean prediction over the background. Each
         entry is a feature's signed additive contribution to the prediction;
         linear-leaf slopes are included exactly. Averaged across the bag when
-        ``n_ensembles > 1`` (the bag prediction is the members' mean, so the
-        averaged attribution stays exact). ``X_background`` overrides the
+        ``n_ensembles > 1`` -- the bag prediction is the members' mean, so the
+        averaged attribution stays exact. ``X_background`` overrides the
         reference distribution (default: a sample of the training data).
-        For the log-link losses (Poisson/Gamma/Tweedie) and custom losses
-        with a non-identity ``transform``, attributions are in raw (link)
-        space -- rows sum to the log of the prediction, the usual GBDT
-        margin-space convention."""
+
+        For the log-link losses (Poisson/Gamma/Tweedie) and custom losses with a
+        non-identity ``transform``, attributions are in raw (link) space: rows
+        sum to the log of the prediction, the usual GBDT margin-space convention.
+        """
         Xv = _check_predict_input(self, X)
         X = X if Xv is None else Xv
+
         if X_background is not None:
             # The background matrix is consumed positionally too; a reordered
             # DataFrame would silently skew every baseline.
             bg = _check_predict_input(self, X_background)
             X_background = X_background if bg is None else bg
+
         if self.estimators_ is not None:
             out = [m.model_.shap_values(X, background=X_background)
                    for m in self.estimators_]
+
             # Fold each member's conformal quantile offset into the baseline so
             # rows still sum to predict(X) - expected_value_.
             self.expected_value_ = float(np.mean(
                 [b + m.quantile_offset_ for m, (_, b) in zip(self.estimators_, out)]))
             return np.mean([p for p, _ in out], axis=0)
+
         phi, base = self.model_.shap_values(X, background=X_background)
         # The conformal quantile offset is a constant shift; it belongs to the
         # baseline, keeping rows summing to predict(X) - expected_value_.
@@ -2122,10 +2302,10 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         Extra Newton refinement steps per leaf. ``None`` is the auto default and
         resolves to 3, which helps small and categorical-heavy binary fits.
         Refinement only applies to the plain constant-leaf path: it is inert
-        while ``linear_leaves`` is active (default-on for binary ≥ ~1000 rows,
-        where the per-leaf ridge already fits the second-order-optimal leaf) and
-        is not implemented for multiclass. An explicitly-set value that will be
-        ignored on the path about to run warns.
+        while ``linear_leaves`` is active (default-on for binary at >= ~1000
+        rows, where the per-leaf ridge already fits the second-order-optimal
+        leaf) and is not implemented for multiclass. An explicitly-set value
+        that will be ignored on the path about to run warns.
     linear_leaves : bool or None, default None
         Fit a ridge linear model per leaf over the numeric split features instead
         of a constant. ``None`` enables it for binary classification and disables
@@ -2198,33 +2378,35 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
     refit_full : "replay", bool, default "replay"
         After the automatic early-stopping split has chosen the tree budget
         (and model selection / temperature scaling have used it), retrain the
-        winning configuration on 100% of the rows — rounds scaled by the
-        train-size ratio, learning rate pinned — so the final model does not
+        winning configuration on 100% of the rows -- rounds scaled by the
+        train-size ratio, learning rate pinned -- so the final model does not
         pay the holdout data tax. Only affects fits that used the automatic
         split (an explicit ``eval_set`` or ``early_stopping=False`` is
         unchanged); the calibrated temperature transfers to the refit model.
-        ``validation_history_`` keeps the early-stopped fit's curve. Costs
-        refitting on since 0.25.0: it is the strongest single-model setting
-        measured (benchmarks/SELECT_PLAN.md). Set ``False``, or ``quality=2``,
-        for the faster pre-0.25 behaviour.
+        ``validation_history_`` keeps the early-stopped fit's curve. Costs one
+        extra refit; on by default since 0.25.0, as the strongest single-model
+        setting measured (benchmarks/SELECT_PLAN.md). Set ``False``, or
+        ``quality=2``, for the faster pre-0.25 behaviour.
 
         **The default is** ``"replay"``, which gets the same thing for about
         two thirds of the cost. Growing trees is 83-85% of a fit and is a
         SEARCH; ``"replay"`` reuses the winner's tree structures and refits
         only the leaf values against full-data gradients, so the held-out rows
         still shape every leaf value while the split search is not paid for
-        twice. Measured against ``True`` at 3 seeds: on Grinsztajn accuracy was
-        flat (27W-32L over 59 datasets, mean +0.005%) and fit time fell 34% on
-        all 59; on high-cardinality categorical data it ran slightly behind
-        (mean −0.256%) for 17% less fit time. Pass ``True`` for the
-        from-scratch refit — marginally stronger on high-card data, and the
-        setting benchmarked in REFIT_PLAN.md. Multiclass ignores ``"replay"``
-        and always uses the from-scratch refit (benchmarks/REPLAY_PLAN.md).
+        twice.
+
+        Measured against ``True`` at 3 seeds: on Grinsztajn accuracy was flat
+        (27W-32L over 59 datasets, mean +0.005%) and fit time fell 34% on all
+        59; on high-cardinality categorical data it ran slightly behind (mean
+        -0.256%) for 17% less fit time. Pass ``True`` for the from-scratch
+        refit -- marginally stronger on high-card data, and the setting
+        benchmarked in REFIT_PLAN.md. Multiclass ignores ``"replay"`` and
+        always uses the from-scratch refit (benchmarks/REPLAY_PLAN.md).
     refit_members : bool, default False
         The bagged analogue of ``refit_full``, and off by default. A bag member
         trains on ``max_samples`` of the rows and early-stops on its
         out-of-bag complement, so its leaf values never see the rows it stopped
-        on — the full-data refit that helps a single model has never fired for
+        on -- the full-data refit that helps a single model has never fired for
         it. With ``True`` each member replays its own tree structure against
         gradients from every row once early stopping is done. Only the leaf
         values move; the splits stay exactly as that member's own sample grew
@@ -2353,18 +2535,18 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
             here overrides the constructor value. (The constructor form lets
             ``GridSearchCV``/``Pipeline`` carry it, which a fit-only kwarg can't.)
         eval_set : (X_val, y_val) tuple or None
-            Explicit validation set with original class labels.  When provided,
+            Explicit validation set with original class labels. When provided,
             automatic splitting is skipped.
         groups : array-like of shape (n_samples,) or None
-            Group labels (e.g. ``df['subject_id']``).  When supplied and early
+            Group labels (e.g. ``df['subject_id']``). When supplied and early
             stopping triggers an automatic split, ``StratifiedGroupKFold`` keeps
             groups intact and class proportions balanced across the split.
         sample_weight : array-like of shape (n_samples,) or None
-            Per-sample weights.  Normalized to mean 1 internally.  Applied
+            Per-sample weights, normalized to mean 1 internally. Applied
             throughout: the gradient/leaf fit, the categorical target encoder,
             the quantile bin borders, and the early-stopping metric on an
             automatically split (or bagged out-of-bag) validation set, so a
-            zero-weight row never influences the model.  An explicitly passed
+            zero-weight row never influences the model. An explicitly passed
             ``eval_set`` carries no weights and is scored unweighted.
         callbacks : callable or list of callable, or None
             Per-round fit hooks ``cb(iteration, train_loss, val_loss, model)``;
@@ -2377,21 +2559,25 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         _validate_hyperparams(self)
         y = _validate_fit_input(self, X, y, cat_features, sample_weight,
                                 classification=True)
+
         if eval_set is not None:
             _check_eval_set(eval_set, self.n_features_in_,
                             classification=True)
             if not getattr(self, "_is_bag_member", False):
                 _check_feature_names_match(self, eval_set[0])
+
             # Bag members are exempt: their OOB eval set may legitimately hold
             # a rare label their row sample missed, and the parent aligns
             # member probability columns to the global class set.
             if not getattr(self, "_is_bag_member", False):
                 _check_eval_labels(eval_set, y)
+
         with _quality_applied(self):
             if self.n_ensembles and self.n_ensembles > 1:
                 if callbacks is not None:
                     raise ValueError(
                         "callbacks are not supported with n_ensembles > 1.")
+
                 # Fix the global class set up front: a member's bootstrap may
                 # miss a rare class, and predict_proba aligns each member's
                 # columns to this.
@@ -2402,10 +2588,12 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                     raise ValueError(
                         f"Need at least 2 classes; got {self.n_classes_} "
                         "class(es).")
+
                 self._multiclass = self.n_classes_ > 2
                 self.estimators_ = _fit_bagged(self, X, yarr, cat_features,
                                                eval_set, groups, sample_weight)
                 return self
+
             self.estimators_ = None
             return self._fit_single(X, y, cat_features, eval_set, groups,
                                     sample_weight, callbacks)
@@ -2440,14 +2628,15 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         es_active, auto_split, X, y, sample_weight, eval_set = _auto_es_split(
             self, X, y, sample_weight, eval_set, groups,
             stratify=y)  # always stratify for classification
+
         if auto_split:
             self.classes_ = np.unique(y)
             self.n_classes_ = self.classes_.size
             lost = np.setdiff1d(all_classes, self.classes_)
             if lost.size and not getattr(self, "_is_bag_member", False):
-                # Without this, the model silently trains without the lost
-                # class and never predicts it (its eval rows are even
-                # remapped onto neighboring classes).
+                # Without this the model silently trains without the lost class
+                # and never predicts it -- its eval rows are even remapped onto
+                # neighboring classes.
                 raise ValueError(
                     f"The automatic early-stopping split left class(es) "
                     f"{lost.tolist()} entirely in the validation set, "
@@ -2463,35 +2652,41 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         kw = {k: v for k, v in self.get_params().items()
               if k not in _SKLEARN_ONLY}
         kw["early_stopping_rounds"] = es_rounds
-        # Size-adaptive min_child_weight (see _auto_min_child_weight): resolved
-        # on the FINAL training set (post early-stopping split).
+
+        # Size-adaptive min_child_weight (see _auto_min_child_weight), resolved
+        # on the FINAL training set, after the early-stopping split.
         if kw.get("min_child_weight") is None:
             kw["min_child_weight"] = _auto_min_child_weight(len(X))
+
         # An explicit depth=None resolves to the documented classifier default
         # (the regressor resolves it per loss); the booster requires an int.
         if kw.get("depth") is None:
             kw["depth"] = 6
-        # leaf_estimation_iterations None = auto -> 3. This is the classifier's
-        # long-standing effective value (it helps small/categorical binary and
-        # is inert where linear leaves take over or for multiclass); None just
-        # keeps the API from advertising a concrete count that is dead in those
-        # regimes. The booster requires an int.
+
+        # leaf_estimation_iterations None = auto -> 3, the classifier's
+        # long-standing effective value: it helps small and categorical binary
+        # fits, and is inert where linear leaves take over or for multiclass.
+        # None just keeps the API from advertising a concrete count that is dead
+        # in those regimes. The booster requires an int.
         if kw.get("leaf_estimation_iterations") is None:
             kw["leaf_estimation_iterations"] = 3
+
         # colsample None = auto: full columns for a single model (the bagged
         # path resolves members to 0.85 before this runs; see _fit_bagged).
         if kw.get("colsample") is None:
             kw["colsample"] = 1.0
-        # Auto-resolve cat_combinations: on only for tractable all-categorical data
-        # (targets the all-categorical multiclass gap, e.g. car).
+
+        # cat_combinations auto: on only for tractable all-categorical data,
+        # which targets the all-categorical multiclass gap (car and friends).
         if kw.get("cat_combinations") is None:
             kw["cat_combinations"] = _auto_cat_combinations(
                 cat_features, self.n_features_in_, len(X))
 
         self._multiclass = self.n_classes_ > 2
-        # Resolve the linear_leaves auto-default: ON for binary (a clean broad
-        # Brier win that survives bagging), OFF for multiclass (unsupported).
-        # An explicit True on multiclass is a user error -> raise; explicit
+
+        # linear_leaves auto-default: ON for binary (a clean broad Brier win that
+        # survives bagging), OFF for multiclass, where it is unsupported. An
+        # explicit True on multiclass is a user error and raises; an explicit
         # False is honored everywhere.
         if self.linear_leaves is None:
             kw["linear_leaves"] = not self._multiclass
@@ -2499,10 +2694,11 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
             raise NotImplementedError(
                 "linear_leaves is not supported for multiclass classification "
                 "yet; use it on regression or binary classification.")
+
         # Warn when an explicitly non-default setting will be silently inert on
-        # the path about to run (the auto defaults stay quiet -- the precedence
-        # is documented). The linear-leaf update owns the training step, so it
-        # shadows both ordered boosting and leaf refinement; multiclass never
+        # the path about to run. The auto defaults stay quiet -- their precedence
+        # is documented. The linear-leaf update owns the training step, so it
+        # shadows both ordered boosting and leaf refinement, and multiclass never
         # refines leaves. leaf_estimation_iterations is checked against the raw
         # attribute (None = auto, no user intent) rather than the resolved kw,
         # and a refinement count of 1 asks for nothing, so neither warns.
@@ -2524,15 +2720,16 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
             warnings.warn(
                 "leaf_estimation_iterations is not implemented for multiclass "
                 "and will be ignored.", UserWarning, stacklevel=2)
-        # cross_features: None (auto default) and True run the same
-        # validation-selected race everywhere, multiclass included (M1);
-        # explicit False disables.
+
+        # cross_features: None (the auto default) and True run the same
+        # validation-selected race everywhere, multiclass included (M1); an
+        # explicit False disables it.
         cal_Xv = cal_y = cal_w = None  # validation set used to calibrate temperature
+
         # Cheap selection (benchmarks/PARETO_PLAN.md step 2): when
-        # selection_rounds is set and the cross refit will run (pair
-        # candidates exist iff >= 2 numeric columns), the base fit is only
-        # an audition -- cap it; it is refit in full below only if the
-        # augmented model loses the selection.
+        # selection_rounds is set and the cross refit will run (pair candidates
+        # exist iff >= 2 numeric columns), the base fit is only an audition, so
+        # cap it. It is refit in full below only if the augmented model loses.
         n_cats = len(cat_features) if cat_features else 0
         n_nums = X.shape[1] - n_cats
         fast = (self.selection_rounds is not None
@@ -2540,10 +2737,12 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                 and eval_set is not None and len(X) >= CROSS_MIN_SAMPLES
                 and (n_nums >= 2 or (n_nums >= 1 and n_cats >= 1)))
         stop = _stop_after(self.selection_rounds) if fast else None
-        # Shared across the base fit, the cross-augmented candidate, and
-        # the possible refit below -- identical inputs, so preprocessing
-        # is computed once (see _BaseBooster._prep_matrices).
+
+        # Shared across the base fit, the cross-augmented candidate and the
+        # possible refit below: identical inputs, so preprocessing is computed
+        # once (see _BaseBooster._prep_matrices).
         prep_cache = {}
+
         if self._multiclass:
             def _make(**extra):
                 return MulticlassBoosting(**extra, **kw)
@@ -2562,23 +2761,26 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                 sw_v = eval_set[2] if len(eval_set) > 2 else None
                 cal_w = sw_v
                 eval_set = (cal_Xv, cal_y, sw_v)
+
         self.model_ = _make()
         self.model_.fit(X, y_fit, cat_features=cat_features, eval_set=eval_set,
                         sample_weight=sample_weight,
                         callbacks=_add_callback(callbacks, stop),
                         prep_cache=prep_cache)
+
         if self._multiclass:
             self.classes_ = self.model_.classes_
             if eval_set is not None:
                 cal_y = np.searchsorted(self.classes_, np.asarray(eval_set[1]))
 
-        # Numeric cross features (default-on auto): refit with difference/
-        # product columns for the top numeric feature pairs of the base fit
-        # and keep the lower-validation-loss model (the regressor's selection
-        # pattern; see _cross_candidate_pairs). Binary judges on binary
-        # logloss, multiclass on softmax logloss -- same raced budget.
+        # Numeric cross features (default-on auto): refit with difference and
+        # product columns for the top numeric feature pairs of the base fit, and
+        # keep the lower-validation-loss model -- the regressor's selection
+        # pattern, see _cross_candidate_pairs. Binary judges on binary log loss,
+        # multiclass on softmax log loss, at the same raced budget.
         self.cross_features_selected_ = None
         self.cross_pairs_ = None
+
         if (self.cross_features is not False
                 and eval_set is not None and len(X) >= CROSS_MIN_SAMPLES):
             pairs = _cross_candidate_pairs(
@@ -2587,7 +2789,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                 aug = _make(cross_pairs=pairs)
                 if fast:
                     # Symmetric race at the shared budget (see the regressor):
-                    # judge both candidates on their first selection_rounds;
+                    # judge both candidates on their first selection_rounds and
                     # kill a trailing augmented fit at the budget.
                     base_best = _best_val(self.model_)
                     aug.fit(X, y_fit, cat_features=cat_features,
@@ -2605,13 +2807,14 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                             callbacks=callbacks, prep_cache=prep_cache)
                     self.cross_features_selected_ = \
                         _best_val(aug) < _best_val(self.model_)
+
                 if self.cross_features_selected_:
                     self.model_ = aug
                     self.cross_pairs_ = pairs
                 elif fast and len(self.model_.valid_history_) >= self.selection_rounds:
-                    # The incumbent audition was actually truncated by the cap
-                    # (an audition that early-stopped on its own already IS the
-                    # full fit); give the winning base variant its full fit.
+                    # The incumbent audition really was truncated by the cap, so
+                    # give the winning base variant its full fit. (An audition
+                    # that early-stopped on its own already IS the full fit.)
                     self.model_ = _make()
                     self.model_.fit(X, y_fit, cat_features=cat_features,
                                     eval_set=eval_set,
@@ -2623,7 +2826,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         # holding them through temperature scaling below.
         prep_cache.clear()
 
-        # Temperature scaling on the validation set: dividing raw scores by T > 0
+        # Temperature scaling on the validation set. Dividing raw scores by T > 0
         # is monotonic, so predict() is unchanged while predict_proba() becomes
         # better calibrated (lower log loss).
         self.temperature_ = 1.0
@@ -2632,10 +2835,11 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
             self.temperature_ = _fit_temperature(raw, cal_y, self._multiclass,
                                                  sample_weight=cal_w)
 
-        # Full-data refit (benchmarks/REFIT_PLAN.md): reclaim the auto-split
-        # data tax after early stopping, selection and temperature scaling
-        # have consumed the holdout. The temperature above was calibrated on
-        # the ES winner's validation scores and transfers to the refit model.
+        # Full-data refit (benchmarks/REFIT_PLAN.md): reclaim the auto-split data
+        # tax once early stopping, selection and temperature scaling have
+        # consumed the holdout. The temperature above was calibrated on the
+        # early-stopping winner's validation scores and transfers to the refit
+        # model.
         if self.refit_full and auto_split and self.model_.trees_:
             y_refit = (y_full if self._multiclass else
                        (y_full == self.classes_[1]).astype(np.float64))
@@ -2644,35 +2848,39 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
                 replay=self.refit_full == "replay")
         elif (_bag_refit_rows(self) is not None and self.model_.trees_
                 and not self._multiclass):
-            # Binary only: multiclass has no replay path (`_refit_on_full`
-            # rebuilds a vector-leaf model from scratch there), so a member
+            # Binary only. Multiclass has no replay path -- `_refit_on_full`
+            # rebuilds a vector-leaf model from scratch there -- so a member
             # refit would cost a whole extra fit per member instead of a cheap
-            # structure replay -- a different trade that this evidence does
-            # not cover. Multiclass bags are unchanged.
+            # structure replay. That is a different trade, and this evidence does
+            # not cover it, so multiclass bags are unchanged.
             bx, byy, bsw, bfrac = _bag_refit_rows(self)
             y_refit = (byy == self.classes_[1]).astype(np.float64)
             self.model_ = _refit_on_full(
                 self, self.model_, bx, y_refit, bsw, cat_features, kw,
                 replay=True, train_frac=bfrac)
+
         return self
 
     def predict_proba(self, X):
         Xv = _check_predict_input(self, X)
         X = X if Xv is None else Xv
+
         if self.estimators_ is not None:
-            # Soft-vote: average members' calibrated probabilities, aligning each
-            # member's class columns to the global class set (a member whose
-            # bootstrap missed a class simply contributes 0 to that column).
-            # One shared conversion + factorization cache for the whole bag,
-            # and one thread-limit switch (members' re-entries are no-ops).
+            # Soft-vote: average the members' calibrated probabilities, aligning
+            # each member's class columns to the global class set. A member whose
+            # sample missed a class simply contributes 0 to that column. One
+            # shared conversion and factorization cache for the whole bag, and
+            # one thread-limit switch (members' re-entries are no-ops).
             with _thread_limit(self.thread_count):
                 Xc, ctx = _bag_predict_context(self, X)
                 probas = [m._proba_impl(Xc, ctx) for m in self.estimators_]
+
             acc = np.zeros((probas[0].shape[0], self.n_classes_))
             for m, p in zip(self.estimators_, probas):
                 cols = np.searchsorted(self.classes_, m.classes_)
                 acc[:, cols] += p
             return acc / len(self.estimators_)
+
         return self._proba_impl(X)
 
     def _proba_impl(self, X, cat_ctx=None):
@@ -2696,10 +2904,12 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
 
     @property
     def validation_history_(self):
-        """Per-round validation loss recorded during ``fit`` (binary or softmax
-        log loss), as a list whose length is the number of rounds run. Empty when
-        no ``eval_set`` / early-stopping split was available; for a bagged model
-        (``n_ensembles > 1``) a list of the members' histories."""
+        """Per-round validation loss recorded during ``fit`` -- binary or softmax
+        log loss -- as a list as long as the number of rounds run.
+
+        Empty when no ``eval_set`` or early-stopping split was available; a list
+        of the members' histories for a bagged model (``n_ensembles > 1``).
+        """
         if self.estimators_ is not None:
             return [m.model_.valid_history_ for m in self.estimators_]
         return self.model_.valid_history_
@@ -2718,24 +2928,29 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         rows sum to ``raw_log_odds(X) - expected_value_`` (pre-temperature), with
         ``expected_value_`` set as an attribute. Each entry is a feature's signed
         contribution to the log-odds of the positive class; linear-leaf slopes are
-        included exactly. Averaged across the bag when ``n_ensembles > 1`` (an
-        additive surrogate for the soft-voted probability). Multiclass is not
-        supported yet. ``X_background`` overrides the reference distribution."""
+        included exactly. Averaged across the bag when ``n_ensembles > 1``, an
+        additive surrogate for the soft-voted probability. Multiclass is not
+        supported yet. ``X_background`` overrides the reference distribution.
+        """
         Xv = _check_predict_input(self, X)
         X = X if Xv is None else Xv
+
         if X_background is not None:
             bg = _check_predict_input(self, X_background)
             X_background = X_background if bg is None else bg
+
         members = self.estimators_ if self.estimators_ is not None else None
         if (members is not None and getattr(members[0], "_multiclass", False)) \
                 or (members is None and self._multiclass):
             raise NotImplementedError(
                 "shap_values is not supported for multiclass classification yet.")
+
         if members is not None:
             out = [m.model_.shap_values(X, background=X_background)
                    for m in members]
             self.expected_value_ = float(np.mean([b for _, b in out]))
             return np.mean([p for p, _ in out], axis=0)
+
         phi, base = self.model_.shap_values(X, background=X_background)
         self.expected_value_ = base
         return phi

--- a/chimeraboost/tree.py
+++ b/chimeraboost/tree.py
@@ -17,37 +17,40 @@ import numpy as np
 from numba import njit, prange
 
 
-# Below this many samples, per-level work is fixed-cost bound (kernel launches,
-# empty-leaf zero/scan, strided split scans) rather than sample bound;
-# build_oblivious_tree switches to the small-n variants (occupied-leaf lists,
-# serial descend). Both sides of every dispatch are bit-identical, so the
-# threshold only affects speed. 32768 sits comfortably between the measured
-# regimes (1.7x fused win at 2k, parity at 200k).
+# Below this many samples, per-level cost is fixed overhead (kernel launches,
+# empty-leaf zero/scan, strided split scans) rather than sample count, so
+# build_oblivious_tree switches to the small-n variants: occupied-leaf lists
+# and a serial descend.
+#
+# Both sides of every dispatch are bit-identical, so this only moves speed.
+# 32768 sits between the measured regimes: 1.7x fused win at 2k, parity at 200k.
 _SMALL_N = 32768
 
 # Above this many rows, ObliviousTree.apply descends level by level with the
-# parallel `_descend_leaves` instead of the serial fused `_assign_leaves`:
-# the per-level fork/join only amortizes once the serial O(n x depth) walk
-# clearly dominates it. Both sides are bit-identical, so the threshold only
-# moves speed. Matters per boosting round: eval-set scoring and replay
-# refits assign leaves once per retained tree.
+# parallel `_descend_leaves` instead of the serial fused `_assign_leaves`. The
+# per-level fork/join only pays for itself once the serial O(n x depth) walk
+# clearly dominates it.
+#
+# Both sides are bit-identical, so this only moves speed. It matters once per
+# boosting round: eval-set scoring and replay refits assign leaves once per
+# retained tree.
 _ASSIGN_PAR_N = 32768
 
-# Placeholder passed as the fused level kernel's occupancy buffer on the
-# large-n path, where it is never touched (shared and read-only, so safe
-# across concurrent fits).
+# Passed as the fused level kernel's occupancy buffer on the large-n path,
+# where it is never touched. Shared and read-only, so safe across concurrent
+# fits.
 _EMPTY_I64 = np.empty(0, dtype=np.int64)
 
 
 # --- MVS gradient row sampling -------------------------------------------
-# These run once per boosting round, before any tree work. They are here
+# These run once per boosting round, before any tree work. They live here
 # rather than in booster.py because booster.py holds no kernels: it imports
 # every one of them from this module.
 #
-# The tree build is numba-parallel across every core while this step was
-# single-threaded numpy allocating ~10 full-length temporaries per round, so
-# at 200k rows subsampling cost more than the trees it fed: measured at 61%
-# of a subsample=0.7 fit. Whole-fit effect of the port, 12 threads, best of 2
+# The tree build is numba-parallel across every core, while this step used to
+# be single-threaded numpy allocating ~10 full-length temporaries per round.
+# At 200k rows subsampling therefore cost more than the trees it fed: 61% of
+# a subsample=0.7 fit. Whole-fit effect of the port, 12 threads, best of 2
 # (2026-07-30):
 #
 #                             case   subsample     base      new
@@ -57,24 +60,24 @@ _EMPTY_I64 = np.empty(0, dtype=np.int64)
 #     binary     200k x 20, 200 trees      0.7    3.96 s   3.00 s   1.32x
 #     multiclass 200k x 20, 100 trees      0.7    5.02 s   4.63 s   1.08x
 #
-# Multiclass gains least: its vector-leaf round does K channels of work
-# around one shared row draw, so sampling is a smaller slice to begin with.
-# What is left is dominated by the np.sort, which stays in numpy on purpose
-# (see _mvs_lambda_scan) and which numpy 2.x vectorizes better than we could.
+# Multiclass gains least: its vector-leaf round does K channels of work around
+# one shared row draw, so sampling is a smaller slice to begin with. What is
+# left is dominated by the np.sort, which stays in numpy on purpose (see
+# _mvs_lambda_scan) and which numpy 2.x vectorizes better than we could.
 
 
 @njit(cache=True)
 def _mvs_lambda_scan(sorted_g, total, target):
     """MVS threshold: the first k where sorted_g[k] <= suffix[k]/remaining[k].
 
-    `sorted_g` is |grad| sorted DESCENDING and `total` is its sum; both are
-    computed by the caller in numpy and must stay there -- they are the only
-    two operations in the MVS path that use numpy's pairwise summation, so
-    reproducing them here is what would move lambda in the last ulp, and a
-    moved lambda changes which rows the mask keeps and therefore the model.
+    `sorted_g` is |grad| sorted DESCENDING and `total` is its sum. The caller
+    computes both in numpy and they MUST stay there: they are the only two
+    operations in the MVS path that rely on numpy's pairwise summation. Redoing
+    them here would move lambda in the last ulp, and a moved lambda changes which
+    rows the mask keeps -- so it changes the model.
 
-    Everything else is exact, which is why this loop is bit-identical to the
-    vectorized form it replaces:
+    Everything else is exact, so this loop is bit-identical to the vectorized
+    form it replaces:
 
       * `prefix` reproduces `np.cumsum(sorted_g[:-1])` exactly -- cumsum is
         `add.accumulate`, sequential by definition, so there is no summation
@@ -82,25 +85,29 @@ def _mvs_lambda_scan(sorted_g, total, target):
       * `remaining` equals `target - np.arange(n)[k]` exactly for n < 2**53.
       * the comparison and the final divide are single IEEE-754 double
         operations on the same operands as the vectorized form. No fastmath
-        anywhere in this module, and no `a*b + c` shape here, so nothing can
-        be contracted into an FMA.
+        anywhere in this module, and no `a*b + c` shape here, so nothing can be
+        contracted into an FMA.
 
-    Fusing also buys an early exit and drops six full-length temporaries
-    (prefix, suffix, remaining, the product, the boolean cond, its argmax).
-    Once `remaining` hits zero every later k fails the test too, so bailing
-    there matches `cond.any() == False` -> lambda 0, the "all rows forced"
-    signal the caller reads as "use the uniform fallback".
+    Fusing also buys an early exit and drops six full-length temporaries (prefix,
+    suffix, remaining, the product, the boolean cond, its argmax). Once
+    `remaining` hits zero every later k fails too, so bailing there matches
+    `cond.any() == False` -> lambda 0, the "all rows forced" signal the caller
+    reads as "use the uniform fallback".
     """
     n = sorted_g.shape[0]
     prefix = 0.0
+
     for k in range(n):
         remaining = target - np.float64(k)
         if remaining <= 0.0:
             return 0.0
+
         suffix = total - prefix
         if sorted_g[k] * remaining <= suffix:
             return suffix / remaining
+
         prefix += sorted_g[k]
+
     return 0.0
 
 
@@ -108,17 +115,16 @@ def _mvs_lambda_scan(sorted_g, total, target):
 def _mvs_weights(grad, u, lam, max_w):
     """Per-row MVS importance weights: 1/p where the row survives, else 0.
 
-    Replaces seven numpy passes and their temporaries (`np.abs`, the divide,
-    `np.minimum`, the mask compare, `np.maximum`, the cap `np.minimum`, and
-    `np.where`) with one fused pass. Every one of those is elementwise, so
-    evaluating them per row reproduces the vectorized result exactly --
-    including the NaN corners, where `p > 1.0` is False so `p` stays NaN,
-    `u < NaN` is False, and the row lands on the zero branch just as
-    `np.where(mask, ..., 0.0)` puts it.
+    One fused pass replaces seven numpy passes and their temporaries (`np.abs`,
+    the divide, `np.minimum`, the mask compare, `np.maximum`, the cap
+    `np.minimum`, `np.where`). All of those are elementwise, so evaluating them
+    per row reproduces the vectorized result exactly -- including the NaN
+    corners, where `p > 1.0` is False so `p` stays NaN, `u < NaN` is False, and
+    the row lands on the zero branch just as `np.where(mask, ..., 0.0)` puts it.
 
-    `u` is the caller's `rng.random(n)` draw, passed in rather than generated
-    here: that draw is one call on the booster's numpy Generator and the
-    stream position is golden-frozen.
+    `u` is the caller's `rng.random(n)` draw rather than one generated here:
+    that draw is a single call on the booster's numpy Generator and the stream
+    position is golden-frozen.
 
     The cap `max_w = 1/subsample` bounds the reweighting of near-zero-gradient
     rows, whose effective contribution g_i/p_i is lambda regardless.
@@ -141,8 +147,11 @@ def _mvs_weights(grad, u, lam, max_w):
 @njit(cache=True)
 def _mvs_weights_serial(grad, u, lam, max_w):
     """Serial twin of `_mvs_weights` for small n, where the parallel fork/join
-    costs more than the pass. Every write is independent, so the two are
-    bit-identical; the booster dispatches on `_SMALL_N`."""
+    costs more than the pass itself.
+
+    Every write is independent, so the two are bit-identical; the booster
+    dispatches on `_SMALL_N`.
+    """
     n = grad.shape[0]
     w = np.empty(n, dtype=np.float64)
     for i in range(n):
@@ -162,33 +171,36 @@ def _mvs_weights_serial(grad, u, lam, max_w):
 def _build_histograms_into(Xb, grad, hess, leaf, n_leaves, hist, feat_mask):
     """Fill per-feature gradient/hessian histograms into a pre-allocated buffer.
 
-    REFERENCE KERNEL: the fit path now uses the fused `_build_and_split`; this
+    REFERENCE KERNEL: the fit path now uses the fused `_build_and_split`. This
     is kept (with `_best_split`) as the plainly-readable equivalence oracle for
     tests/test_tree_kernels.py.
 
     `Xb` is feature-major (n_features, n_samples), so `Xb[f]` is a contiguous
-    row and the inner sample loop reads bins, grads, and hessians sequentially.
+    row and the inner sample loop reads bins, grads and hessians sequentially.
 
-    `hist` has shape (n_features, max_leaves, max_bins, 2): grad and hess for a
-    bin are interleaved on the last axis so each scatter write touches a single
-    cache line instead of two separate arrays. Reused across every tree and
-    level; we zero only the (n_leaves) slice we are about to write. Parallelized
-    over features so each thread owns a disjoint slice -- no write races.
+    `hist` has shape (n_features, max_leaves, max_bins, 2). Grad and hess for a
+    bin are interleaved on the last axis so each scatter write touches one cache
+    line instead of two arrays. The buffer is reused across every tree and level,
+    and we zero only the (n_leaves) slice we are about to write. Parallel over
+    features, so each thread owns a disjoint slice -- no races.
 
-    Features with feat_mask[f] == 0 (column subsampling) are skipped entirely:
-    `_best_split` never reads their slice (it honors the same mask), so the
-    stale data left there is harmless and the whole scan is saved. At
-    colsample=c that removes a (1-c) fraction of histogram work.
+    Features with feat_mask[f] == 0 (column subsampling) are skipped entirely.
+    `_best_split` honors the same mask and never reads their slice, so the stale
+    data left there is harmless and the whole scan is saved. At colsample=c that
+    removes a (1-c) fraction of histogram work.
     """
     n_features, n_samples = Xb.shape
     max_bins = hist.shape[2]
+
     for f in prange(n_features):
         if feat_mask[f] == 0:
             continue
+
         for l in range(n_leaves):
             for b in range(max_bins):
                 hist[f, l, b, 0] = 0.0
                 hist[f, l, b, 1] = 0.0
+
         Xf = Xb[f]
         for i in range(n_samples):
             l = leaf[i]
@@ -201,16 +213,16 @@ def _build_histograms_into(Xb, grad, hess, leaf, n_leaves, hist, feat_mask):
 def _descend_leaves(leaf, Xf, t):
     """Push every sample one level deeper, in place: leaf = (leaf<<1) + (Xf > t).
 
-    The fit path descends inside `_build_split_descend`; this kernel is the
-    large-n arm of `ObliviousTree.apply` (per-round eval scoring, replay
-    refits) and the descend oracle for tests/test_tree_kernels.py.
+    The fit path descends inside `_build_split_descend`. This kernel is the
+    large-n arm of `ObliviousTree.apply` (per-round eval scoring, replay refits)
+    and the descend oracle for tests/test_tree_kernels.py.
 
-    Replaces the per-level numpy expression
-    ``leaf = (leaf << 1) + (Xb[f] > t).astype(np.int64)`` which allocated several
-    n-sample temporaries (the bool mask, its int64 cast, the shifted array, the
-    sum) on every one of the (max_depth x n_trees) level steps — measured at ~⅓
-    of total fit time. One parallel pass over the contiguous feature row, no
-    temporaries; bit-identical bucketing.
+    It replaces the numpy expression
+    ``leaf = (leaf << 1) + (Xb[f] > t).astype(np.int64)``, which allocated
+    several n-sample temporaries (the bool mask, its int64 cast, the shifted
+    array, the sum) on every one of the (max_depth x n_trees) level steps —
+    measured at ~⅓ of total fit time. One parallel pass over the contiguous
+    feature row, no temporaries, bit-identical bucketing.
     """
     for i in prange(leaf.shape[0]):
         leaf[i] = (leaf[i] << 1) + (1 if Xf[i] > t else 0)
@@ -220,8 +232,10 @@ def _descend_leaves(leaf, Xf, t):
 def _descend_leaves_serial(leaf, Xf, t):
     """Serial twin of `_descend_leaves` for small n, where the parallel
     fork/join costs more than the pass itself (~4.7us vs 0.9us at n=2k).
+
     Every write is independent, so serial and parallel are bit-identical;
-    `build_oblivious_tree` dispatches on `_SMALL_N`."""
+    `build_oblivious_tree` dispatches on `_SMALL_N`.
+    """
     for i in range(leaf.shape[0]):
         leaf[i] = (leaf[i] << 1) + (1 if Xf[i] > t else 0)
 
@@ -229,37 +243,35 @@ def _descend_leaves_serial(leaf, Xf, t):
 @njit(cache=True, parallel=True)
 def _build_and_split(Xb, grad, hess, leaf, active, hist, feat_mask,
                      n_bins_per_feature, l2, min_child_weight):
-    """Fused histogram build + best-split search: one parallel launch per
-    level instead of two, and the split scan runs on the hist slice the same
-    thread just wrote (cache-hot).
+    """Fused histogram build + best-split search: one parallel launch per level
+    instead of two, with the split scan reading the hist slice the same thread
+    just wrote (cache-hot).
 
-    REFERENCE KERNEL: the fit path now runs `_build_split_descend` (this
-    kernel's search plus the level's descend/occupancy in the same launch);
-    this is retained as its split-search oracle for
-    tests/test_tree_kernels.py.
+    REFERENCE KERNEL: the fit path runs `_build_split_descend`, which adds the
+    level's descend and occupancy to this search. Kept as that kernel's
+    split-search oracle for tests/test_tree_kernels.py.
 
-    Produces EXACTLY the outputs of `_build_histograms_into` followed by
-    `_best_split` (the retained reference kernels in this module) — verified
-    by an exact-equality test — while cutting the small-n fixed cost three
-    ways:
+    Output is EXACTLY `_build_histograms_into` followed by `_best_split` --
+    checked by an exact-equality test -- while cutting the small-n fixed cost
+    three ways:
 
-      * `active` lists the leaf rows that actually contain samples (callers
-        may pass any superset, e.g. arange(n_leaves) when counting isn't
-        worth it). Empty leaves are all-zero histogram rows: skipping them
-        skips zeroing and scanning cells that contribute nothing. Occupancy
-        is feature-independent, so one list serves every feature.
-      * Only bins [0, n_bins_[f]) are zeroed and scanned per feature — the
-        scatter never writes past a feature's actual bin count.
-      * The split scan is transposed (leaf-outer, bin-inner): the prefix and
-        gain passes stream each hist row sequentially instead of striding
-        across leaf rows per threshold. gain[t] still accumulates leaves in
-        ascending order, so every floating-point sum matches the reference
-        `_best_split` bit for bit; the parent term gl*gl/(ht+l2) is computed
-        once per leaf (identical value, one divide instead of nb-1).
+      * `active` lists the leaf rows that hold samples (any superset works, e.g.
+        arange(n_leaves) when counting isn't worth it). Empty leaves are all-zero
+        rows, so skipping them skips zeroing and scanning cells that contribute
+        nothing. Occupancy is feature-independent, so one list serves every
+        feature.
+      * Only bins [0, n_bins_[f]) are zeroed and scanned — the scatter never
+        writes past a feature's actual bin count.
+      * The scan is transposed (leaf-outer, bin-inner), so the prefix and gain
+        passes stream each hist row instead of striding across leaf rows per
+        threshold. gain[t] still accumulates leaves in ascending order, so every
+        float sum matches `_best_split` bit for bit. The parent term
+        gt*gt/(ht+l2) is computed once per leaf: same value, one divide instead
+        of nb-1.
 
-    Legality (`min_child_weight`) matches the reference: a threshold dies if
-    ANY contributing leaf would gain a sparse non-empty child; leaves with no
-    hessian mass contribute neither gain nor legality vetoes.
+    Legality (`min_child_weight`) matches the reference: a threshold dies if ANY
+    contributing leaf would gain a sparse non-empty child. Leaves with no hessian
+    mass cast neither gain nor veto.
     """
     n_features, n_samples = Xb.shape
     max_bins = hist.shape[2]
@@ -270,12 +282,15 @@ def _build_and_split(Xb, grad, hess, leaf, active, hist, feat_mask,
     for f in prange(n_features):
         if feat_mask[f] == 0:
             continue
+
+        # Zero this feature's leaf rows, then scatter the samples in.
         nb = n_bins_per_feature[f]
         for k in range(n_active):
             l = active[k]
             for b in range(nb):
                 hist[f, l, b, 0] = 0.0
                 hist[f, l, b, 1] = 0.0
+
         Xf = Xb[f]
         for i in range(n_samples):
             l = leaf[i]
@@ -283,8 +298,10 @@ def _build_and_split(Xb, grad, hess, leaf, active, hist, feat_mask,
             hist[f, l, b, 0] += grad[i]
             hist[f, l, b, 1] += hess[i]
 
+        # Score every threshold, summing gain across the leaves.
         gain = np.zeros(max_bins)
         legal = np.ones(max_bins, dtype=np.uint8)
+
         for k in range(n_active):
             l = active[k]
             gt = 0.0
@@ -292,11 +309,14 @@ def _build_and_split(Xb, grad, hess, leaf, active, hist, feat_mask,
             for b in range(nb):
                 gt += hist[f, l, b, 0]
                 ht += hist[f, l, b, 1]
+
             if ht <= 0.0:
                 continue
+
             par = gt * gt / (ht + l2)
             gl = 0.0
             hl = 0.0
+
             for t in range(nb - 1):
                 gl += hist[f, l, t, 0]
                 hl += hist[f, l, t, 1]
@@ -316,15 +336,18 @@ def _build_and_split(Xb, grad, hess, leaf, active, hist, feat_mask,
             if legal[t] and gain[t] > best_g:
                 best_g = gain[t]
                 best_t = t
+
         feat_gain[f] = best_g
         feat_thr[f] = best_t
 
+    # Best feature overall.
     best_f = 0
     best_gain = -np.inf
     for f in range(n_features):
         if feat_gain[f] > best_gain:
             best_gain = feat_gain[f]
             best_f = f
+
     return best_f, feat_thr[best_f], best_gain
 
 
@@ -332,31 +355,35 @@ def _build_and_split(Xb, grad, hess, leaf, active, hist, feat_mask,
 def _build_split_descend(Xb, grad, hess, leaf, active, hist, feat_mask,
                          n_bins_per_feature, l2, min_child_weight, min_gain,
                          small, n_leaves_next, next_active):
-    """`_build_and_split` plus the level's follow-up work in the same launch:
-    when the found split is usable (legal threshold, gain > min_gain) the
+    """`_build_and_split` plus the level's follow-up work in the same launch.
+
+    When the split it finds is usable (legal threshold, gain > min_gain) this
     kernel also pushes every sample one level deeper, and on the small-n path
     emits the next level's occupied-leaf list.
 
-    Replaces, per level: one split launch + one descend launch + a
-    bincount/flatnonzero numpy pair. At small n the per-level cost is
-    launch/fixed-cost bound (GROW_PLAN.md Phase 0: per-tree Python residue
-    8-15% of fit on Grinsztajn-sized sets) — that fixed cost is what this
-    removes; the arithmetic is unchanged.
+    Per level it replaces one split launch, one descend launch and a
+    bincount/flatnonzero numpy pair. At small n the per-level cost is fixed
+    overhead, not arithmetic (GROW_PLAN.md Phase 0: per-tree Python residue is
+    8-15% of fit on Grinsztajn-sized sets). That overhead is what this removes.
 
-    Bit-identity: the split search is `_build_and_split`'s code verbatim
-    (that kernel is retained as this one's oracle, itself oracle-tested
-    against `_build_histograms_into` + `_best_split`); the descend is
-    `_descend_leaves(_serial)`'s integer update, fused with an integer
-    occupancy count (exact in any order); the occupancy list is ascending
-    nonzero-count indices — exactly flatnonzero(bincount(leaf,
-    n_leaves_next)). The descend fires iff the caller's continue-predicate
-    holds (NOT (gain <= min_gain or t < 0)), so a rejected level leaves
-    `leaf` untouched, like the old Python-side break did.
+    Bit-identity, piece by piece:
 
-    Returns (best_f, best_t, best_gain, n_next); n_next is the occupancy
-    list length, or -1 when no list was built (large n, or no descend).
-    `next_active` needs room for n_leaves_next entries on the small-n path;
-    it is never touched otherwise.
+      * the split search is `_build_and_split`'s code verbatim (that kernel is
+        this one's oracle, and is itself oracle-tested against
+        `_build_histograms_into` + `_best_split`);
+      * the descend is `_descend_leaves(_serial)`'s integer update, fused with
+        an integer occupancy count, exact in any order;
+      * the occupancy list is ascending nonzero-count indices — exactly
+        flatnonzero(bincount(leaf, n_leaves_next)).
+
+    The descend fires iff the caller's continue-predicate holds (NOT (gain <=
+    min_gain or t < 0)), so a rejected level leaves `leaf` untouched, the way
+    the old Python-side break did.
+
+    Returns (best_f, best_t, best_gain, n_next). n_next is the occupancy list
+    length, or -1 when no list was built (large n, or no descend).
+    `next_active` needs room for n_leaves_next entries on the small-n path; it
+    is never touched otherwise.
     """
     n_features, n_samples = Xb.shape
     max_bins = hist.shape[2]
@@ -367,12 +394,15 @@ def _build_split_descend(Xb, grad, hess, leaf, active, hist, feat_mask,
     for f in prange(n_features):
         if feat_mask[f] == 0:
             continue
+
+        # Zero this feature's leaf rows, then scatter the samples in.
         nb = n_bins_per_feature[f]
         for k in range(n_active):
             l = active[k]
             for b in range(nb):
                 hist[f, l, b, 0] = 0.0
                 hist[f, l, b, 1] = 0.0
+
         Xf = Xb[f]
         for i in range(n_samples):
             l = leaf[i]
@@ -380,8 +410,10 @@ def _build_split_descend(Xb, grad, hess, leaf, active, hist, feat_mask,
             hist[f, l, b, 0] += grad[i]
             hist[f, l, b, 1] += hess[i]
 
+        # Score every threshold, summing gain across the leaves.
         gain = np.zeros(max_bins)
         legal = np.ones(max_bins, dtype=np.uint8)
+
         for k in range(n_active):
             l = active[k]
             gt = 0.0
@@ -389,11 +421,14 @@ def _build_split_descend(Xb, grad, hess, leaf, active, hist, feat_mask,
             for b in range(nb):
                 gt += hist[f, l, b, 0]
                 ht += hist[f, l, b, 1]
+
             if ht <= 0.0:
                 continue
+
             par = gt * gt / (ht + l2)
             gl = 0.0
             hl = 0.0
+
             for t in range(nb - 1):
                 gl += hist[f, l, t, 0]
                 hl += hist[f, l, t, 1]
@@ -413,9 +448,11 @@ def _build_split_descend(Xb, grad, hess, leaf, active, hist, feat_mask,
             if legal[t] and gain[t] > best_g:
                 best_g = gain[t]
                 best_t = t
+
         feat_gain[f] = best_g
         feat_thr[f] = best_t
 
+    # Best feature overall.
     best_f = 0
     best_gain = -np.inf
     for f in range(n_features):
@@ -424,6 +461,8 @@ def _build_split_descend(Xb, grad, hess, leaf, active, hist, feat_mask,
             best_f = f
     best_t = feat_thr[best_f]
 
+    # Descend one level. At small n, list the leaves that are now occupied so
+    # the next level can skip the empty rows.
     n_next = -1
     if best_t >= 0 and best_gain > min_gain:
         Xf = Xb[best_f]
@@ -433,6 +472,7 @@ def _build_split_descend(Xb, grad, hess, leaf, active, hist, feat_mask,
                 nl = (leaf[i] << 1) + (1 if Xf[i] > best_t else 0)
                 leaf[i] = nl
                 counts[nl] += 1
+
             n_next = 0
             for l in range(n_leaves_next):
                 if counts[l] > 0:
@@ -441,24 +481,28 @@ def _build_split_descend(Xb, grad, hess, leaf, active, hist, feat_mask,
         else:
             for i in prange(n_samples):
                 leaf[i] = (leaf[i] << 1) + (1 if Xf[i] > best_t else 0)
+
     return best_f, best_t, best_gain, n_next
 
 
-# Quantized-gradient histograms (QUANT_PLAN.md, LightGBM-4-style adaptation):
+# Quantized-gradient histograms (QUANT_PLAN.md, a LightGBM-4-style adaptation).
 # grad/hess are quantized per tree to integers and packed into ONE int64 per
-# sample, so the histogram scatter does a single integer RMW per (sample,
-# feature) instead of two float64 RMWs, and the buffer footprint halves.
-# _QMAX_CAP bounds the quantized range at 15 bits; build_oblivious_tree
-# shrinks it further for huge n so that any cell/prefix sum keeps
-# |sum qg| <= n*qmax < 2**31 and 0 <= sum qh < 2**32 — the packed halves can
-# then never bleed into each other and shift/mask unpacking is exact.
+# sample, so the histogram scatter does a single integer read-modify-write per
+# (sample, feature) instead of two float64 ones, and the buffer footprint halves.
+#
+# _QMAX_CAP bounds the quantized range at 15 bits. build_oblivious_tree shrinks
+# it further for huge n so that any cell or prefix sum keeps
+# |sum qg| <= n*qmax < 2**31 and 0 <= sum qh < 2**32. The packed halves can then
+# never bleed into each other and shift/mask unpacking is exact.
 _QMAX_CAP = 32767
 
 
 @njit(cache=True, parallel=True)
 def _gh_absmax(grad, hess):
-    """Fused (max |grad|, max hess) reduction — the quantization scales —
-    without numpy temporaries (np.abs(grad).max() would allocate n floats)."""
+    """Fused (max |grad|, max hess) reduction — the quantization scales.
+
+    Avoids numpy temporaries: np.abs(grad).max() would allocate n floats.
+    """
     gmax = 0.0
     hmax = 0.0
     for i in prange(grad.shape[0]):
@@ -472,23 +516,28 @@ def _gh_absmax(grad, hess):
 def _quantize_pack(grad, hess, inv_dg, inv_dh, qmax, qseed, out):
     """out[i] = (qg << 32) + qh with stochastic rounding qX = floor(x*inv + u).
 
-    The uniform pair u comes from counter-based splitmix64(qseed + i):
-    deterministic given the seed (reproducible models, no RNG state threaded
-    through numba), unbiased rounding (round-to-nearest would bias every
-    histogram cell the same way; stochastic errors cancel by sqrt(n) — the
-    LightGBM quantized-training result). qg lands in [-qmax, qmax] and qh in
-    [0, qmax] by construction of the scales; the clamps only guard the edge
-    where gmax * (qmax/gmax) rounds a hair above qmax, keeping the caller's
-    overflow bound exact. Hessians are non-negative for every library loss,
-    so qh's lower clamp is defensive only."""
+    The uniform pair u comes from a counter-based splitmix64(qseed + i), which
+    buys two things. It is deterministic given the seed, so models stay
+    reproducible without threading RNG state through numba. And the rounding is
+    unbiased: round-to-nearest would bias every histogram cell the same way,
+    whereas stochastic errors cancel by sqrt(n) — the LightGBM
+    quantized-training result.
+
+    The scales put qg in [-qmax, qmax] and qh in [0, qmax] by construction. The
+    clamps only guard the edge where gmax * (qmax/gmax) rounds a hair above qmax,
+    which keeps the caller's overflow bound exact. Hessians are non-negative for
+    every library loss, so qh's lower clamp is defensive only.
+    """
     n = grad.shape[0]
     for i in prange(n):
+        # splitmix64 of the row index, split into two uniforms.
         z = (qseed + np.uint64(i)) * np.uint64(0x9E3779B97F4A7C15)
         z = (z ^ (z >> np.uint64(30))) * np.uint64(0xBF58476D1CE4E5B9)
         z = (z ^ (z >> np.uint64(27))) * np.uint64(0x94D049BB133111EB)
         z = z ^ (z >> np.uint64(31))
         u1 = (z & np.uint64(0xFFFFFFFF)) * (1.0 / 4294967296.0)
         u2 = (z >> np.uint64(32)) * (1.0 / 4294967296.0)
+
         qg = np.int64(np.floor(grad[i] * inv_dg + u1))
         qh = np.int64(np.floor(hess[i] * inv_dh + u2))
         qg = min(max(qg, -qmax), qmax)
@@ -502,17 +551,18 @@ def _build_split_descend_q(Xb, q, leaf, active, histq, feat_mask,
                            min_gain, small, n_leaves_next, next_active):
     """Packed-int64 twin of `_build_split_descend` for quantized training.
 
-    Structure is that kernel's verbatim except the histogram: `histq` is
-    int64 (n_features, max_leaves, max_bins), the scatter adds the packed
-    sample value once, and the scan runs packed-integer prefix sums (exact —
-    see _QMAX_CAP) that are unpacked (arithmetic shift / mask) and
-    dequantized with dg/dh only where the float gain formula needs them.
+    The structure is that kernel's verbatim except for the histogram. `histq` is
+    int64 (n_features, max_leaves, max_bins), the scatter adds the packed sample
+    value once, and the scan runs packed-integer prefix sums (exact — see
+    _QMAX_CAP) that are unpacked by arithmetic shift and mask, then dequantized
+    with dg/dh only where the float gain formula needs them.
+
     On exactly-representable grad/hess (integer multiples of power-of-two
-    scales) this reproduces the float kernel bit for bit — that is the
-    oracle test in tests/test_tree_kernels.py; on real data it differs from
-    the float kernel only by the quantization noise. hr = ht - hl is
-    computed in float like the reference; multiplication by a positive
-    scale is monotone, so hr never goes negative."""
+    scales) this reproduces the float kernel bit for bit — the oracle test in
+    tests/test_tree_kernels.py. On real data it differs only by the quantization
+    noise. hr = ht - hl is computed in float like the reference; multiplying by
+    a positive scale is monotone, so hr never goes negative.
+    """
     n_features, n_samples = Xb.shape
     max_bins = histq.shape[2]
     n_active = active.shape[0]
@@ -522,28 +572,36 @@ def _build_split_descend_q(Xb, q, leaf, active, histq, feat_mask,
     for f in prange(n_features):
         if feat_mask[f] == 0:
             continue
+
+        # Zero this feature's leaf rows, then scatter the samples in.
         nb = n_bins_per_feature[f]
         for k in range(n_active):
             l = active[k]
             for b in range(nb):
                 histq[f, l, b] = 0
+
         Xf = Xb[f]
         for i in range(n_samples):
             histq[f, leaf[i], Xf[i]] += q[i]
 
+        # Score every threshold, unpacking each integer prefix sum as it goes.
         gain = np.zeros(max_bins)
         legal = np.ones(max_bins, dtype=np.uint8)
+
         for k in range(n_active):
             l = active[k]
             tot = np.int64(0)
             for b in range(nb):
                 tot += histq[f, l, b]
+
             ht = (tot & 0xFFFFFFFF) * dh
             gt = (tot >> 32) * dg
             if ht <= 0.0:
                 continue
+
             par = gt * gt / (ht + l2)
             acc = np.int64(0)
+
             for t in range(nb - 1):
                 acc += histq[f, l, t]
                 hl = (acc & 0xFFFFFFFF) * dh
@@ -564,9 +622,11 @@ def _build_split_descend_q(Xb, q, leaf, active, histq, feat_mask,
             if legal[t] and gain[t] > best_g:
                 best_g = gain[t]
                 best_t = t
+
         feat_gain[f] = best_g
         feat_thr[f] = best_t
 
+    # Best feature overall.
     best_f = 0
     best_gain = -np.inf
     for f in range(n_features):
@@ -575,6 +635,8 @@ def _build_split_descend_q(Xb, q, leaf, active, histq, feat_mask,
             best_f = f
     best_t = feat_thr[best_f]
 
+    # Descend one level. At small n, list the leaves that are now occupied so
+    # the next level can skip the empty rows.
     n_next = -1
     if best_t >= 0 and best_gain > min_gain:
         Xf = Xb[best_f]
@@ -584,6 +646,7 @@ def _build_split_descend_q(Xb, q, leaf, active, histq, feat_mask,
                 nl = (leaf[i] << 1) + (1 if Xf[i] > best_t else 0)
                 leaf[i] = nl
                 counts[nl] += 1
+
             n_next = 0
             for l in range(n_leaves_next):
                 if counts[l] > 0:
@@ -592,6 +655,7 @@ def _build_split_descend_q(Xb, q, leaf, active, histq, feat_mask,
         else:
             for i in prange(n_samples):
                 leaf[i] = (leaf[i] << 1) + (1 if Xf[i] > best_t else 0)
+
     return best_f, best_t, best_gain, n_next
 
 
@@ -600,23 +664,23 @@ def _best_split(hist, n_bins_per_feature, l2, feat_mask, min_child_weight,
                 n_leaves):
     """Find the (feature, threshold) with the highest total gain.
 
-    REFERENCE KERNEL: the fit path now uses the fused `_build_and_split`; kept
-    as the equivalence oracle for tests/test_tree_kernels.py.
+    REFERENCE KERNEL: the fit path now uses the fused `_build_and_split`. This
+    is kept as the equivalence oracle for tests/test_tree_kernels.py.
 
     `hist` is the interleaved (n_features, max_leaves, max_bins, 2) buffer:
-    [..., 0] is grad, [..., 1] is hess. `n_leaves` says how many leaf rows are
-    actually active at this level, so we only read those.
+    [..., 0] is grad, [..., 1] is hess. `n_leaves` is how many leaf rows are
+    active at this level, so we read only those.
 
     For a candidate threshold t, bins <= t go left and bins > t go right, the
     same way in every current leaf. Gain is summed across leaves. Features with
     feat_mask[f] == 0 are skipped (column subsampling).
 
     A threshold is legal unless some leaf would gain a *sparse non-empty* child
-    (0 < hessian mass < min_child_weight) -- that is the sparse-leaf overfit risk,
+    (0 < hessian mass < min_child_weight). That is the sparse-leaf overfit risk,
     and since the split is shared it is rejected for the whole level. Children
     that come out EMPTY (a leaf whose samples all go one way) are exempt: pure
-    leaves are normal in an oblivious tree and must not block the shared split,
-    or effective depth caps far below what the data supports.
+    leaves are normal in an oblivious tree, and blocking the shared split on them
+    caps effective depth far below what the data supports.
     """
     n_features = hist.shape[0]
     feat_gain = np.full(n_features, -np.inf)
@@ -625,8 +689,9 @@ def _best_split(hist, n_bins_per_feature, l2, feat_mask, min_child_weight,
     for f in prange(n_features):
         if feat_mask[f] == 0:
             continue
-        nb = n_bins_per_feature[f]
+
         # Totals per leaf for this feature (same regardless of threshold).
+        nb = n_bins_per_feature[f]
         Gt = np.zeros(n_leaves)
         Ht = np.zeros(n_leaves)
         for l in range(n_leaves):
@@ -638,28 +703,30 @@ def _best_split(hist, n_bins_per_feature, l2, feat_mask, min_child_weight,
         HL = np.zeros(n_leaves)
         best_g = -np.inf
         best_t = -1
+
         # Threshold t means "left = bins [0..t]". Last bin can't be a threshold.
         for t in range(nb - 1):
-            # Pass 1: Advance running prefix sums for all leaves unconditionally
-            # so GL/HL carry correctly into the next threshold.
+            # Pass 1: advance the running prefix sums for all leaves
+            # unconditionally, so GL/HL carry into the next threshold.
             for l in range(n_leaves):
                 GL[l] += hist[f, l, t, 0]
                 HL[l] += hist[f, l, t, 1]
 
-            # Pass 2: gain of this threshold, and its legality (see docstring:
-            # only a sparse non-empty child vetoes the shared split).
+            # Pass 2: gain of this threshold, and its legality. Only a sparse
+            # non-empty child vetoes the shared split (see the docstring).
             gain = 0.0
             legal = True
             for l in range(n_leaves):
                 if Ht[l] > 0.0:
                     hl = HL[l]
                     hr = Ht[l] - hl
-                    # Empty child (hl==0 or hr==0) is exempt; only 0 < mass <
-                    # min_child_weight is illegal.
+
+                    # An empty child (hl == 0 or hr == 0) is exempt.
                     if (hl > 0.0 and hl < min_child_weight) or \
                        (hr > 0.0 and hr < min_child_weight):
                         legal = False
                         break
+
                     gl = GL[l]
                     gr = Gt[l] - gl
                     gain += (
@@ -675,12 +742,14 @@ def _best_split(hist, n_bins_per_feature, l2, feat_mask, min_child_weight,
         feat_gain[f] = best_g
         feat_thr[f] = best_t
 
+    # Best feature overall.
     best_f = 0
     best_gain = -np.inf
     for f in range(n_features):
         if feat_gain[f] > best_gain:
             best_gain = feat_gain[f]
             best_f = f
+
     return best_f, feat_thr[best_f], best_gain
 
 
@@ -707,6 +776,7 @@ def _leaf_values(leaf, grad, hess, n_leaves, l2, lr):
     for i in range(leaf.shape[0]):
         G[leaf[i]] += grad[i]
         H[leaf[i]] += hess[i]
+
     values = np.zeros(n_leaves)
     for l in range(n_leaves):
         if H[l] > 0.0:
@@ -719,17 +789,20 @@ def _solve_small(A, b):
     """Solve ``A x = b`` for a small dense system via LU with partial pivoting.
 
     Drop-in replacement for ``np.linalg.solve`` on the tiny (d x d, d <= depth+1)
-    per-leaf normal equations. Same algorithm family as LAPACK's gesv (LU with
-    partial pivoting) but hand-rolled, which avoids instantiating numba's LAPACK
-    bindings: those alone account for several seconds of JIT compile time on the
-    first fit in a fresh environment. ``A`` and ``b`` are modified in place.
-    Returns the solution, or a vector of NaN if a pivot underflows (the caller
-    then falls back to the constant Newton leaf value; with the ridge + jitter
-    on the diagonal this cannot trigger in practice).
+    per-leaf normal equations. Same algorithm family as LAPACK's gesv, but
+    hand-rolled to avoid instantiating numba's LAPACK bindings: those alone cost
+    several seconds of JIT compile time on the first fit in a fresh environment.
+
+    ``A`` and ``b`` are modified in place. Returns the solution, or a vector of
+    NaN if a pivot underflows -- the caller then falls back to the constant
+    Newton leaf value. With the ridge and jitter on the diagonal, that cannot
+    trigger in practice.
     """
     d = A.shape[0]
     x = np.empty(d)
+
     for c in range(d):
+        # Pick the pivot row.
         p = c
         amax = abs(A[c, c])
         for r in range(c + 1, d):
@@ -737,10 +810,12 @@ def _solve_small(A, b):
             if ar > amax:
                 amax = ar
                 p = r
+
         if amax < 1e-300:
             for j in range(d):
                 x[j] = np.nan
             return x
+
         if p != c:
             for j in range(d):
                 tmp = A[c, j]
@@ -749,6 +824,8 @@ def _solve_small(A, b):
             tmp = b[c]
             b[c] = b[p]
             b[p] = tmp
+
+        # Eliminate below the pivot.
         inv = 1.0 / A[c, c]
         for r in range(c + 1, d):
             f = A[r, c] * inv
@@ -757,11 +834,14 @@ def _solve_small(A, b):
                 for j in range(c + 1, d):
                     A[r, j] -= f * A[c, j]
                 b[r] -= f * b[c]
+
+    # Back substitution.
     for r in range(d - 1, -1, -1):
         s = b[r]
         for j in range(r + 1, d):
             s -= A[r, j] * x[j]
         x[r] = s / A[r, r]
+
     return x
 
 
@@ -770,31 +850,38 @@ def _linear_leaf_fit(leaf, grad, hess, n_leaves, lin_feats, centers_std, Xb,
                      l2_intercept, lin_lambda, lr):
     """Fit a small hessian-weighted ridge per leaf (local linear-leaf models).
 
-    For samples in a leaf we solve the second-order objective
+    For the samples in a leaf we solve the second-order objective
+
         min_beta  sum_i [ g_i f_i + 1/2 h_i f_i^2 ] + 1/2 ( l2*b^2 + lin*||w||^2 )
+
     with f_i = b + w . x_std_i over the leaf's numeric split features -- i.e. the
     normal equations  (A^T diag(h) A + Lambda) beta = -A^T g,  A = [1, x_std],
-    accumulated directly (no per-leaf design matrix). The fitted output is
-    `lr * beta`. Leaves with too few samples to support the slope (or empty
-    leaves) fall back to the plain constant Newton value, so the linear model
-    only ever ADDS local slope where the data supports it. Returns `lin_coef` of
-    shape (n_leaves, 1 + len(lin_feats)) (column 0 = intercept).
+    accumulated directly, with no per-leaf design matrix. The output is
+    `lr * beta`.
 
-    `centers_std` is the per-feature table of standardized bin-center values;
-    NaN (missing) bins are treated as 0 (= the feature mean).
+    Leaves too small to support a slope, and empty leaves, fall back to the plain
+    constant Newton value, so the linear model only ever ADDS slope where the
+    data supports it. Returns `lin_coef` of shape (n_leaves, 1 + len(lin_feats));
+    column 0 is the intercept. `centers_std` is the per-feature table of
+    standardized bin-center values, with NaN (missing) bins treated as 0, the
+    feature mean.
 
-    Parallel over leaves, bit-identically to the old serial global scan: a
-    stable counting sort groups sample indices by leaf in original order, so
-    each leaf's normal equations accumulate in exactly the same float-add
-    sequence the serial version used (a leaf only ever saw its own samples,
-    in increasing i). Thread-count invariant for the same reason. The
-    standardized design values are gathered per sample inside the leaf loop
-    (no (k, n) scratch matrix, and a single parallel region keeps the JIT
-    compile cost down)."""
+    Notes
+    -----
+    Parallel over leaves and bit-identical to the old serial global scan. A
+    stable counting sort groups sample indices by leaf in original order, so each
+    leaf accumulates in exactly the float-add sequence the serial version used --
+    a leaf only ever saw its own samples, in increasing i. Thread-count invariant
+    for the same reason.
+
+    Design values are gathered per sample inside the leaf loop: no (k, n) scratch
+    matrix, and one parallel region holds the JIT compile cost down.
+    """
     n = leaf.shape[0]
     k = lin_feats.shape[0]
     d = 1 + k
     coef = np.zeros((n_leaves, d))
+
     # Per-leaf grad/hess totals (for the constant fallback) and counts.
     counts = np.zeros(n_leaves, dtype=np.int64)
     Gtot = np.zeros(n_leaves)
@@ -804,37 +891,45 @@ def _linear_leaf_fit(leaf, grad, hess, n_leaves, lin_feats, centers_std, Xb,
         counts[l] += 1
         Gtot[l] += grad[i]
         Htot[l] += hess[i]
+
     # Stable counting sort: order[start[l]:start[l+1]] = leaf-l samples in
     # increasing original index.
     start = np.zeros(n_leaves + 1, dtype=np.int64)
     for l in range(n_leaves):
         start[l + 1] = start[l] + counts[l]
+
     pos = start[:n_leaves].copy()
     order = np.empty(n, dtype=np.int64)
     for i in range(n):
         l = leaf[i]
         order[pos[l]] = i
         pos[l] += 1
+
     # Per-leaf normal equations + solve; leaves are independent.
     for l in prange(n_leaves):
         if counts[l] == 0:
             continue
+
         if counts[l] < 2 * d or k == 0:
             if Htot[l] > 0.0:
                 coef[l, 0] = -lr * Gtot[l] / (Htot[l] + l2_intercept)
             continue
+
         Ml = np.zeros((d, d))
         rl = np.zeros(d)
         xrow = np.empty(k)
+
         for q in range(start[l], start[l + 1]):
             i = order[q]
             h = hess[i]
             g = grad[i]
+
             # Standardized design values for this sample; missing bins -> 0.
             for j in range(k):
                 f = lin_feats[j]
                 v = centers_std[f, Xb[f, i]]
                 xrow[j] = v if np.isfinite(v) else 0.0
+
             Ml[0, 0] += h
             rl[0] += -g
             for j in range(k):
@@ -844,11 +939,13 @@ def _linear_leaf_fit(leaf, grad, hess, n_leaves, lin_feats, centers_std, Xb,
                 rl[1 + j] += -g * xj
                 for jj in range(k):
                     Ml[1 + j, 1 + jj] += h * xj * xrow[jj]
+
         Ml[0, 0] += l2_intercept
         for j in range(1, d):
             Ml[j, j] += lin_lambda
         for j in range(d):
             Ml[j, j] += 1e-9              # jitter: keep the solve well-posed
+
         beta = _solve_small(Ml, rl)
         if np.isnan(beta[0]):
             # Singular pivot (unreachable given the diagonal ridge + jitter):
@@ -856,8 +953,10 @@ def _linear_leaf_fit(leaf, grad, hess, n_leaves, lin_feats, centers_std, Xb,
             if Htot[l] > 0.0:
                 coef[l, 0] = -lr * Gtot[l] / (Htot[l] + l2_intercept)
             continue
+
         for j in range(d):
             coef[l, j] = lr * beta[j]
+
     return coef
 
 
@@ -865,8 +964,9 @@ def _linear_leaf_fit(leaf, grad, hess, n_leaves, lin_feats, centers_std, Xb,
 def _linear_predict(leaf, lin_feats, lin_coef, centers_std, Xb):
     """Per-sample output of a linear-leaf tree: intercept + slope . x_std.
 
-    Parallel over samples; each out[i] is independent, so bit-identical to
-    the serial loop."""
+    Parallel over samples. Each out[i] is independent, so this is bit-identical
+    to the serial loop.
+    """
     n = leaf.shape[0]
     k = lin_feats.shape[0]
     out = np.empty(n)
@@ -886,13 +986,16 @@ def _linear_predict(leaf, lin_feats, lin_coef, centers_std, Xb):
 def _leaf_values_vec(leaf, grad, hess, coupling, n_leaves, l2, lr):
     """Vector (K-output) Newton leaf values on ONE shared leaf partition.
 
-    ``grad``/``hess`` are the (n, K) per-class softmax gradient/hessian
-    matrices; ``coupling`` is the softmax rank correction ((K-1)/K), applied
-    to the hessian exactly as the per-class-tree path applies it before its
-    scalar `_leaf_values` call. Column k of the result is what
-    `_leaf_values(leaf, grad[:, k], hess[:, k] * coupling, ...)` returns —
-    the same Newton formula, K columns per leaf instead of K separate trees.
-    That equivalence is the oracle test in tests/test_vector_leaf.py."""
+    ``grad``/``hess`` are the (n, K) per-class softmax gradient/hessian matrices.
+    ``coupling`` is the softmax rank correction ((K-1)/K), applied to the hessian
+    exactly as the per-class-tree path applies it before its scalar
+    `_leaf_values` call.
+
+    Column k of the result is what
+    `_leaf_values(leaf, grad[:, k], hess[:, k] * coupling, ...)` returns — the
+    same Newton formula, K columns per leaf instead of K separate trees. That
+    equivalence is the oracle test in tests/test_vector_leaf.py.
+    """
     n, K = grad.shape
     G = np.zeros((n_leaves, K))
     H = np.zeros((n_leaves, K))
@@ -900,10 +1003,11 @@ def _leaf_values_vec(leaf, grad, hess, coupling, n_leaves, l2, lr):
         l = leaf[i]
         for k in range(K):
             G[l, k] += grad[i, k]
-            # Couple per element, BEFORE the sum, exactly like the scalar
-            # path's `hess[:, k] * coupling` argument — keeps the oracle
-            # equivalence bit-exact (c*Σh ≠ Σ(c*h) in floats).
+            # Couple per element, BEFORE the sum, exactly like the scalar path's
+            # `hess[:, k] * coupling` argument. Keeps the oracle equivalence
+            # bit-exact: c*Σh ≠ Σ(c*h) in floats.
             H[l, k] += hess[i, k] * coupling
+
     values = np.zeros((n_leaves, K))
     for l in range(n_leaves):
         for k in range(K):
@@ -916,10 +1020,12 @@ def _leaf_values_vec(leaf, grad, hess, coupling, n_leaves, l2, lr):
 # Multi-quantile vector leaves (benchmarks/QUANTILE_PLAN.md).
 #
 # The quantile head's leaf value is not a Newton step but the exact empirical
-# quantile of the leaf's residuals, one per tau -- the same override the
+# quantile of the leaf's residuals, one per tau. It is the same override the
 # scalar MAE/Quantile path applies in `booster._correct_leaves`, widened to K
-# channels. The channels are not constrained against one another here; ordering
-# is imposed per row on delivered predictions (`booster.MultiQuantileBoosting`).
+# channels.
+#
+# The channels are not constrained against one another here; ordering is imposed
+# per row on delivered predictions (`booster.MultiQuantileBoosting`).
 # ---------------------------------------------------------------------------
 
 
@@ -933,20 +1039,23 @@ def _project_pinball(y, F, c, cdot, w, out):
         g_i = sum over {k : F_ik > y_i} of c_k, minus dot(c, taus)
 
     which is one accumulating pass over the row instead of a K-element dot
-    product against a materialized (n, K) gradient. Not building that matrix is
-    the whole reason a K-level head can cost about what a 1-level one costs per
-    round outside the leaf refit.
+    product against a materialized (n, K) gradient. Skipping that matrix is why
+    a K-level head costs about what a 1-level one costs per round, outside the
+    leaf refit.
 
-    An earlier version read the sum straight out of a precomputed suffix table
-    by binary-searching the row's PIT rank, which is valid only while ``F_i`` is
-    non-decreasing. Leaf vectors are no longer constrained against one another
-    (ordering is imposed per row on delivered predictions instead), so a row's
-    channels may cross during training and ``{k : F_ik > y_i}`` need not be a
-    suffix. The scan below makes no ordering assumption at all; it costs K
-    comparisons rather than log K over the same cache lines.
+    ``w`` is a per-row weight array, ones when unweighted -- multiplying by
+    exactly 1.0 is bit-exact, so the unweighted path is unchanged.
 
-    ``w`` is a per-row weight array (ones when unweighted -- multiplying by
-    exactly 1.0 is bit-exact, so the unweighted path is unchanged).
+    Notes
+    -----
+    TRAP, and the reason this is a plain scan: an earlier version read the sum
+    out of a precomputed suffix table by binary-searching the row's PIT rank,
+    which is only valid while ``F_i`` is non-decreasing. Leaf vectors are no
+    longer constrained against one another (ordering is imposed per row on
+    delivered predictions instead), so a row's channels may cross during training
+    and ``{k : F_ik > y_i}`` need not be a suffix. The scan below assumes no
+    ordering at all, costing K comparisons rather than log K over the same cache
+    lines.
     """
     n, K = F.shape
     for i in prange(n):
@@ -960,8 +1069,10 @@ def _project_pinball(y, F, c, cdot, w, out):
 
 @njit(cache=True, parallel=True)
 def _add_leaf_values(F, values, leaf):
-    """``F += values[leaf]`` in place, without materializing the (n, K) gather
-    that fancy indexing would allocate every round."""
+    """``F += values[leaf]`` in place.
+
+    Avoids the (n, K) gather that fancy indexing would allocate every round.
+    """
     n, K = F.shape
     for i in prange(n):
         l = leaf[i]
@@ -973,10 +1084,11 @@ def _add_leaf_values(F, values, leaf):
 def _lerp_np(a, b, t):
     """NumPy's `_lerp` (numpy/lib/function_base.py), branch included.
 
-    The obvious ``a + (b - a) * t`` disagrees with `np.quantile` on roughly 7%
-    of random inputs; reproducing the ``t >= 0.5`` branch makes the leaf
-    quantile bit-identical to the scalar path's `np.quantile` call, which is
-    what lets tests/test_quantile_head.py assert exact equality."""
+    The obvious ``a + (b - a) * t`` disagrees with `np.quantile` on roughly 7% of
+    random inputs. Reproducing the ``t >= 0.5`` branch makes the leaf quantile
+    bit-identical to the scalar path's `np.quantile` call, which is what lets
+    tests/test_quantile_head.py assert exact equality.
+    """
     diff = b - a
     out = a + diff * t
     if t >= 0.5:
@@ -987,13 +1099,18 @@ def _lerp_np(a, b, t):
 @njit(cache=True)
 def _select_kth(buf, lo, hi, k):
     """Quickselect: reorder ``buf[lo:hi]`` so ``buf[k]`` is its (k-lo)-th
-    smallest element, everything left of k no greater, everything right no
-    smaller. Median-of-three pivot. O(m) expected, versus O(m log m) for a
-    full sort -- and the leaf refit runs this K times per leaf per round, so
-    the difference is the head's dominant per-round cost."""
+    smallest element, everything left of k no greater and everything right no
+    smaller. Median-of-three pivot.
+
+    O(m) expected versus O(m log m) for a full sort -- and the leaf refit runs
+    this K times per leaf per round, so that difference is the head's dominant
+    per-round cost.
+    """
     left = lo
     right = hi - 1
+
     while left < right:
+        # Median-of-three pivot.
         mid = (left + right) // 2
         x = buf[left]
         y = buf[mid]
@@ -1005,6 +1122,7 @@ def _select_kth(buf, lo, hi, k):
         if x > y:
             y = x
         pivot = y
+
         i = left
         j = right
         while i <= j:
@@ -1016,6 +1134,8 @@ def _select_kth(buf, lo, hi, k):
                 buf[i], buf[j] = buf[j], buf[i]
                 i += 1
                 j -= 1
+
+        # Keep narrowing onto the side that holds k.
         if k <= j:
             right = j
         elif k >= i:
@@ -1026,18 +1146,21 @@ def _select_kth(buf, lo, hi, k):
 
 @njit(cache=True)
 def _quantile_slice(buf, lo, hi, alpha):
-    """The ``alpha`` quantile of ``buf[lo:hi]``, matching `np.quantile`'s
-    default ('linear') method bit for bit. Reorders the slice in place."""
+    """The ``alpha`` quantile of ``buf[lo:hi]``, matching `np.quantile`'s default
+    ('linear') method bit for bit. Reorders the slice in place.
+    """
     m = hi - lo
     if m <= 0:
         return 0.0
     if m == 1:
         return buf[lo]
+
     pos = alpha * (m - 1)
     j = int(np.floor(pos))
     if j >= m - 1:          # alpha == 1.0: the maximum, nothing to interpolate
         _select_kth(buf, lo, hi, hi - 1)
         return buf[hi - 1]
+
     frac = pos - j
     _select_kth(buf, lo, hi, lo + j)
     a = buf[lo + j]
@@ -1054,8 +1177,10 @@ def _quantile_slice(buf, lo, hi, alpha):
 
 @njit(cache=True)
 def _sort_pairs(buf, wbuf, lo, hi, wlo):
-    """Sort ``buf[lo:hi]`` ascending, carrying ``wbuf`` along. Insertion sort:
-    only the weighted path uses it, and leaves are small."""
+    """Sort ``buf[lo:hi]`` ascending, carrying ``wbuf`` along.
+
+    Insertion sort: only the weighted path uses it, and leaves are small.
+    """
     for i in range(1, hi - lo):
         v = buf[lo + i]
         wv = wbuf[wlo + i]
@@ -1071,16 +1196,21 @@ def _sort_pairs(buf, wbuf, lo, hi, wlo):
 @njit(cache=True)
 def _weighted_quantile_slice(buf, wbuf, lo, hi, alpha, wlo):
     """Nearest-rank weighted quantile of ``buf[lo:hi]``, reproducing
-    `losses._weighted_quantile`: sort by value, walk the cumulative weight,
-    take the first element whose running total reaches ``alpha`` of the whole.
-    Reorders both slices in place."""
+    `losses._weighted_quantile`.
+
+    Sort by value, walk the cumulative weight, take the first element whose
+    running total reaches ``alpha`` of the whole. Reorders both slices in place.
+    """
     m = hi - lo
     if m <= 0:
         return 0.0
+
     _sort_pairs(buf, wbuf, lo, hi, wlo)
+
     total = 0.0
     for i in range(m):
         total += wbuf[wlo + i]
+
     target = total * alpha
     run = 0.0
     for i in range(m):
@@ -1095,16 +1225,19 @@ def _leaf_row_index(leaf, n_leaves):
     """Group rows by leaf into contiguous, disjoint slices.
 
     Returns ``(off, rows)`` where leaf l owns ``rows[off[l]:off[l+1]]``, rows
-    listed in ascending order within each leaf (the same grouping
-    `booster._correct_leaves` gets from a stable argsort). Disjointness is what
-    makes the `prange` over leaves race-free: each leaf writes only its own
-    slice of the shared scratch buffer."""
+    listed in ascending order within each leaf -- the same grouping
+    `booster._correct_leaves` gets from a stable argsort.
+
+    Disjointness is what makes the `prange` over leaves race-free: each leaf
+    writes only its own slice of the shared scratch buffer.
+    """
     n = leaf.shape[0]
     off = np.zeros(n_leaves + 1, dtype=np.int64)
     for i in range(n):
         off[leaf[i] + 1] += 1
     for l in range(n_leaves):
         off[l + 1] += off[l]
+
     fill = off.copy()
     rows = np.empty(n, dtype=np.int64)
     for i in range(n):
@@ -1126,27 +1259,30 @@ def _leaf_quantiles_vec(leaf, y, F, taus, n_leaves, lr):
     tests/test_quantile_head.py.
 
     Each channel is an independent step and nothing constrains them against one
-    another here; ordering is imposed on delivered predictions instead, per row
+    another here; ordering is imposed per row on delivered predictions instead
     (see `booster.MultiQuantileBoosting`). `lr` multiplies from the outside,
-    matching `_correct_leaves`."""
+    matching `_correct_leaves`.
+    """
     n = leaf.shape[0]
     K = taus.shape[0]
     off, rows = _leaf_row_index(leaf, n_leaves)
     values = np.zeros((n_leaves, K))
+
     # One scratch run per (leaf, channel). Costs an (n, K) buffer -- the same
     # footprint as the score matrix itself -- and buys load balance: a real
     # oblivious tree's leaves are badly uneven, so a prange over leaves alone
     # leaves most threads idle waiting on the biggest one. Leaf l owns
     # buf[off[l]*K : off[l+1]*K], so the runs stay disjoint.
     buf = np.empty(n * K, dtype=np.float64)
+
     for t in prange(n_leaves * K):
         l = t // K
         k = t - l * K
         lo = off[l]
         m = off[l + 1] - lo
         if m > 0:
-            # Forward strided scan of one F column, contiguous write. The
-            # leaf's rows are ascending so the prefetcher tracks it. Gathering
+            # Forward strided scan of one F column, contiguous write. The leaf's
+            # rows are ascending so the prefetcher tracks it. Gathering
             # channel-major in one pass was measured SLOWER -- it trades these
             # reads for a transposing write that costs more than it saves.
             st = lo * K + k * m
@@ -1160,13 +1296,17 @@ def _leaf_quantiles_vec(leaf, y, F, taus, n_leaves, lr):
 @njit(cache=True)
 def _leaf_quantiles_vec_serial(leaf, y, F, taus, n_leaves, lr):
     """Serial twin of `_leaf_quantiles_vec` for small n, where the parallel
-    fork/join costs more than the pass. Every write is to a disjoint slice, so
-    the two are bit-identical; the booster dispatches on `_SMALL_N`."""
+    fork/join costs more than the pass.
+
+    Every write is to a disjoint slice, so the two are bit-identical; the booster
+    dispatches on `_SMALL_N`.
+    """
     n = leaf.shape[0]
     K = taus.shape[0]
     off, rows = _leaf_row_index(leaf, n_leaves)
     values = np.zeros((n_leaves, K))
     buf = np.empty(n, dtype=np.float64)
+
     for l in range(n_leaves):
         lo = off[l]
         hi = off[l + 1]
@@ -1186,19 +1326,23 @@ def _leaf_quantiles_vec_serial(leaf, y, F, taus, n_leaves, lr):
 
 @njit(cache=True, parallel=True)
 def _leaf_quantiles_vec_w(leaf, y, F, w, taus, n_leaves, lr):
-    """Weighted `_leaf_quantiles_vec`. Reproduces `losses._weighted_quantile`
-    (nearest rank on cumulative weight), which is the rule the scalar weighted
-    quantile path already uses. Rows carrying zero weight -- MVS drops, or a
-    user's zero sample weights -- contribute nothing, so the leaf value sees
-    exactly the rows the split search saw."""
+    """Weighted `_leaf_quantiles_vec`.
+
+    Reproduces `losses._weighted_quantile` (nearest rank on cumulative weight),
+    the rule the scalar weighted quantile path already uses. Rows carrying zero
+    weight -- MVS drops, or a user's zero sample weights -- contribute nothing,
+    so the leaf value sees exactly the rows the split search saw.
+    """
     n = leaf.shape[0]
     K = taus.shape[0]
     off, rows = _leaf_row_index(leaf, n_leaves)
     values = np.zeros((n_leaves, K))
-    # Per-(leaf, channel) runs, as in the unweighted twin. The weights need
-    # their own copy per run because the paired sort reorders them.
+
+    # Per-(leaf, channel) runs, as in the unweighted twin. The weights need their
+    # own copy per run because the paired sort reorders them.
     buf = np.empty(n * K, dtype=np.float64)
     wbuf = np.empty(n * K, dtype=np.float64)
+
     for t in prange(n_leaves * K):
         l = t // K
         k = t - l * K
@@ -1224,6 +1368,7 @@ def _leaf_quantiles_vec_w_serial(leaf, y, F, w, taus, n_leaves, lr):
     values = np.zeros((n_leaves, K))
     buf = np.empty(n, dtype=np.float64)
     wbuf = np.empty(n, dtype=np.float64)
+
     for l in range(n_leaves):
         lo = off[l]
         hi = off[l + 1]
@@ -1242,10 +1387,11 @@ def _leaf_quantiles_vec_w_serial(leaf, y, F, w, taus, n_leaves, lr):
 def _loo_leaf_step(leaf, grad, hess, n_leaves, l2, lr):
     """Leave-one-out training step for every row, fused into two passes.
 
-    First pass scatters per-leaf grad/hess totals; second pass gathers each
+    The first pass scatters per-leaf grad/hess totals. The second gathers each
     row's totals, removes the row's own contribution, and forms the shrunk
     Newton step. Replaces two np.bincount calls plus several NumPy temporaries
-    with one scatter and one compute loop over `leaf`."""
+    with one scatter and one compute loop over `leaf`.
+    """
     G = np.zeros(n_leaves)
     H = np.zeros(n_leaves)
     n = leaf.shape[0]
@@ -1253,6 +1399,7 @@ def _loo_leaf_step(leaf, grad, hess, n_leaves, l2, lr):
         l = leaf[i]
         G[l] += grad[i]
         H[l] += hess[i]
+
     out = np.empty(n, dtype=np.float64)
     for i in range(n):
         l = leaf[i]
@@ -1261,9 +1408,9 @@ def _loo_leaf_step(leaf, grad, hess, n_leaves, l2, lr):
             denom = 0.0
         if denom + l2 <= 0.0:
             # Singleton leaf (or all co-leaf rows subsampled away) with
-            # l2_leaf_reg=0: no curvature left once the row's own
-            # contribution is removed, so there is no leave-one-out step to
-            # take. Mirrors the H[l] > 0 guard in _leaf_values.
+            # l2_leaf_reg=0: no curvature left once the row's own contribution
+            # is removed, so there is no leave-one-out step to take. Mirrors the
+            # H[l] > 0 guard in _leaf_values.
             out[i] = 0.0
         else:
             out[i] = -lr * (G[l] - grad[i]) / (denom + l2)
@@ -1284,18 +1431,20 @@ def _predict_tree(Xb, splits_feat, splits_thr, values):
 def _predict_forest(Xb, feats, thrs, depths, vals, voff, init):
     """Sum a whole ensemble of oblivious trees in one parallel pass over samples.
 
-    Parameters are the trees packed into flat arrays (see `pack_forest`):
-    `feats`/`thrs` are (n_trees, max_depth) split tables, `depths[t]` the real
-    depth of tree t, and `vals`/`voff` a ragged leaf-value table (tree t's leaf
-    values live at vals[voff[t] : voff[t+1]]).
+    The trees arrive packed into flat arrays (see `pack_forest`): `feats`/`thrs`
+    are (n_trees, max_depth) split tables, `depths[t]` is the real depth of tree
+    t, and `vals`/`voff` form a ragged leaf-value table where tree t's values
+    live at vals[voff[t] : voff[t+1]].
 
-    Parallelizing over samples (not trees) means each sample loads its handful
-    of feature bins once and keeps them hot in cache while walking every tree.
-    The per-sample accumulation runs init + tree0 + tree1 + ... in tree order,
-    matching the serial `F += tree.predict(Xb)` loop bit-for-bit."""
+    Parallelizing over samples rather than trees lets each sample load its
+    handful of feature bins once and keep them hot while walking every tree. The
+    per-sample accumulation runs init + tree0 + tree1 + ... in tree order,
+    matching the serial `F += tree.predict(Xb)` loop bit for bit.
+    """
     n = Xb.shape[1]
     n_trees = feats.shape[0]
     out = np.empty(n, dtype=np.float64)
+
     for i in prange(n):
         acc = init
         for t in range(n_trees):
@@ -1303,6 +1452,7 @@ def _predict_forest(Xb, feats, thrs, depths, vals, voff, init):
             # contributes nothing (its lone leaf value is never applied).
             if depths[t] == 0:
                 continue
+
             leaf = 0
             for d in range(depths[t]):
                 if Xb[feats[t, d], i] > thrs[t, d]:
@@ -1318,14 +1468,16 @@ def _predict_forest(Xb, feats, thrs, depths, vals, voff, init):
 def _predict_forest_rm(Xb, feats, thrs, depths, vals, voff, init):
     """`_predict_forest` for a row-major (n_samples, n_features) binned matrix.
 
-    Predict-time binning produces row-major output; consuming it directly
-    keeps each sample's feature bins in one or two cache lines for the whole
-    forest walk and skips the feature-major transpose copy entirely. Same
-    arithmetic and per-sample accumulation order as `_predict_forest`, so the
-    two are bit-identical."""
+    Predict-time binning produces row-major output. Consuming it directly keeps
+    each sample's feature bins in one or two cache lines for the whole forest
+    walk, and skips the feature-major transpose copy entirely. Same arithmetic
+    and per-sample accumulation order as `_predict_forest`, so the two are
+    bit-identical.
+    """
     n = Xb.shape[0]
     n_trees = feats.shape[0]
     out = np.empty(n, dtype=np.float64)
+
     for i in prange(n):
         acc = init
         for t in range(n_trees):
@@ -1333,6 +1485,7 @@ def _predict_forest_rm(Xb, feats, thrs, depths, vals, voff, init):
             # contributes nothing (its lone leaf value is never applied).
             if depths[t] == 0:
                 continue
+
             leaf = 0
             for d in range(depths[t]):
                 if Xb[i, feats[t, d]] > thrs[t, d]:
@@ -1346,11 +1499,13 @@ def _predict_forest_rm(Xb, feats, thrs, depths, vals, voff, init):
 
 @njit(cache=True)
 def _predict_forest_rm_serial(Xb, feats, thrs, depths, vals, voff, init):
-    """Serial twin of `_predict_forest_rm` for tiny batches: the OpenMP
-    fork/join (~20us on 12 threads) exceeds the whole 1-row walk, and the
-    parallel kernel only overtakes serial around n~5. Bit-identical
+    """Serial twin of `_predict_forest_rm` for tiny batches.
+
+    The OpenMP fork/join (~20us on 12 threads) exceeds the whole 1-row walk, and
+    the parallel kernel only overtakes serial around n~5. Bit-identical
     (independent per-row writes); the booster dispatches on
-    `binning._SERIAL_PREDICT_N`."""
+    `binning._SERIAL_PREDICT_N`.
+    """
     n = Xb.shape[0]
     n_trees = feats.shape[0]
     out = np.empty(n, dtype=np.float64)
@@ -1373,20 +1528,23 @@ def _predict_forest_rm_serial(Xb, feats, thrs, depths, vals, voff, init):
 def pack_forest(trees, max_depth):
     """Flatten a list of ObliviousTrees into the arrays `_predict_forest` wants.
 
-    Returns (feats, thrs, depths, vals, voff). Cached by the booster after fit
-    so repeated predict calls skip the rebuild."""
+    Returns (feats, thrs, depths, vals, voff). The booster caches this after fit
+    so repeated predict calls skip the rebuild.
+    """
     n_trees = len(trees)
     feats = np.zeros((n_trees, max_depth), dtype=np.int64)
     thrs = np.zeros((n_trees, max_depth), dtype=np.int64)
     depths = np.empty(n_trees, dtype=np.int64)
     voff = np.empty(n_trees + 1, dtype=np.int64)
     voff[0] = 0
+
     for t, tree in enumerate(trees):
         d = tree.depth
         depths[t] = d
         feats[t, :d] = tree.splits_feat
         thrs[t, :d] = tree.splits_thr
         voff[t + 1] = voff[t] + tree.values.shape[0]
+
     vals = np.empty(voff[-1], dtype=np.float64)
     for t, tree in enumerate(trees):
         vals[voff[t]:voff[t + 1]] = tree.values
@@ -1397,9 +1555,10 @@ def pack_forest_vec(trees, max_depth):
     """Flatten a forest of vector-leaf (K-output) oblivious trees for
     `_predict_forest_vec_rm`.
 
-    Same layout as `pack_forest` except tree t's leaf-value block is
+    Same layout as `pack_forest` except that tree t's leaf-value block is
     leaf-major (n_leaves, K) flattened: class k of leaf l lives at
-    vals[voff[t] + l*K + k]. Returns (feats, thrs, depths, vals, voff, K)."""
+    vals[voff[t] + l*K + k]. Returns (feats, thrs, depths, vals, voff, K).
+    """
     n_trees = len(trees)
     K = trees[0].values.shape[1]
     feats = np.zeros((n_trees, max_depth), dtype=np.int64)
@@ -1407,12 +1566,14 @@ def pack_forest_vec(trees, max_depth):
     depths = np.empty(n_trees, dtype=np.int64)
     voff = np.empty(n_trees + 1, dtype=np.int64)
     voff[0] = 0
+
     for t, tree in enumerate(trees):
         d = tree.depth
         depths[t] = d
         feats[t, :d] = tree.splits_feat
         thrs[t, :d] = tree.splits_thr
         voff[t + 1] = voff[t] + tree.values.shape[0] * K
+
     vals = np.empty(voff[-1], dtype=np.float64)
     for t, tree in enumerate(trees):
         vals[voff[t]:voff[t + 1]] = tree.values.reshape(-1)
@@ -1421,22 +1582,27 @@ def pack_forest_vec(trees, max_depth):
 
 @njit(cache=True, parallel=True)
 def _predict_forest_vec_rm(Xb, feats, thrs, depths, vals, voff, K, init):
-    """Sum a forest of vector-leaf oblivious trees in one parallel pass over
-    a row-major (n_samples, n_features) binned matrix — the K-output
-    analogue of `_predict_forest_rm`. One tree walk serves all K classes
-    (the per-class-forest path walked the same rows K times). Per-sample
-    accumulation runs init + tree0 + tree1 + ... in tree order per class,
-    matching the fit loop's `F += tree.values[leaf]` bit for bit."""
+    """Sum a forest of vector-leaf oblivious trees in one parallel pass over a
+    row-major (n_samples, n_features) binned matrix — the K-output analogue of
+    `_predict_forest_rm`.
+
+    One tree walk serves all K classes; the per-class-forest path walked the same
+    rows K times. Per-sample accumulation runs init + tree0 + tree1 + ... in tree
+    order per class, matching the fit loop's `F += tree.values[leaf]` bit for bit.
+    """
     n = Xb.shape[0]
     n_trees = feats.shape[0]
     out = np.empty((n, K), dtype=np.float64)
+
     for i in prange(n):
         for k in range(K):
             out[i, k] = init[k]
+
         for t in range(n_trees):
             # A depth-0 tree found no legal split; it contributes nothing.
             if depths[t] == 0:
                 continue
+
             leaf = 0
             for d in range(depths[t]):
                 if Xb[i, feats[t, d]] > thrs[t, d]:
@@ -1453,8 +1619,11 @@ def _predict_forest_vec_rm(Xb, feats, thrs, depths, vals, voff, K, init):
 def _predict_forest_vec_rm_serial(Xb, feats, thrs, depths, vals, voff, K,
                                   init):
     """Serial twin of `_predict_forest_vec_rm` for tiny batches — see
-    `_predict_forest_rm_serial`. Bit-identical (independent per-row
-    writes); the booster dispatches on `binning._SERIAL_PREDICT_N`."""
+    `_predict_forest_rm_serial`.
+
+    Bit-identical (independent per-row writes); the booster dispatches on
+    `binning._SERIAL_PREDICT_N`.
+    """
     n = Xb.shape[0]
     n_trees = feats.shape[0]
     out = np.empty((n, K), dtype=np.float64)
@@ -1479,11 +1648,13 @@ def _predict_forest_vec_rm_serial(Xb, feats, thrs, depths, vals, voff, K,
 def pack_forest_linear(trees, max_depth):
     """Flatten a forest of (possibly) linear-leaf trees for `_predict_forest_linear`.
 
-    A constant-leaf tree is just a linear tree with k=0 features (its coef block
-    is the leaf intercepts), so one packed layout + kernel serves both. Per tree:
-    `lin_k[t]` linear features at `lin_feat_idx[featoff[t]:featoff[t+1]]`, and a
-    leaf-major coef block at `coef[coefoff[t]:coefoff[t+1]]` of shape
-    (n_leaves, 1 + lin_k[t]) flattened (column 0 = intercept)."""
+    A constant-leaf tree is just a linear tree with k=0 features -- its coef
+    block is the leaf intercepts -- so one packed layout and one kernel serve
+    both. Per tree: `lin_k[t]` linear features at
+    `lin_feat_idx[featoff[t]:featoff[t+1]]`, and a leaf-major coef block at
+    `coef[coefoff[t]:coefoff[t+1]]` of shape (n_leaves, 1 + lin_k[t]) flattened,
+    column 0 being the intercept.
+    """
     n_trees = len(trees)
     feats = np.zeros((n_trees, max_depth), dtype=np.int64)
     thrs = np.zeros((n_trees, max_depth), dtype=np.int64)
@@ -1493,6 +1664,7 @@ def pack_forest_linear(trees, max_depth):
     coefoff = np.empty(n_trees + 1, dtype=np.int64)
     featoff[0] = 0
     coefoff[0] = 0
+
     for t, tree in enumerate(trees):
         d = tree.depth
         depths[t] = d
@@ -1503,8 +1675,10 @@ def pack_forest_linear(trees, max_depth):
         lin_k[t] = k
         featoff[t + 1] = featoff[t] + k
         coefoff[t + 1] = coefoff[t] + n_leaves * (1 + k)
+
     lin_feat_idx = np.empty(featoff[-1], dtype=np.int64)
     coef = np.empty(coefoff[-1], dtype=np.float64)
+
     for t, tree in enumerate(trees):
         if lin_k[t] > 0:
             lin_feat_idx[featoff[t]:featoff[t + 1]] = tree.lin_feats
@@ -1521,23 +1695,27 @@ def _predict_forest_linear(Xb, feats, thrs, depths, lin_k, featoff,
     parallel pass over samples -- the linear-leaf analogue of `_predict_forest`.
 
     Each leaf contributes intercept + sum_j slope_j * centers_std[feat_j, bin],
-    matching `_linear_predict`/`ObliviousTree.predict` so the fused path agrees
-    with the per-tree path bit-for-bit (same accumulation order)."""
+    matching `_linear_predict`/`ObliviousTree.predict`, so the fused path agrees
+    with the per-tree path bit for bit (same accumulation order).
+    """
     n = Xb.shape[1]
     n_trees = feats.shape[0]
     out = np.empty(n, dtype=np.float64)
+
     for i in prange(n):
         acc = init
         for t in range(n_trees):
             d = depths[t]
             if d == 0:
                 continue
+
             leaf = 0
             for dd in range(d):
                 if Xb[feats[t, dd], i] > thrs[t, dd]:
                     leaf = leaf * 2 + 1
                 else:
                     leaf = leaf * 2
+
             k = lin_k[t]
             row = coefoff[t] + leaf * (1 + k)
             val = coef[row]                      # intercept
@@ -1556,23 +1734,29 @@ def _predict_forest_linear(Xb, feats, thrs, depths, lin_k, featoff,
 def _predict_forest_linear_rm(Xb, feats, thrs, depths, lin_k, featoff,
                               lin_feat_idx, coefoff, coef, centers_std, init):
     """`_predict_forest_linear` for a row-major (n_samples, n_features) binned
-    matrix — see `_predict_forest_rm` for why. Bit-identical to the
-    feature-major kernel (same arithmetic, same accumulation order)."""
+    matrix — see `_predict_forest_rm` for why.
+
+    Bit-identical to the feature-major kernel: same arithmetic, same
+    accumulation order.
+    """
     n = Xb.shape[0]
     n_trees = feats.shape[0]
     out = np.empty(n, dtype=np.float64)
+
     for i in prange(n):
         acc = init
         for t in range(n_trees):
             d = depths[t]
             if d == 0:
                 continue
+
             leaf = 0
             for dd in range(d):
                 if Xb[i, feats[t, dd]] > thrs[t, dd]:
                     leaf = leaf * 2 + 1
                 else:
                     leaf = leaf * 2
+
             k = lin_k[t]
             row = coefoff[t] + leaf * (1 + k)
             val = coef[row]                      # intercept
@@ -1592,22 +1776,26 @@ def _predict_forest_linear_rm_serial(Xb, feats, thrs, depths, lin_k, featoff,
                                      lin_feat_idx, coefoff, coef, centers_std,
                                      init):
     """Serial twin of `_predict_forest_linear_rm` for tiny batches — see
-    `_predict_forest_rm_serial`."""
+    `_predict_forest_rm_serial`.
+    """
     n = Xb.shape[0]
     n_trees = feats.shape[0]
     out = np.empty(n, dtype=np.float64)
+
     for i in range(n):
         acc = init
         for t in range(n_trees):
             d = depths[t]
             if d == 0:
                 continue
+
             leaf = 0
             for dd in range(d):
                 if Xb[i, feats[t, dd]] > thrs[t, dd]:
                     leaf = leaf * 2 + 1
                 else:
                     leaf = leaf * 2
+
             k = lin_k[t]
             row = coefoff[t] + leaf * (1 + k)
             val = coef[row]                      # intercept
@@ -1629,38 +1817,44 @@ def _shap_forest_linear(Xb, Rb, feats, thrs, depths, lin_k, featoff,
     """Exact interventional TreeSHAP for a forest of oblivious (linear-leaf or
     constant, k=0) trees, returned in the user's ORIGINAL feature space.
 
-    For each instance x (column of Xb) and background reference r (column of Rb)
-    the per-tree Shapley values are computed by exact enumeration over subsets of
-    the distinct ORIGINAL features the tree uses. This is tractable precisely
+    For each instance x (a column of Xb) and background reference r (a column of
+    Rb), the per-tree Shapley values come from exact enumeration over subsets of
+    the distinct ORIGINAL features the tree uses. That is tractable precisely
     because the trees are oblivious: a depth-D tree touches at most D distinct
     features, so the coalition game has at most D players (<=2**D subsets), not
-    one per input column. A feature in coalition S takes its value from x, the
-    rest from r; the leaf -- and any linear-leaf slope term -- is evaluated under
-    that mix, so the linear leaves are explained faithfully rather than ignored.
+    one per input column. A feature in coalition S takes its value from x and the
+    rest from r; the leaf -- and any linear-leaf slope -- is evaluated under that
+    mix, so linear leaves are explained faithfully rather than ignored.
 
     Contributions are averaged over the background and summed over trees, giving
-    for every instance the Shapley-efficiency identity (to float tolerance)
+    every instance the Shapley-efficiency identity (to float tolerance)
+
         sum_orig phi[i, orig] == predict_trees(x_i) - mean_r predict_trees(r).
-    Two internal columns mapping to the same original feature (categorical combos
-    / multi-target encodings) are treated as ONE player, so the attribution lands
-    directly in input-feature space. `fact[s]` is s! (precomputed up to depth).
-    Parallelized over instances; each thread owns a disjoint row of `phi`."""
+
+    Two internal columns mapping to the same original feature (categorical
+    combos, multi-target encodings) count as ONE player, so the attribution lands
+    directly in input-feature space. `fact[s]` is s!, precomputed up to depth.
+    Parallel over instances; each thread owns a disjoint row of `phi`.
+    """
     n = Xb.shape[1]
     nbg = Rb.shape[1]
     n_trees = feats.shape[0]
     phi = np.zeros((n, n_orig))
     inv_nbg = 1.0 / nbg
+
     for i in prange(n):
         for t in range(n_trees):
             d = depths[t]
             if d == 0:
                 continue
+
             k = lin_k[t]
             fb = featoff[t]
             cb = coefoff[t]
-            # Distinct original features used by this tree = coalition players U;
-            # level_u[dd] is the U-slot of level dd's feature (features reused
-            # across levels share a slot, so they move together in a coalition).
+
+            # The distinct original features this tree uses are the coalition
+            # players U. level_u[dd] is the U-slot of level dd's feature, so a
+            # feature reused across levels moves as one player.
             U = np.empty(d, dtype=np.int64)
             level_u = np.empty(d, dtype=np.int64)
             u = 0
@@ -1676,6 +1870,7 @@ def _shap_forest_linear(Xb, Rb, feats, thrs, depths, lin_k, featoff,
                     idx = u
                     u += 1
                 level_u[dd] = idx
+
             lin_u = np.empty(k, dtype=np.int64)
             for j in range(k):
                 o = feat_orig[lin_feat_idx[fb + j]]
@@ -1683,19 +1878,25 @@ def _shap_forest_linear(Xb, Rb, feats, thrs, depths, lin_k, featoff,
                     if U[q] == o:
                         lin_u[j] = q
                         break
+
             nsub = 1 << u
-            # x-side: level bits and standardized linear values (ref-independent).
+
+            # x-side level bits and standardized linear values; both are
+            # independent of the reference, so they are computed once.
             xbit = np.empty(d, dtype=np.int64)
             for dd in range(d):
                 xbit[dd] = 1 if Xb[feats[t, dd], i] > thrs[t, dd] else 0
+
             xval = np.empty(k)
             for j in range(k):
                 f = lin_feat_idx[fb + j]
                 v = centers_std[f, Xb[f, i]]
                 xval[j] = v if np.isfinite(v) else 0.0
+
             fval = np.empty(nsub)
             rbit = np.empty(d, dtype=np.int64)
             rval = np.empty(k)
+
             for b in range(nbg):
                 for dd in range(d):
                     rbit[dd] = 1 if Rb[feats[t, dd], b] > thrs[t, dd] else 0
@@ -1703,8 +1904,9 @@ def _shap_forest_linear(Xb, Rb, feats, thrs, depths, lin_k, featoff,
                     f = lin_feat_idx[fb + j]
                     vv = centers_std[f, Rb[f, b]]
                     rval[j] = vv if np.isfinite(vv) else 0.0
-                # Output of every coalition: bits/linear-values follow x inside S,
-                # r outside it.
+
+                # Output of every coalition: bits and linear values follow x
+                # inside S, r outside it.
                 for mask in range(nsub):
                     leaf = 0
                     for dd in range(d):
@@ -1719,8 +1921,9 @@ def _shap_forest_linear(Xb, Rb, feats, thrs, depths, lin_k, featoff,
                         vv = xval[j] if (mask >> lin_u[j]) & 1 else rval[j]
                         val += coef[row + 1 + j] * vv
                     fval[mask] = val
-                # Shapley value of each player: weighted marginal over every
-                # coalition that excludes it.
+
+                # Shapley value of each player: the weighted marginal over
+                # every coalition that excludes it.
                 for ui in range(u):
                     bit_ui = 1 << ui
                     contrib = 0.0
@@ -1734,15 +1937,18 @@ def _shap_forest_linear(Xb, Rb, feats, thrs, depths, lin_k, featoff,
                             mm >>= 1
                         w = fact[s] * fact[u - s - 1] / fact[u]
                         contrib += w * (fval[mask | bit_ui] - fval[mask])
+
                     phi[i, U[ui]] += contrib * inv_nbg
+
     return phi
 
 
 class ObliviousTree:
     """A single symmetric tree. Stores its splits and leaf values.
 
-    Its `apply`/`predict` take a feature-major binned matrix (n_features,
-    n_samples) -- the same layout the builder consumes."""
+    `apply` and `predict` take a feature-major binned matrix
+    (n_features, n_samples) -- the same layout the builder consumes.
+    """
 
     __slots__ = ("splits_feat", "splits_thr", "values", "gains", "depth",
                  "lin_feats", "lin_coef", "centers_std")
@@ -1754,6 +1960,7 @@ class ObliviousTree:
         self.values = values
         self.gains = gains if gains is not None else np.zeros(len(splits_feat))
         self.depth = len(splits_feat)
+
         # Optional linear-leaf models (None => plain constant leaves).
         self.lin_feats = lin_feats
         self.lin_coef = lin_coef
@@ -1763,6 +1970,7 @@ class ObliviousTree:
         """Return the leaf index of each sample."""
         if self.depth == 0:
             return np.zeros(Xb.shape[1], dtype=np.int64)
+
         n = Xb.shape[1]
         if n > _ASSIGN_PAR_N:
             # Level-by-level parallel descend; each Xb[f] is a contiguous
@@ -1772,17 +1980,21 @@ class ObliviousTree:
                 _descend_leaves(leaf, Xb[self.splits_feat[d]],
                                 self.splits_thr[d])
             return leaf
+
         return _assign_leaves(Xb, self.splits_feat, self.splits_thr)
 
     def predict(self, Xb):
         if self.depth == 0:
             return np.zeros(Xb.shape[1], dtype=np.float64)
+
         if self.lin_coef is not None:
             leaf = self.apply(Xb)
             return _linear_predict(leaf, self.lin_feats, self.lin_coef,
                                    self.centers_std, Xb)
+
         if Xb.shape[1] > _ASSIGN_PAR_N:
             return self.values[self.apply(Xb)]
+
         return _predict_tree(Xb, self.splits_feat, self.splits_thr, self.values)
 
 
@@ -1791,34 +2003,37 @@ def replay_oblivious_tree(donor, Xb, grad, hess, l2, lr, linear_leaves=False,
     """Refit one tree's LEAF VALUES on new data, reusing ``donor``'s splits.
 
     The split search is what makes growing expensive -- a histogram pass over
-    every feature at every level. Given a structure that is already known to be
-    good, the leaf values follow from a single leaf assignment plus a scatter-add
-    of the gradients, which is O(n * depth) instead of O(n * features * depth).
+    every feature at every level. Given a structure already known to be good, the
+    leaf values follow from one leaf assignment plus a scatter-add of the
+    gradients: O(n * depth) instead of O(n * features * depth).
 
-    Used by the full-data refit (``refit_full="replay"``): the early-stopping
-    winner's structures are replayed round by round against gradients computed
-    on ALL rows, so the held-out validation rows reach the leaf estimates
-    without re-paying for the split search. Returns ``(tree, leaf)``, matching
+    Used by the full-data refit (``refit_full="replay"``). The early-stopping
+    winner's structures are replayed round by round against gradients computed on
+    ALL rows, so the held-out validation rows reach the leaf estimates without
+    re-paying for the split search. Returns ``(tree, leaf)``, matching
     ``build_oblivious_tree``.
 
-    ``Xb`` must be binned by the DONOR's binner -- ``splits_thr`` are bin
-    indices, so a re-fitted binner would silently move every threshold.
+    ``Xb`` must be binned by the DONOR's binner: ``splits_thr`` are bin indices,
+    so a re-fitted binner would silently move every threshold.
     """
     sf, st = donor.splits_feat, donor.splits_thr
     if len(sf) == 0:                       # degenerate donor; caller stops
         return (ObliviousTree(sf, st, np.zeros(1), np.zeros(0)),
                 np.zeros(Xb.shape[1], dtype=np.int64))
+
     leaf = _assign_leaves(Xb, sf, st)
     n_leaves = 1 << len(sf)
     values = _leaf_values(leaf, grad, hess, n_leaves, l2, lr)
-    lin_feats = lin_coef = None
-    # Linear leaves are refit too -- same features the donor split on, new
+
+    # Linear leaves are refit too: same features the donor split on, new
     # coefficients from the full-data gradients.
+    lin_feats = lin_coef = None
     if (linear_leaves and centers_std is not None
             and donor.lin_feats is not None):
         lin_feats = donor.lin_feats
         lin_coef = _linear_leaf_fit(leaf, grad, hess, n_leaves, lin_feats,
                                     centers_std, Xb, l2, linear_lambda, lr)
+
     # Carry the donor's split gains: the structure IS the donor's, so its gains
     # are the honest attribution for it. Zeroing them would leave
     # ``feature_importances_`` summing only the trailing grown trees.
@@ -1843,13 +2058,13 @@ def _build_split_descend_vec(Xb, grad, rw, leaf, n_active, hist, histw,
         sum_k [Gl_k²/(Hl+l2) + Gr_k²/(Hr+l2) - Gt_k²/(Ht+l2)]
           = ‖Gl‖²/(Hl+l2) + ‖Gr‖²/(Hr+l2) - ‖Gt‖²/(Ht+l2)
 
-    which is basis-free -- the identity that makes the default path's single
+    which is basis-free. That identity is what makes the default path's single
     projection an honest rank-1 truncation of this quantity rather than a
-    different algorithm. Costs K histogram channels per feature instead of
+    different algorithm. It costs K histogram channels per feature instead of
     one, which is exactly why it is the reference arm and not the default.
 
-    Simplified relative to the scalar kernel: no occupancy list and no
-    small-n path (level d always scans leaves 0..n_active-1). Both are speed
+    Simplified relative to the scalar kernel: no occupancy list and no small-n
+    path (level d always scans leaves 0..n_active-1). Both are speed
     optimizations, and this kernel is not on the fast path.
     """
     n_features, n_samples = Xb.shape
@@ -1861,12 +2076,15 @@ def _build_split_descend_vec(Xb, grad, rw, leaf, n_active, hist, histw,
     for f in prange(n_features):
         if feat_mask[f] == 0:
             continue
+
+        # Zero this feature's leaf rows, then scatter the samples in.
         nb = n_bins_per_feature[f]
         for l in range(n_active):
             for b in range(nb):
                 histw[f, l, b] = 0.0
                 for k in range(K):
                     hist[f, l, b, k] = 0.0
+
         Xf = Xb[f]
         for i in range(n_samples):
             l = leaf[i]
@@ -1875,10 +2093,12 @@ def _build_split_descend_vec(Xb, grad, rw, leaf, n_active, hist, histw,
             for k in range(K):
                 hist[f, l, b, k] += grad[i, k]
 
+        # Score every threshold on the summed-across-channel gain.
         gain = np.zeros(max_bins)
         legal = np.ones(max_bins, dtype=np.uint8)
         gt = np.empty(K)
         gl = np.empty(K)
+
         for l in range(n_active):
             ht = 0.0
             for k in range(K):
@@ -1887,15 +2107,19 @@ def _build_split_descend_vec(Xb, grad, rw, leaf, n_active, hist, histw,
                 ht += histw[f, l, b]
                 for k in range(K):
                     gt[k] += hist[f, l, b, k]
+
             if ht <= 0.0:
                 continue
+
             sq = 0.0
             for k in range(K):
                 sq += gt[k] * gt[k]
             par = sq / (ht + l2)
+
             hl = 0.0
             for k in range(K):
                 gl[k] = 0.0
+
             for t in range(nb - 1):
                 hl += histw[f, l, t]
                 for k in range(K):
@@ -1919,9 +2143,11 @@ def _build_split_descend_vec(Xb, grad, rw, leaf, n_active, hist, histw,
             if legal[t] and gain[t] > best_g:
                 best_g = gain[t]
                 best_t = t
+
         feat_gain[f] = best_g
         feat_thr[f] = best_t
 
+    # Best feature overall, then descend one level if the split is usable.
     best_f = 0
     best_gain = -np.inf
     for f in range(n_features):
@@ -1934,16 +2160,18 @@ def _build_split_descend_vec(Xb, grad, rw, leaf, n_active, hist, histw,
         Xf = Xb[best_f]
         for i in prange(n_samples):
             leaf[i] = (leaf[i] << 1) + (1 if Xf[i] > best_t else 0)
+
     return best_f, best_t, best_gain
 
 
 def alloc_exact_hist(n_features, max_depth, n_bins_per_feature, K):
     """Buffers for `build_oblivious_tree_exact`, allocated once per fit.
 
-    Sized (n_features, 2**max_depth, max_bins, K) plus a shared weight
-    histogram. This is K times the default path's footprint -- at depth 6, 50
-    features, 128 bins and K=19 it is roughly 62 MB -- which is the honest
-    price of the exact gain and another reason it is not the default."""
+    Sized (n_features, 2**max_depth, max_bins, K) plus a shared weight histogram.
+    That is K times the default path's footprint -- at depth 6, 50 features, 128
+    bins and K=19 it is roughly 62 MB. The honest price of the exact gain, and
+    another reason it is not the default.
+    """
     max_bins = n_features and int(n_bins_per_feature.max())
     max_leaves = 1 << max_depth
     return (np.zeros((n_features, max_leaves, max_bins, K)),
@@ -1959,34 +2187,38 @@ def build_oblivious_tree_exact(Xb, grad, n_bins_per_feature, max_depth, l2,
     The reference arm for the multi-quantile head's split search (see
     `_build_split_descend_vec`). Returns ``(tree, train_leaf)`` like
     `build_oblivious_tree`, but leaf values are left as zeros: the quantile
-    booster overwrites them with the exact per-tau residual quantiles either
-    way, so computing a Newton step here would be wasted work.
+    booster overwrites them with the exact per-tau residual quantiles either way,
+    so computing a Newton step here would be wasted work.
 
-    ``row_weight`` is the per-row weight (sample weights times any MVS
-    importance weight); None means uniform. It plays the hessian's role, one
-    total shared by every channel.
+    ``row_weight`` is the per-row weight (sample weights times any MVS importance
+    weight); None means uniform. It plays the hessian's role, one total shared by
+    every channel.
     """
     n_features, n_samples = Xb.shape
     if feature_mask is None:
         feature_mask = np.ones(n_features, dtype=np.int64)
+
     K = grad.shape[1]
     if hist_buffers is None:
         hist, histw = alloc_exact_hist(n_features, max_depth,
                                        n_bins_per_feature, K)
     else:
         hist, histw = hist_buffers
+
     rw = np.ones(n_samples) if row_weight is None else row_weight
     splits_feat = []
     splits_thr = []
     splits_gain = []
     leaf = np.zeros(n_samples, dtype=np.int64)
     n_active = 1
+
     for d in range(max_depth):
         f, t, gain = _build_split_descend_vec(
             Xb, grad, rw, leaf, n_active, hist, histw, feature_mask,
             n_bins_per_feature, l2, min_child_weight, min_gain)
         if gain <= min_gain or t < 0:
             break
+
         splits_feat.append(f)
         splits_thr.append(t)
         splits_gain.append(gain)
@@ -2006,46 +2238,58 @@ def build_oblivious_tree(Xb, grad, hess, n_bins_per_feature,
                          linear_leaves=False, centers_std=None, is_numeric=None,
                          linear_lambda=1.0, quantize=False, qbuf=None,
                          qseed=0):
-    """Grow one oblivious tree level by level. Returns (tree, train_leaf), where
-    train_leaf is the tree's leaf index for every training sample.
+    """Grow one oblivious tree level by level.
 
-    Xb: feature-major binned matrix (n_features, n_samples).
-    feature_mask: optional 0/1 array over features; 0 disables a feature for
-    this tree (column subsampling). None means all features are eligible.
-    min_child_weight: minimum hessian mass each side of a split must retain in
-    every non-empty leaf. Stops the tree growing once no legal split remains,
-    which prevents sparse-leaf overfitting at higher depth.
-    hist_buffers: optional buffer reused across trees to avoid per-level
-    allocation: interleaved (n_features, 2**max_depth, max_bins, 2) float64,
-    or with quantize=True int64 (n_features, 2**max_depth, max_bins). If
-    None, it is allocated here (for one-off calls and tests).
-    linear_leaves: when True, attach a per-leaf ridge linear model over the
-    tree's numeric split features (`centers_std`/`is_numeric` required;
-    `linear_lambda` is the slope penalty). Low-count leaves fall back to the
-    constant Newton value. The split search is unaffected.
-    quantize: run the SPLIT SEARCH on packed-int64 quantized grad/hess
-    (QUANT_PLAN.md) — one integer RMW per scatter write, half the histogram
-    footprint. Leaf values (and the linear-leaf ridge) still use the
-    original float64 grad/hess, so quantization noise touches only the
-    structure choice. `qbuf` is an optional reusable int64 (n_samples)
-    scratch for the packed values; `qseed` seeds the stochastic rounding
-    (pass a fresh draw per tree for decorrelated rounding noise).
+    Returns (tree, train_leaf), where train_leaf is the tree's leaf index for
+    every training sample.
+
+    Parameters
+    ----------
+    Xb : feature-major binned matrix (n_features, n_samples).
+
+    feature_mask : 0/1 array over features; 0 disables a feature for this tree
+        (column subsampling). None means every feature is eligible.
+
+    min_child_weight : minimum hessian mass each side of a split must retain in
+        every non-empty leaf. Growth stops once no legal split remains, which
+        prevents sparse-leaf overfitting at higher depth.
+
+    hist_buffers : buffer reused across trees to avoid per-level allocation.
+        Interleaved (n_features, 2**max_depth, max_bins, 2) float64, or with
+        quantize=True int64 (n_features, 2**max_depth, max_bins). If None it is
+        allocated here, for one-off calls and tests.
+
+    linear_leaves : when True, attach a per-leaf ridge linear model over the
+        tree's numeric split features. Requires `centers_std` and `is_numeric`;
+        `linear_lambda` is the slope penalty. Low-count leaves fall back to the
+        constant Newton value. The split search is unaffected.
+
+    quantize : run the SPLIT SEARCH on packed-int64 quantized grad/hess
+        (QUANT_PLAN.md) — one integer read-modify-write per scatter, half the
+        histogram footprint. Leaf values and the linear-leaf ridge still use the
+        original float64 grad/hess, so quantization noise touches only the
+        structure choice. `qbuf` is an optional reusable int64 (n_samples)
+        scratch for the packed values. `qseed` seeds the stochastic rounding;
+        pass a fresh draw per tree for decorrelated rounding noise.
     """
     n_features, n_samples = Xb.shape
     max_bins = n_features and int(n_bins_per_feature.max())
     if feature_mask is None:
         feature_mask = np.ones(n_features, dtype=np.int64)
+
     if hist_buffers is None:
         hist = (np.zeros((n_features, 1 << max_depth, max_bins),
                          dtype=np.int64) if quantize
                 else np.zeros((n_features, 1 << max_depth, max_bins, 2)))
     else:
         hist = hist_buffers
+
     if quantize:
-        # qmax keeps every packed cell/prefix sum overflow-safe (see _QMAX_CAP
-        # comment); scales map the observed grad/hess range onto [-qmax, qmax]
-        # and [0, qmax]. All-zero grad or hess degenerates to qg/qh = 0, which
-        # yields zero gains — the same no-split outcome as the float kernel.
+        # qmax keeps every packed cell and prefix sum overflow-safe (see the
+        # _QMAX_CAP comment); the scales map the observed grad/hess range onto
+        # [-qmax, qmax] and [0, qmax]. All-zero grad or hess degenerates to
+        # qg/qh = 0, which yields zero gains — the same no-split outcome as the
+        # float kernel.
         qmax = min(_QMAX_CAP, (2 ** 31 - 1) // max(n_samples, 1))
         gmax, hmax = _gh_absmax(grad, hess)
         inv_dg = qmax / gmax if gmax > 0.0 else 0.0
@@ -2054,24 +2298,27 @@ def build_oblivious_tree(Xb, grad, hess, n_bins_per_feature,
         dh = hmax / qmax if hmax > 0.0 else 0.0
         if qbuf is None:
             qbuf = np.empty(n_samples, dtype=np.int64)
+
         _quantize_pack(grad, hess, inv_dg, inv_dh, np.int64(qmax),
                        np.uint64(qseed), qbuf)
+
     splits_feat = []
     splits_thr = []
     splits_gain = []
     leaf = np.zeros(n_samples, dtype=np.int64)
 
+    # One fused launch per level: split search, descend, and at small n the next
+    # level's occupied-leaf list, which lets the kernel skip zeroing and scanning
+    # empty leaf rows. Any superset of the occupied rows is exact (empty rows are
+    # all-zero once zeroed), so at large n we pass all rows — there the scatter
+    # dominates and the trim is noise. The two occupancy buffers ping-pong so the
+    # kernel never writes the buffer `active` currently views.
     small = n_samples < _SMALL_N
-    # One fused launch per level: split search + descend + (small n) the next
-    # level's occupied-leaf list, which lets the kernel skip zeroing/scanning
-    # empty leaf rows. Any superset is exact (empty rows are all-zero once
-    # zeroed), so at large n we pass all rows — there the scatter dominates
-    # and the trim is noise. Occupancy buffers ping-pong so the kernel never
-    # writes the buffer `active` currently views.
     act_w = np.empty(1 << max_depth, dtype=np.int64) if small else _EMPTY_I64
     act_r = np.empty(1 << max_depth, dtype=np.int64) if small else _EMPTY_I64
     active = np.arange(1, dtype=np.int64)            # level 0: the root
     n_leaves_next = 2
+
     for d in range(max_depth):
         if quantize:
             f, t, gain, n_next = _build_split_descend_q(
@@ -2085,9 +2332,11 @@ def build_oblivious_tree(Xb, grad, hess, n_bins_per_feature,
                 n_leaves_next, act_w)
         if gain <= min_gain or t < 0:
             break
+
         splits_feat.append(f)
         splits_thr.append(t)
         splits_gain.append(gain)
+
         if small:
             active = act_w[:n_next]
             act_w, act_r = act_r, act_w
@@ -2099,6 +2348,7 @@ def build_oblivious_tree(Xb, grad, hess, n_bins_per_feature,
     st = np.array(splits_thr, dtype=np.int64)
     n_leaves = 1 << len(splits_feat)
     values = _leaf_values(leaf, grad, hess, n_leaves, l2, lr)
+
     lin_feats = lin_coef = None
     if linear_leaves and len(splits_feat) > 0 and centers_std is not None:
         # Linear term uses the NUMERIC features the tree actually split on.
@@ -2106,13 +2356,16 @@ def build_oblivious_tree(Xb, grad, hess, n_bins_per_feature,
         for f in splits_feat:
             if is_numeric[f] and f not in seen:
                 seen.append(f)
+
         if seen:
             lin_feats = np.array(seen, dtype=np.int64)
             lin_coef = _linear_leaf_fit(leaf, grad, hess, n_leaves, lin_feats,
                                         centers_std, Xb, l2, linear_lambda, lr)
+
     tree = ObliviousTree(sf, st, values, np.array(splits_gain, dtype=np.float64),
                          lin_feats=lin_feats, lin_coef=lin_coef,
                          centers_std=centers_std if lin_coef is not None else None)
+
     # `leaf` is the training-set assignment, returned so callers (LOO update,
     # leaf correction) reuse it instead of recomputing tree.apply(Xb).
     return tree, leaf

--- a/chimeraboost/warmup.py
+++ b/chimeraboost/warmup.py
@@ -1,22 +1,22 @@
 """Pre-compile ChimeraBoost's numba kernels.
 
-The hot loops are numba kernels compiled on first use. The machine code is
-cached on disk (``cache=True``), but a process on a fresh machine or container
-pays the full JIT cost (~5-15 s) inside its first ``fit``, and the first
-``predict`` in a fresh process pays ~0.2-2 s (kernel compile or cache load).
-Long-lived processes never notice; fleets of short-lived workers (benchmark
-harnesses, serverless inference, ray/spark tasks) pay it on every task, where
-it can dwarf the actual fit/predict work.
+The hot loops are numba kernels, compiled on first use and cached on disk
+(``cache=True``). A fresh machine or container still pays the full JIT cost
+(~5-15 s) inside its first ``fit``, and ~0.2-2 s inside the first ``predict``
+of a fresh process (kernel compile or cache load).
 
-``warmup()`` runs a few tiny synthetic fits + predictions chosen to touch
-every kernel on the default fit and predict paths, so subsequent real calls
-run at steady-state speed. Call it at import/startup time, outside anything
-you time or bill -- or run the ``chimeraboost-warmup`` command once after
-installing.
+Long-lived processes never notice. Fleets of short-lived workers -- benchmark
+harnesses, serverless inference, ray/spark tasks -- pay it on every task, where
+it can dwarf the real fit/predict work.
 
-Note that numba stamps each cache entry with its source file's modification
-time and size, so **upgrading ChimeraBoost invalidates the cache**: the first
-run after ``pip install -U`` pays the compile again.
+``warmup()`` runs a few tiny synthetic fits and predictions that touch every
+kernel on the default fit and predict paths, so later real calls run at
+steady-state speed. Call it at import or startup time, outside anything you
+time or bill -- or run ``chimeraboost-warmup`` once after installing.
+
+numba stamps each cache entry with its source file's modification time and
+size, so **upgrading ChimeraBoost invalidates the cache**: the first run after
+``pip install -U`` pays the compile again.
 """
 
 import argparse
@@ -38,16 +38,17 @@ _NOTICE_DONE = False
 def _cache_is_cold():
     """True when numba's on-disk cache holds nothing usable for our kernels.
 
-    Checks one kernel per source file, because numba invalidates per ``.py``
-    (the cache entry is stamped with that file's mtime and size). An empty
-    index means no cache file, a numba version change, or -- the common case
-    after ``pip install -U chimeraboost`` -- a stale source stamp.
+    Checks one kernel per source file: numba invalidates per ``.py``, stamping
+    each entry with that file's mtime and size. An empty index means no cache
+    file, a numba version change, or -- the common case after
+    ``pip install -U chimeraboost`` -- a stale source stamp.
 
-    Reaches into numba internals, so any failure is read as "warm": a numba
+    Reaches into numba internals, so any failure reads as "warm". A numba
     reorganisation should silence the notice, never break a fit.
     """
     from .binning import _bin_matrix
     from .tree import _build_split_descend_q
+
     try:
         for kernel in (_bin_matrix, _build_split_descend_q):
             if kernel.signatures:
@@ -56,27 +57,30 @@ def _cache_is_cold():
                 return True
     except Exception:
         return False
+
     return False
 
 
 def _maybe_notice_cold_compile():
     """Print one line to stderr when a cold compile is about to happen.
 
-    A silent 15-second first call is indistinguishable from a hang; this says
-    what it is. Fires at most once per process, and only when the disk cache
-    really is cold -- so a given machine sees it about once per release, not
-    once per session.
+    A silent 15-second first call looks like a hang; this says what it is.
+    Fires at most once per process, and only when the disk cache really is
+    cold -- so a machine sees it about once per release, not once per session.
     """
     global _NOTICE_DONE
+
     if _NOTICE_DONE:
         return
     _NOTICE_DONE = True
+
     if os.environ.get("CHIMERABOOST_NO_NOTICE"):
         return
     if os.environ.get("CHIMERABOOST_WARMUP"):
         return                    # already opted into paying it at import
     if not _cache_is_cold():
         return
+
     print("chimeraboost: first run on this machine -- compiling numba kernels "
           "(~15 s, one time, then cached on disk). Run `chimeraboost-warmup` "
           "after installing to pay this up front; set CHIMERABOOST_NO_NOTICE=1 "
@@ -86,11 +90,12 @@ def _maybe_notice_cold_compile():
 def warmup(verbose=False, background=False, shap=False):
     """Compile (or load from the on-disk cache) all default-path kernels.
 
-    Covers binary classification with linear leaves, a categorical feature
-    and a validation set; multiclass; regression with ordered boosting and
-    non-uniform sample weights (the weighted ordered-TS kernel); and the
-    gdiff cross-feature group-sum kernel. Together these touch every fit- and
-    predict-path numba kernel except the SHAP kernels (``shap=True``).
+    Covers binary classification with linear leaves, a categorical feature and
+    a validation set; multiclass; multi-quantile regression; regression with
+    ordered boosting and non-uniform sample weights (the weighted ordered-TS
+    kernel); and the gdiff cross-feature group-sum kernel. Together these touch
+    every fit- and predict-path numba kernel except the SHAP kernels
+    (``shap=True``).
 
     Instead of calling this yourself, run ``chimeraboost-warmup`` once after
     installing, or set the environment variable ``CHIMERABOOST_WARMUP=1`` to
@@ -115,23 +120,32 @@ def warmup(verbose=False, background=False, shap=False):
     float or threading.Thread
         Wall-clock seconds spent warming up, or the started daemon thread
         when ``background=True`` (``.join()`` it to wait for readiness).
+
+    Notes
+    -----
+    A few kernels never fire inside a fit this small: they need more rows than
+    a warmup fit has, or a weighted fit, or a degenerate column. Those are
+    called directly below, with the dtypes the real call passes.
     """
     global _NOTICE_DONE
+
     if background:
         t = threading.Thread(target=warmup,
                              kwargs={"verbose": verbose, "shap": shap},
                              name="chimeraboost-warmup", daemon=True)
         t.start()
         return t
+
     _NOTICE_DONE = True   # this call *is* the compile -- do not narrate it
+
     t0 = time.perf_counter()
     rng = np.random.default_rng(0)
 
     # Row count that reaches the PARALLEL predict kernels. Derived from the
-    # dispatch threshold rather than hardcoded: a raised threshold once
-    # silently pulled every warmup predict onto the serial twins, leaving the
-    # parallel forest walk to compile on the user's first real batch -- the
-    # exact stall warmup exists to prevent.
+    # dispatch threshold, not hardcoded: a raised threshold once pulled every
+    # warmup predict onto the serial twins, leaving the parallel forest walk to
+    # compile on the user's first real batch -- the exact stall warmup exists
+    # to prevent.
     from .binning import _SERIAL_PREDICT_N
     npar = _SERIAL_PREDICT_N + 1
 
@@ -139,9 +153,9 @@ def warmup(verbose=False, background=False, shap=False):
         if verbose:
             print(f"chimeraboost.warmup: {msg} ({time.perf_counter() - t0:.2f}s)")
 
-    # Binary, >= LINEAR_LEAVES_MIN_SAMPLES rows so the linear-leaf kernels
-    # compile (they are the binary default), one categorical column for the
-    # ordered-TS kernel, an eval_set for the per-round validation predict.
+    # Binary. At least LINEAR_LEAVES_MIN_SAMPLES rows so the linear-leaf
+    # kernels compile (they are the binary default), one categorical column for
+    # the ordered-TS kernel, an eval_set for the per-round validation predict.
     n = 1152
     X = np.column_stack([rng.standard_normal((n, 3)),
                          rng.integers(0, 3, size=n).astype(np.float64)])
@@ -152,8 +166,8 @@ def warmup(verbose=False, background=False, shap=False):
     clf.predict_proba(X[:1])   # tiny-batch serial predict kernels
     _log("binary + linear leaves + categoricals")
 
-    # Multiclass (vector-leaf tree build + vector forest predictors; the
-    # npar-row call warms the parallel kernel, the 1-row call the serial twin).
+    # Multiclass: vector-leaf tree build and vector forest predictors. The
+    # npar-row call warms the parallel kernel, the 1-row call the serial twin.
     ym = np.digitize(X[:320, 0], [-0.5, 0.5])
     mc = ChimeraBoostClassifier(n_estimators=2, random_state=0)
     mc.fit(X[:320, :3], ym)
@@ -162,9 +176,8 @@ def warmup(verbose=False, background=False, shap=False):
     _log("multiclass")
 
     # Multi-quantile head: the leaf-quantile kernels (quickselect) and the
-    # vector forest predictors. A short grid keeps the compile cheap -- the
-    # kernels are generic in K, so the number of levels does not change what
-    # gets compiled.
+    # vector forest predictors. The kernels are generic in K, so a short grid
+    # compiles the same code as a long one and costs less.
     yq = X[:320, 0] + 0.5 * rng.standard_normal(320)
     qr = ChimeraBoostQuantileRegressor(quantiles=[0.1, 0.5, 0.9],
                                        n_estimators=2, random_state=0,
@@ -172,11 +185,10 @@ def warmup(verbose=False, background=False, shap=False):
     qr.fit(X[:320, :3], yq)
     qr.predict(X[:npar, :3])
     qr.predict(X[:1, :3])      # serial twin
-    # The parallel leaf-quantile kernel only runs above tree._SMALL_N rows,
-    # and the weighted twins only on a weighted or subsampled fit -- both too
-    # big or too narrow to reach through a warmup fit, so compile them
-    # directly with the dtypes the real call uses (same treatment as the gdiff
-    # kernel below).
+
+    # The parallel leaf-quantile kernel only runs above tree._SMALL_N rows, and
+    # the weighted twins only on a weighted or subsampled fit. Call them
+    # directly.
     from .tree import (_leaf_quantiles_vec, _leaf_quantiles_vec_w,
                        _leaf_quantiles_vec_w_serial)
     _wl = np.arange(8, dtype=np.int64) % 2
@@ -189,59 +201,61 @@ def warmup(verbose=False, background=False, shap=False):
     _leaf_quantiles_vec_w_serial(_wl, _wy, _wF, _ww, _wt, 2, 0.1)
     _log("multi-quantile")
 
-    # Regression, ordered boosting on (the LOO leaf-step kernel), with a
-    # categorical column and NON-uniform sample weights: the weighted
-    # ordered-TS kernel (`_ordered_ts_weighted`) and the weighted binner
-    # borders only compile on a weighted fit (uniform weights collapse to the
-    # unweighted path), which the other stages deliberately keep.
+    # Regression with ordered boosting on (the LOO leaf-step kernel), a
+    # categorical column and NON-uniform sample weights. The weighted
+    # ordered-TS kernel (`_ordered_ts_weighted`) and the weighted binner borders
+    # only compile on a weighted fit: uniform weights collapse to the unweighted
+    # path, which the other stages deliberately keep.
     yr = X[:320, 0] + 0.1 * rng.standard_normal(320)
     sw = rng.uniform(0.5, 1.5, size=320)
     reg = ChimeraBoostRegressor(n_estimators=2, random_state=0,
                                 ordered_boosting=True)
     reg.fit(X[:320], yr, cat_features=[3], sample_weight=sw)
     reg.predict(X[:npar])
+
     # 320 rows is below LINEAR_LEAVES_MIN_SAMPLES, so this model has constant
-    # leaves: a sub-threshold call here is the only thing that compiles the
-    # plain serial predict twin. Without it a warmed serving process still stalls
-    # ~0.3 s on its first single-row request.
+    # leaves, and this sub-threshold call is the only thing that compiles the
+    # plain serial predict twin. Without it a warmed serving process still
+    # stalls ~0.3 s on its first single-row request.
     reg.predict(X[:1])
     _log("regression + ordered boosting + weighted categoricals")
 
-    # The gdiff (group-centered cross feature) kernel sits on the default
-    # path only for fits >= CROSS_MIN_SAMPLES rows -- too big for a warmup
-    # fit, so compile it directly with the dtypes the real call uses.
+    # The gdiff (group-centered cross feature) kernel sits on the default path
+    # only for fits of CROSS_MIN_SAMPLES rows or more -- too big for a warmup
+    # fit. Call it directly.
     from .preprocessing import _grouped_kahan_sum
     _grouped_kahan_sum(np.zeros(4, dtype=np.int64), np.ones(4), 2)
     _log("gdiff group-sum kernel")
 
-    # The parallel descend only runs above tree._ASSIGN_PAR_N rows (large
-    # eval sets, replay refits) -- too big for a warmup fit, so compile it
-    # directly with the dtypes `ObliviousTree.apply` passes (int64 leaves,
-    # a uint16 binned feature row, an int64 threshold).
+    # The parallel descend only runs above tree._ASSIGN_PAR_N rows (large eval
+    # sets, replay refits) -- too big for a warmup fit. Call it directly, with
+    # the dtypes `ObliviousTree.apply` passes: int64 leaves, a uint16 binned
+    # feature row, an int64 threshold.
     from .binning import BIN_DTYPE
     from .tree import _descend_leaves, _predict_tree
     _descend_leaves(np.zeros(4, dtype=np.int64),
                     np.zeros(4, dtype=BIN_DTYPE), np.int64(1))
-    # The fused walk+gather no longer runs during a warmup fit (eval-set
-    # scoring goes leaf-assign + fused add now), but staged_predict and
-    # linear-leaf eval still call it -- keep it warm directly.
+
+    # The fused walk+gather no longer runs during a warmup fit (eval-set scoring
+    # is leaf-assign plus fused add now), but staged_predict and linear-leaf
+    # eval still call it -- keep it warm.
     _predict_tree(np.zeros((2, 4), dtype=BIN_DTYPE),
                   np.zeros(2, dtype=np.int64), np.zeros(2, dtype=np.int64),
                   np.zeros(4))
     _log("parallel descend + tree-walk kernels")
 
     # The greedy-border sweep only fires when a column's quantile borders
-    # collapse (one value holding more than an even bin's share of mass) --
-    # none of the warmup fits' columns do, so compile it directly with the
-    # dtypes `_greedy_borders` passes (same treatment as the gdiff kernel).
+    # collapse (one value holding more than an even bin's share of mass), and no
+    # warmup column does. Call it directly, with the dtypes `_greedy_borders`
+    # passes.
     from .binning import _greedy_border_fill
     _greedy_border_fill(np.arange(4, dtype=np.float64), np.ones(4),
                         np.zeros(4, dtype=np.bool_), 2.0, 3)
     _log("greedy-border sweep kernel")
 
     # The fused level kernel (`_build_split_descend_q`) has one signature for
-    # both its small-n and large-n branches, so the small fits above compile
-    # everything on the tree-build path — no direct kernel calls needed.
+    # both its small-n and large-n branches, so the small fits above already
+    # compile the whole tree-build path -- no direct call needed.
 
     # SHAP is opt-in: `_shap_forest_linear` is an expensive parallel kernel
     # (~3.7 s cold) that most callers never reach. The same call also compiles
@@ -256,16 +270,17 @@ def warmup(verbose=False, background=False, shap=False):
 def _warmup_from_env(value):
     """Dispatch the ``CHIMERABOOST_WARMUP`` env var (called at package import).
 
-    unset/``""``/``"0"`` — do nothing. ``"background"`` — daemon-thread warmup
-    so the import returns immediately (useful only when real startup work
-    follows the import for the compile to overlap with). Anything else truthy
-    (``"1"``) — plain blocking warmup: the import pays the compile once, and
-    every later fit/predict runs at steady-state speed.
+    Unset, ``""`` or ``"0"`` does nothing. ``"background"`` warms up in a
+    daemon thread so the import returns immediately -- worth it only when real
+    startup work follows the import for the compile to overlap with. Anything
+    else truthy (``"1"``) warms up inline: the import pays the compile once,
+    and every later fit/predict runs at steady-state speed.
     """
     if not value or value.strip() == "0":
         return None
     if value.strip().lower() in ("background", "thread", "bg"):
         return warmup(background=True)
+
     return warmup()
 
 
@@ -279,13 +294,14 @@ def _cache_dir():
 
 
 def main(argv=None):
-    """``chimeraboost-warmup`` — compile the kernels now, not on first fit.
+    """``chimeraboost-warmup`` -- compile the kernels now, not on first fit.
 
-    Run once after ``pip install`` (and again after every upgrade, which
-    invalidates numba's cache). Also reachable as
+    Run once after ``pip install``, and again after every upgrade, which
+    invalidates numba's cache. Also reachable as
     ``python -m chimeraboost.warmup`` or ``python -m chimeraboost``.
     """
     from . import __version__
+
     parser = argparse.ArgumentParser(
         prog="chimeraboost-warmup",
         description="Compile ChimeraBoost's numba kernels and cache them on "
@@ -298,10 +314,12 @@ def main(argv=None):
     parser.add_argument("--quiet", action="store_true",
                         help="print nothing on success")
     args = parser.parse_args(argv)
+
     elapsed = warmup(verbose=args.verbose, shap=args.shap)
     if not args.quiet:
         print(f"chimeraboost {__version__}: kernels ready in {elapsed:.1f}s "
               f"(cache: {_cache_dir()})")
+
     return 0
 
 


### PR DESCRIPTION
Nathan's ask, verbatim: more blank space, simpler comments for a human reader, and scikit-learn's source as the style model. He said he likes the commenting in general -- so this compresses how things are said, never what is said.

Blank lines roughly doubled across the package: binning 8% to 21%, tree 9% to 16%, booster 9% to 16%, sklearn_api 6% to 12%, preprocessing 10% to 20%. Logical blocks inside long functions are separated, comment paragraphs no longer sit flush against the code they describe, and guard clauses group together.

Long mid-function rationale moved into docstrings, which is where sklearn keeps it. A reader following the logic is no longer interrupted by six lines of history; a reader who wants the history finds it at the top. Mid-function comments are now one or two lines pinned to the statement they explain.

Prose simplified throughout: throat-clearing cut, dense paragraphs split, plainer words. Comment density fell (binning 20% to 15%, sklearn_api 14% to 12%) while every fact survived.

Also fixes six mojibake sequences in sklearn_api.py where a UTF-8 em dash had been misread as `â€"`. One of them was on the `linear_leaves` parameter, so it rendered garbled on the public API docs page.

WHAT PROTECTS THIS

`benchmarks/comment_only_gate.py` hashes each module's AST with docstrings blanked and line numbers dropped. If an executable statement had moved, the hash would change. All twelve modules: unchanged. That is a much stronger claim than a careful diff review, and it is the gate to run on any future pass like this.

Facts were checked mechanically too, not by eye: every date, win-loss record, speedup, PR reference and measured timing in the old comments was extracted and looked for in the new files. Nothing was lost -- the 2026-07-30 Grinsztajn 21W-32L binning record, the numba-vs-numpy pairwise summation constraint, the divide-by-zero the `light_bins` floor prevents, the "border <= v goes right" failure mode that silently kills a feature, and every citation are all still there, just in fewer words.

932 passed, 1 skipped, numerical-identity goldens included -- identical to main.

# What

<!-- 1-3 sentences: what changed and why. Link issues if any. -->

## Benchmark impact

<!-- Pick one: -->
- [ ] No default behavior changes (benchmarks unaffected)
- [ ] Default/algorithm change — Grinsztajn + OpenML-gate evidence attached (sign test, before/after aggregate table)

## Checklist

- [ ] `pytest` green
- [ ] TabArena-Lite untouched (sealed holdout — results are report-only, never a reason for a change)
- [ ] CHANGELOG.md updated (user-facing changes)
- [ ] Docs updated (API/parameter changes)
