### PR TITLE
Benchmark methodology: barriers, forecasts, inert-slice controls; E1 step 1

### DIFF
--- a/.claude/skills/experiment/SKILL.md
+++ b/.claude/skills/experiment/SKILL.md
@@ -5,6 +5,18 @@ description: Run the validated A/B experiment protocol for a proposed library ch
 
 The validated 3-tier methodology (it shipped mcw-auto, linear-leaves, cross_features; skipping tiers shipped nothing):
 
+0. **Barriers and a forecast** (minutes, before any run):
+   - `python benchmarks/barrier_check.py "<the idea in a sentence>"` — prints which
+     of the closures in `benchmarks/BARRIERS.md` this idea's family already owes an
+     argument about. A match is not a veto; it means the plan file must say which
+     finding is wrong or why it does not apply, **written before the run**. No match
+     is not a clearance either — read `BARRIERS.md` yourself and add tags if the
+     family turns out to be closed.
+   - Write a one-line **forecast** into the plan file's pre-registration: predicted
+     direction and rough effect size on **both** Pareto axes (strength and fit
+     time). The verdict scores it hit or miss. This costs nothing and is the only
+     way we learn which classes of idea we misjudge.
+
 1. **Mechanism probe** (cheap): the SynthGen screen —
    `python benchmarks/run_benchmarks.py --synth --seeds 3 --save` (182 frozen prior-sampled
    datasets, ~30 min) vs the newest synth baseline, then
@@ -36,6 +48,11 @@ The validated 3-tier methodology (it shipped mcw-auto, linear-leaves, cross_feat
      will cover without downloading anything.
    - **Sequential only** — never two benchmarks at once (HC's CatBoost fits run
      50–240 s on card 7k–15k). Progress: `python benchmarks/bench_status.py`.
+   - **Control**: `compare_runs` prints a `control (inert slice)` line — the
+     exact-tie count read as evidence the change engaged only where it claims to,
+     plus an engaged-only sign test. Add `--expect-inert` whenever the change is
+     conditionally gated (size-, feature- or dtype-gated); the control then fails
+     loudly if it engaged everywhere, which is a bug report rather than a result.
    - Sign-test: `python benchmarks/compare_runs.py BASE.json NEW.json --by-suite`
      → one INDEPENDENT test per stratum. **Never pool them.** The suites answer
      different questions, and a variant reuses its parent's rows, so a pooled bar
@@ -78,6 +95,11 @@ Ship rules:
 A/B trap (cost an hour once): editable install means `python script.py` runs **repo** code from any
 CWD. For worktree baselines set `PYTHONPATH=<worktree>` and print `chimeraboost.__file__` in both arms.
 
+Two companion files, and they answer different questions. `benchmarks/BARRIERS.md`
+is about **ideas** — what this project has already closed, so a run is not spent
+re-deriving it. `benchmarks/GATE_ROBUSTNESS.md` is about **readings** — how our own
+numbers have looked like evidence and weren't.
+
 **Before letting any number decide a ship, read `benchmarks/GATE_ROBUSTNESS.md`** — the eight ways
 this process has produced numbers that looked like evidence and weren't, each with the incident that
 proved it. The four questions it ends on, in short: how many INDEPENDENT things is this actually;
@@ -87,8 +109,24 @@ capped at 3 rolling origins so extra seeds duplicate (the harness now warns); a 
 decided datasets is a pointer, not a gate; ties count against the change, so a conditionally-gated
 change reads FAIL at 6W-0L; and a mean far from its median is one dataset (compare_runs now names it).
 
+Recording a verdict — three things beyond the numbers:
+
+- **Both axes, always.** The north star is a frontier with two coordinates, so a
+  kill states its reading on *both*: "flat on strength" is only half a verdict, and
+  a change that is flat on strength and cheaper is a frontier push of exactly equal
+  value. Symmetrically, an idea killed on cost stays live if the same gain can be
+  bought cheaper. Most of this project's "flat" kills have never had their other
+  half read.
+- **Two confidences, not one.** State separately how sure you are that the
+  *mechanism* is real on the decision suites, and how sure you are that it
+  *transfers* to real user data. They are different numbers, and conflating them is
+  how a decision-suite result turns into a leaderboard claim in a later retelling.
+- **Score the forecast** from step 0, hit or miss.
+
 After a ship: update CHANGELOG [Unreleased], regenerate the Pareto (`/pareto`), and record the
-verdict (win or kill — kills are valuable) in memory's algorithm history.
+verdict (win or kill — kills are valuable) in memory's algorithm history. If the kill is
+**general** — a reason that will recur for a whole family of ideas — add it to
+`benchmarks/BARRIERS.md` in the same change, with the incident that proved it.
 
 Sealed holdouts are NEVER part of this loop: TabArena (`/tabarena`) and the
 `pub:` public suite (`benchmarks/PUBLIC_PLAN.md`) are report-only. Never read

--- a/benchmarks/BARRIERS.md
+++ b/benchmarks/BARRIERS.md
@@ -1,0 +1,212 @@
+# Barriers — ideas this project has already closed
+
+Companion to `GATE_ROBUSTNESS.md`. That file is about **readings** that fool us.
+This one is about **ideas**: each entry is a closure we paid for, stated so that
+the next proposal in its family can be recognised before it spends a run.
+
+The scarce resource is benchmark wall-clock — `--decide` is one run at a time and
+takes hours. An idea barred here is not forbidden; it is *known to owe an
+argument*. Clearing a barrier means saying which specific finding below is wrong
+or does not apply, in the plan file, before the run.
+
+`python benchmarks/barrier_check.py "<idea in a sentence>"` matches an idea
+against the tags here and prints what it must clear. Run it before tier 1.
+
+Entries are the machine-readable source for that script: `### B<n> — <title>`
+followed by a `tags:` line. Keep that shape when adding one.
+
+---
+
+### B1 — Audition knobs are structurally inert below the audition thresholds
+tags: audition, selection_rounds, small-data, sus25, sus50, linear_leaves, cross_features, budget
+
+Below `LINEAR_LEAVES_MIN_SAMPLES=1000` and `CROSS_MIN_SAMPLES=2000` no audition
+runs at all, so no audition knob can move anything there. 47 of 48 synth sets
+under 2000 rows were bit-identical across the sel25 arms.
+
+Consequence: never read a small-data stratum as evidence about an audition knob,
+and never propose an audition change *aimed* at small data.
+
+*Incident*: Sel25, 2026-07-31 (`SELECT_PLAN.md`).
+
+### B2 — The rung-3 refit amplifies a bad audition, so audition changes must be judged at `refit_full=True`
+tags: audition, selection_rounds, refit, refit_full, replay, quality, budget, rung
+
+Same knob, same suite, same seeds: at rung 3 sel25 read 6W-20L-10T, p=0.009, mean
+−0.478%; at rung 2 (`refit_full=False`) it read 10W-16L-10T, p=0.327, mean
+**+0.409%**. Rung 3 replays the audition winner's structure over all rows, so a
+wrong pick propagates instead of being diluted.
+
+Consequence: selection **fidelity** is worth more than it was under rung 2. Judge
+every audition-cheapening idea at the shipped default, and re-value
+fidelity-improving ideas upward.
+
+*Incident*: Sel25, 2026-07-31 (`SELECT_PLAN.md`, results `20260731-164927.json`).
+
+### B3 — Partial CatBoost mechanism ports each regress somewhere
+tags: catboost, categorical, cat, encoding, onehot, one-hot, combinations, target-statistics, port, leaf-estimation
+
+Seven CatBoost-inspired levers, seven kills. Each partial port helps some
+categorical sets and regresses another badly, while the win it chases is already
+banked in the current defaults (the all-categorical `cat_combinations` auto-rule,
+the binary `linear_leaves` default, plain boosting with size-adaptive
+`min_child_weight`).
+
+The gap looks like an emergent property of CatBoost's *integrated*
+ordered-boosting-on-permutations machinery, not any single transplantable part.
+
+*Incident*: research cascade, `benchmarks/research/SUMMARY.md`.
+
+### B4 — Ordered boosting is closed
+tags: ordered, ordered-boosting, permutation, catboost, small-data
+
+CatBoost never runs ordered boosting — it is `Plain` at every dataset size. The
+hypothesis family this project carried for months is retired, and our own dormant
+`ordered_boosting` flag with it. Its one size-dependent default is the learning
+rate, which is worth 57% of its small-data edge and which we shipped.
+
+*Incident*: SMALLDATA, 2026-08-01 (`SMALLDATA_PLAN.md`, `probe_catboost_ablation.py`).
+
+### B5 — A shrinkage estimator cannot correct a common in-sample/out-of-sample bias
+tags: shrinkage, pooling, pooled, blend, calibration, quantile, coverage, band, leaf-values
+
+Shrinkage only corrects the component of the error that **varies across** the
+units being shrunk. P15 shrank each leaf's quantile spread toward the pooled band
+to fix under-coverage; train coverage sat at the nominal 0.80 at every pseudo-mass
+while test coverage never arrived, because the pooled band is computed from
+in-sample residuals too and carries the same bias.
+
+Consequence: diagnose whether the defect is a common or a varying component
+before designing any correction that rearranges in-sample quantities.
+
+*Incident*: P15 quantile spread smoothing, 2026-07-31 (PR #63, `LEAFTUNE_PLAN.md`).
+
+### B6 — Broad hyperparameter tuning buys nothing that generalises
+tags: tuning, hyperparameter, search, random-search, reg_lambda, depth, grid, sweep, defaults
+
+A PMLB random search over the whole space found essentially nothing that
+transferred; `min_child_weight` was the one exception, and it shipped. LEAFTUNE
+then reproduced the same result on `reg_lambda` specifically against an exact
+cross-validated grid: 3 wins, 3 losses, 2 ties of 8 datasets, median exactly
+0.000%, none near-solved.
+
+Consequence: the defaults are Grinsztajn-tuned and near a good optimum. A tuning
+proposal needs a mechanism story, not a wider grid.
+
+*Incident*: PMLB random-search study; LEAFTUNE P-series, 2026-07-28.
+
+### B7 — Shadow CV: do not rebuild it
+tags: cv, cross-validation, folds, shared-structure, out-of-fold, oof, reuse
+
+Built end to end 2026-07-28 and thrown away. Three independent reasons: shared
+structure diverges at a 0.70 median so there is nothing to share; sharing it leaks
+(out-of-fold log loss 0.376 on pure noise, below the 0.693 floor); and an exact
+lockstep tier costs ×1.04 against the naive loop, so even done right it buys
+nothing.
+
+*Source*: the program record. It was built and then deleted, so no code or plan
+file survives in the repo to re-check these numbers against.
+
+### B8 — Subsample is a dead axis, on both speed and strength
+tags: subsample, bagging-fraction, row-sampling, mvs, regularization, stochastic
+
+Killed 2026-07-17 on speed, re-tested 2026-07-30 after the MVS numba work made
+`subsample<1` fit 1.32–1.44× faster, and killed again on strength: 0.8 read
+primary 63W-67L median −0.000% and **Brier 31W-55L median −0.730%**; 0.7 was
+worse. The implicit-regularisation mechanism was absent, not merely small — the
+`noise_level` OLS coefficient came back at t = −0.03.
+
+*Incident*: `SUBSAMPLE_PLAN.md`, both dates.
+
+### B9 — Bagging ships only output-identical engineering or more data per member
+tags: bagging, ensemble, n_ensembles, members, oob, quality-ladder
+
+The bagging program is closed with `Ens8` as the blessed mode. Two-member bagging
+is net negative (2 members lose to 1). Everything that changed member *behaviour*
+without giving members more data was killed; what shipped was engineering that
+left predictions identical, plus `refit_members`, which reclaims the per-member
+data tax.
+
+*Incident*: `BAGGING_PLAN.md`; `refit_members`, 2026-08-01.
+
+### B10 — The remaining grow-kernel objects are below their ceilings
+tags: kernel, numba, grow, histogram, scatter, scan, speed, micro-optimisation, dtype
+
+Phase-0 measured every candidate's ceiling as a share of estimator fit before any
+was written: multiclass copy trims 0.9%, int32 leaves ~1–2%, uint8 bins ≤2–3% at
+small n and ~0 at n≥50K — all killed at ceiling. The one double-digit object left
+is the fused scatter+scan split (36.5–57.6% of fit), and it is **FP-drift class**:
+it cannot be made bit-identical, so it cannot pass the numerical-identity goldens
+that every kernel change here has had to pass.
+
+The one lever that was implemented anyway (L-ridge, a row-major restructure) came
+back at ×0.49–0.67 at n≥37.5K and was reverted — the ridge is accumulator-bound,
+not gather-bound.
+
+*Incident*: `GROW_PLAN.md`, Phase 0 and Phase-1 verdicts, 2026-07-18.
+
+### B11 — Isotonic-in-sample is a broken stopping rule
+tags: calibration, isotonic, early-stopping, es, stopping, brier
+
+Calibration-aware early stopping was killed as a default. The reason is
+structural and is the part worth carrying: an isotonic map fitted on the same
+rows the stopping decision then scores cannot report honestly on them, so the
+stopping curve it produces is optimistic exactly where it is being read.
+
+*Source*: the program record — the shipped calibration is temperature scaling
+(`sklearn_api.py`), and no isotonic stopping path exists in the tree today, so
+this entry is history rather than something to inspect. Anyone reopening it
+should re-derive the numbers rather than quote them.
+
+### B12 — Config portfolios die on cost, not on headroom
+tags: portfolio, config, race, multi-config, audition, selection, oracle
+
+A2 passed every strength bar and failed on cost. The test-set oracle ceiling was
++2.587% and validation selection was real (21W-9L-6T, p=0.043) — but it recovers
+only **20% of that ceiling**, and racing four configurations projected to
+**1.90×** fit time against a 1.35× bar.
+
+The reason generalises past A2: **a k=100 audition is nearly a whole fit whenever
+the full fit is short**, which is common (mean 323–382 rounds; multiclass runs
+~100). Any proposal that adds auditions must price them against the *short*-fit
+case, not the average.
+
+*Incident*: A2 Phase 0, 2026-07-25 (`A2_PLAN.md`).
+
+### B13 — Replay is exact and cheap, and misreads the axis that matters
+tags: replay, leaftune, tune_leaves, refit, structure-transfer, sweep
+
+Replay round-trips bit-identically and costs a median 5.2× less per configuration
+than re-growing. But its grid agreed with an exact grid's chosen cell on only 2 of
+8 datasets, and on the one dataset where the parameter genuinely mattered
+(`gr:reg_cat/Brazilian_houses`, +4.4% for exact tuning) replay picked the wrong
+end and gave up **6.8%** on test.
+
+Consequence: replay is a screening instrument, not a selection instrument. Its
+out-of-fold regret diagnostic *did* detect its own failure — keep that diagnostic
+in any future version.
+
+*Incident*: LEAFTUNE, 2026-07-28.
+
+### B14 — No margin rule separates the const-vs-linear race at k=100
+tags: audition, const-vs-linear, linear_leaves, margin, race, selection_rounds, early-exit, budget
+
+The const-versus-linear validation race genuinely crosses late on about a third of
+regression selections, and on the step-0 curves the two arms' overlap is total —
+no margin or early-exit rule at k=100 separates them. `k_ll=500` restores fidelity
+but collapses the 1.50× audition speedup to a projected 1.11×.
+
+Consequence: an early-exit rule on this race owes a measurement against those
+curves. A *per-leg* budget is the untested direction, because the cross race and
+the const-vs-linear race have different crossing behaviour.
+
+*Incident*: `PARETO_PLAN.md`, "Known residual"; Sel25's re-open condition.
+
+---
+
+## Adding an entry
+
+An entry earns its place when a closure is **paid for and general** — a measured
+kill whose reason will recur. A one-off negative goes in its plan file and the
+algorithm history, not here. Keep the `### B<n> — title` / `tags:` shape so
+`barrier_check.py` keeps working, and state the incident that proved it.

--- a/benchmarks/GATE_ROBUSTNESS.md
+++ b/benchmarks/GATE_ROBUSTNESS.md
@@ -78,6 +78,21 @@ suite, so its tie count grows with the quality of its gating.
 - Record both in plan files. "6W-0L-8T, bar FAIL" is honest; "FAIL" alone is
   not.
 
+**Turn it around: the inert slice is a control, not a penalty.** An exact tie
+where a gated change *cannot* engage is positive evidence — the change did what
+it claims and nothing else. That is the one control this project's decision tier
+otherwise lacks; the synthetic suite has had one for a year
+(`synthgen/backtest.py`, the saturated-and-cat-bearing canary slice that must not
+go positive) and `--decide` had none.
+
+- **Guard added**: `compare_runs.py` prints a `control (inert slice)` line on
+  every comparison — the exact-tie count, plus an **engaged-only** sign test.
+  Nothing above it changes; the bar is still over all datasets.
+- Pass `--expect-inert` when the change is conditionally gated. The control then
+  fails loudly if it engaged everywhere, which means either the gate is not doing
+  what it claims or the arm is misconfigured. A change that should be inert
+  somewhere and isn't is a bug report, not a benchmark result.
+
 ## 5. Cross-program comparisons that mix statistics
 
 Plan files record means and medians inconsistently. A candidate was **killed**

--- a/benchmarks/PARETO_PLAN.md
+++ b/benchmarks/PARETO_PLAN.md
@@ -270,3 +270,123 @@ sanity). CatBoost swept all 4 hc multiclass sets (Brier AND F1).
       path (`_build_split_descend`). Nothing is left on a side branch.
 - [x] Memory + CLAUDE.md updated with verdicts (wins AND kills) — ongoing per
       program close; algorithm-history memory current through M1
+
+---
+
+## The dual re-read (2026-08-10) — reopening Track 1
+
+**Why this section exists.** The north star is a frontier with two coordinates,
+but every kill in this project's ledger was recorded against one of them. A
+change that is flat on strength and cheaper pushes the frontier exactly as far as
+one that is cost-neutral and stronger, and we have never gone back to read the
+"flat" verdicts that way. This is a one-pass re-read of the recorded kills asking,
+for each, what it says on the axis it was **not** judged on. It cost no benchmark
+time. The rule it comes from is now in the `/experiment` skill: every verdict
+states both axes.
+
+Two of the kills turn out to have been read on both axes already and are properly
+closed — subsample (faster after the MVS numba work, but Brier 31W-55L median
+−0.730%, so the trade is measured and bad) and the grow kernels (bit-identical by
+construction, so strength cannot move; killed at their measured ceilings). The
+rest divide as follows.
+
+### D1 — The audition: per-leg budget is empty, the decision RULE is not
+
+Sel25 died on strength (gr regression 6W-20L-10T, p=0.009 at the rung-3 default)
+while measuring **8.9%** of total Grinsztajn fit on the cost axis, and its own
+record named a **per-leg** budget as the way back in — long `k` for the
+const-vs-linear race, short for the cross race. Two cheap checks, both costing no
+benchmark time, say that direction is empty and name a better one.
+
+**The per-leg budget is empty, from source plus the recorded flip rate.** The
+cross race is not symmetric with the const-vs-linear race. `_stop_if_behind` kills
+a *trailing* augmented fit at the budget but lets a *leading* one run to its own
+early stop — and the augmented candidate wins 20 of 21 selections (step-0
+pre-registration above). So on 20 of 21 datasets the augmented fit runs full
+whatever `k_cf` is, and shortening it saves almost nothing. Lengthening it is
+barred in the other direction: the cross comparison comes from
+`min(aug.valid_history_[:k]) < base_best`, where `base_best` is the *capped*
+audition's best, so raising `k_cf` above `k_ll` reintroduces exactly the bias the
+symmetric-budget rule was written to remove (`sklearn_api.py:2004-2011`). A
+per-leg budget can therefore only make the cheap leg cheaper, which it is not.
+
+**The rule shape is where the room is** — `benchmarks/probe_audition_rule.py`,
+which replays decision rules against the full validation curves recorded in
+`results/pareto-step0.json`. It reproduces the recorded 4/12 mispicks at k=100
+exactly, so the replay matches the estimator. Findings:
+
+| k | shipped rule | worst validation regret | dataset carrying it |
+|--:|---|--:|---|
+| 25 | 5/12 mispicks | **1.452%** | `gr:reg_cat/nyc-taxi-green-dec-2016` |
+| 50–200 | 4/12 | 0.511% | `gr:reg_num/cpu_act` |
+| 300 | 3/12 | 0.511% | |
+| 500 | 0/12 | 0.000% | |
+
+Three things fall out.
+
+1. **The k=100 plateau is real and flat.** From 50 to 200 nothing changes at all —
+   not the mispick count, not the regret, and not under any of the four rule
+   shapes tried (best-so-far, last value, tail mean, slope-extrapolated). At
+   k=100 the information simply is not in the curves, which generalises B14 from
+   margin rules to every rule of this family.
+2. **The mispicks cost almost nothing where they happen.** Median regret is
+   0.000% and the worst single case is 0.511%. The 4/12 rate reads like a
+   fidelity problem and mostly is not one.
+3. **The exception is exactly the dataset that killed sel25.** At k=25 the worst
+   regret triples to 1.452% on `nyc-taxi-green-dec-2016` — the dataset sel25's
+   own record names as its cheapest repro, losing in all four of its appearances
+   (−1.70% / −4.18% / −1.92% @sus25 / −2.94% @sus50). The offline replay fingers
+   the same dataset the decide-tier run did, and supplies the mechanism: a
+   short-audition mispick that the rung-3 refit then amplifies (B2).
+
+And the opening: at k=25 the **tail-mean** rule reads 4/12 at 0.511% worst regret
+— the same fidelity as the shipped rule at k=100, at a quarter of the budget. If
+that holds up, sel25's 8.9% is available after all, and it was the rule rather
+than the budget that was wrong. One race carries the whole difference at n=12, so
+this is a pointer and nothing more (`GATE_ROBUSTNESS.md` #2).
+
+Queued as E1 in `SELECT_PLAN.md`, **with a curve-corpus widening first** — raising
+n from 12 costs one attribution run, not a decide run, and this is far too thin to
+gate on. Barriers it owes an argument about: B1, B2, B12, B14.
+
+### D2 — Cheapening the audition revives everything killed on audition cost
+
+A2 passed every strength bar and failed only on cost: oracle ceiling +2.587%,
+validation-selected +0.522% at a 70% win rate (21W-9L-6T, p=0.043), and a
+projected **1.90×** fit multiple against a 1.35× bar. Its stated reason —
+"a k=100 audition is nearly a whole fit whenever the full fit is short" — is a
+statement about audition *pricing*, not about config portfolios.
+
+So D1 and A2 are coupled, and the coupling is the point: the audition cost model
+is a shared denominator under several dead ideas. If D1 lands, A2's kill is worth
+re-deriving at the new price rather than re-running blind. **Do not re-run A2
+before D1 reports** — that is the ordering the dual read buys us.
+
+### D3 — The patience default's rationale is stale below 20k rows
+
+`early_stopping_rounds=50` was chosen because "50 beat 10 on 25 of 34 datasets…
+because lr=0.1 keeps improving past a 10-round plateau" (`sklearn_api.py`), and
+the synth backtest records patience 300 as flat. So the axis reads: 10 loses, 50
+ships, 300 is flat.
+
+Since 0.30.0 the small-data learning rate is no longer 0.1 — it fades to 0.07
+below 20k rows. A lower rate improves for *longer*, so the measurement behind the
+default no longer describes the regime where the rate now differs. This is not a
+speed lever (it points at more patience, not less); it is an unmeasured default
+whose stated justification has expired. Open question, not a queued run.
+
+### D4 — Replay is a screening instrument in search of a use
+
+LEAFTUNE killed `tune_leaves`, but the mechanism it built round-trips
+bit-identically and costs a median **5.2× less per configuration** than
+re-growing. Its fidelity failure (agreed with an exact grid on 2 of 8 datasets;
+gave up 6.8% on the one set where the parameter mattered) makes it unfit to
+*select*, and it does not touch the shipped fit path either way — so this is
+research-tooling speed, not product Pareto. Worth remembering the next time a
+study needs a wide sweep; not worth a program.
+
+### What this leaves
+
+D1 is the only queued run. D2 is a scheduling constraint on a future one, D3 an
+open question with no owner, D4 a note. The barriers each of these must clear are
+in `benchmarks/BARRIERS.md`.

--- a/benchmarks/SELECT_PLAN.md
+++ b/benchmarks/SELECT_PLAN.md
@@ -379,6 +379,146 @@ one `--models` flag.
   (`sklearn_api.py:1443`). A forced-on mode could give a stronger rung 1
   at the same one-fit cost. Untested.
 
+## E1 — pre-registered 2026-08-10: the rule, not the budget
+
+**Status: pre-registration only. Nothing has run at the decision tier, and the
+step below that must run first is an attribution run, not a decide run.**
+
+### Why this reopens a closed knob
+
+The "per-leg budget" recorded above as sel25's live sub-question is **empty**, and
+the argument is from source rather than from a run: the augmented candidate wins
+20 of 21 selections and `_stop_if_behind` lets a leading augmented fit run to its
+own early stop, so shortening the cross leg saves nothing on 20 of 21 datasets;
+and lengthening it past `k_ll` reintroduces the asymmetry the symmetric-budget
+rule exists to remove (`sklearn_api.py:2004-2011`). Full reasoning in
+`PARETO_PLAN.md`, "The dual re-read", D1.
+
+What is *not* empty is the decision rule. `benchmarks/probe_audition_rule.py`
+replays rules against the full validation curves in `results/pareto-step0.json`
+(zero benchmark cost; it reproduces the recorded 4/12 mispicks at k=100 exactly,
+which is its self-check). It finds a dead flat plateau from k=50 to k=200 under
+every rule shape tried, near-zero regret where mispicks happen — and one
+exception: at **k=25** the shipped best-so-far rule mispicks
+`gr:reg_cat/nyc-taxi-green-dec-2016` at 1.452% validation regret, while a
+**tail-mean** rule over the same budget reads 4/12 at 0.511%, matching the
+shipped rule's fidelity at k=100 for a quarter of the budget.
+
+That dataset is the one this file already names as sel25's cheapest repro. So the
+kill has a mechanism now: it was the rule that failed at k=25, not the budget.
+
+### The arm
+
+`selection_rounds=25` with the const-vs-linear decision taken on the **mean of
+the last 20 audition rounds** instead of the best value seen. Tie still goes to
+constant leaves. The cross race is untouched, and so is every non-regression path.
+
+### Forecast (both axes, recorded before the run)
+
+- **Cost**: −8 to −10% Grinsztajn fit time, i.e. sel25's measured 8.9%. High
+  confidence; this is arithmetic on the audition, not a new mechanism.
+- **Strength**: flat on Grinsztajn regression, ±0.15% median. This is the whole
+  bet, and the honest prior on it is weak — the evidence is one race flipping at
+  n=12.
+- **Where I expect to be wrong**: that the tail-mean advantage is one dataset's
+  noise and does not survive a wider curve corpus. That is what step 1 tests.
+
+### Steps, in order
+
+1. **Widen the curve corpus first — an attribution run, not a decide run.**
+   `profile_fit.py --attribution` over more regression datasets, then re-run
+   `probe_audition_rule.py`. n=12 races on 4 datasets is a pointer and cannot
+   gate anything (`GATE_ROBUSTNESS.md` #2). **Kill here** if tail-mean's edge at
+   k=25 does not survive: median regret at k=25 must be no worse than the shipped
+   rule at k=100, on at least 30 races. **DONE 2026-08-10 — PASS, see "Step 1
+   result" below.**
+2. Tier-1 synth screen. Note B1: below 1000/2000 rows no audition runs at all, so
+   the small-n slice is structurally inert and must read as exact ties — pass
+   `--expect-inert`, and treat engagement there as a bug report.
+3. Tier-2 `--decide --seeds 3 --save`, judged at `refit_full=True` (B2 — rung 2
+   would flatter it, as it flattered sel25).
+
+### Step 1 result (2026-08-10): 12 → 48 races — bar PASSES; the finding replicates
+
+New corpus: `results/audition-corpus-e1.json` (git-ignored, like step-0) — 12
+regression dataset-variants x 3 seeds not already in step-0, deliberately
+including the sel25 kill's worst losers (both `Brazilian_houses` variants, the
+numeric taxi variant), so the widening is stress-weighted *against* the rule.
+Command: `profile_fit.py --attribution --seeds 3 --uncapped-auditions
+--datasets ... --out audition-corpus-e1`; replay:
+`probe_audition_rule.py --k 25 50 100 200 --corpus
+results/audition-corpus-e1.json` (self-check 4/12 intact).
+
+Two instrument traps found and fixed on the way, worth knowing for any future
+corpus widening:
+
+- **A capped attribution run is circular for this probe.** Under today's
+  `selection_rounds=100` default the recorded curves *stop at the cap*, so the
+  replayed "full-curve truth" is the k=100 decision itself — the first attempt
+  read a trivially perfect 36/36 agreement at k≥100. `profile_fit.py
+  --attribution` now takes `--uncapped-auditions` (`selection_rounds=None`,
+  the conditions step-0 was recorded under); the probe's corpus must come from
+  such a run.
+- **The rung-3 replay refit clobbers audition labels.** It appends a fourth
+  booster-fit record that reuses the winner's label with an empty
+  `valid_history` (it has no validation loop); the probe's last-wins label
+  dict silently dropped 15 of 36 races. The loader now keeps the first fit
+  per label — step-0 output byte-identical before/after, self-check still
+  4/12.
+
+The registered bar — tail-mean@25 median regret no worse than shipped@100 on
+≥30 races — **passes on n=48** (0.000% vs 0.000%). Honest caveat: *every*
+rule/k median in the table is 0.000%, so the registered statistic turned out
+to be nearly vacuous. The sharper paired reading over the same 48 races:
+
+| candidate | mispicks | mean regret | total regret | worst regret |
+|---|--:|--:|--:|--:|
+| shipped@25 | 14/48 | 0.299% | 14.33% | 4.33% |
+| **tail@25** | **12/48** | **0.262%** | **12.58%** | 4.33% |
+| shipped@100 (today) | 12/48 | 0.194% | 9.31% | 3.09% |
+| tail@100 | 15/48 | 0.195% | 9.38% | 3.09% |
+
+- **The pointer survived widening.** tail@25 strictly dominates shipped@25:
+  it fixes both taxi mispicks (`gr:reg_cat` s2 at 1.452%, and a new one,
+  `gr:reg_num` s1 at 0.299%) and pays nothing extra on any other race. The
+  forecast's "where I expect to be wrong" (one dataset's noise) did not
+  materialize.
+- **tail@25 vs shipped@100 is a wash on mispicks** (12 = 12). The mean-regret
+  gap (0.262% vs 0.194%) is entirely ONE dataset — `analcatdata_supreme`
+  (3,039 train rows, the panel's smallest): its s1 race costs tail@25 4.331%
+  while its s0 race costs shipped@100 1.063%, opposite directions on
+  different seeds of the same data. Per GATE_ROBUSTNESS #3, a mean moved by
+  one dataset is not evidence either way.
+- **The tail rule is k=25-specific, not a general upgrade**: at k=100 it is
+  *worse* than the shipped rule (15 vs 12 mispicks). E1's arm stays exactly
+  as registered — k=25 + tail-mean — and no one should "improve" the k=100
+  default rule off this table.
+
+**Consequence: E1 proceeds to step 2.** The arm needs a library knob that does
+not exist yet (the const-vs-linear decision is hard-coded best-so-far in
+`sklearn_api.py`); implementing it is a source change owned by the /experiment
+protocol on its own branch, with the forecast above already registered.
+
+### Barriers this owes an argument about
+
+- **B1** (audition knobs inert on small data) — accepted, not contested; it is
+  why the small-n strata are a control here rather than evidence.
+- **B2** (the refit amplifies a bad audition) — this arm is *aimed* at that
+  finding: it cuts the budget only after making the decision more robust.
+- **B12** (price auditions against the short-fit case) — a 25-round audition is
+  cheap even against a ~100-round multiclass fit, so this one is cleared rather
+  than argued.
+- **B14** (no margin rule separates the race at k=100) — not contested. The probe
+  extends it: at k=100 *no* rule shape separates them. The claim here is only
+  about k=25, where the curves do still differ.
+
+### Kill clause
+
+Registered before the run: fails step 1's bar, or any decisive per-stratum sign
+test against it at tier 2, and `selection_rounds` stays 100 permanently — the
+budget axis is then closed from below as well as above, and B14 gets a line
+saying so.
+
 ## Log
 
 - 2026-07-25: pre-registered.
@@ -393,3 +533,24 @@ one `--models` flag.
   amplifies it**: the same knob reads 10W-16L-10T, p=0.327, mean +0.409% at
   rung 2, so the 07-25 parity finding was a valid rung-2 result invalidated
   by the default flip rather than a bad measurement.
+- 2026-08-10: dual re-read of this kill (`PARETO_PLAN.md`, D1). The per-leg
+  budget recorded above as the live sub-question is **empty** — argued from
+  source and the 20/21 cross flip rate, no run spent. The replacement,
+  **E1**, is pre-registered above: the decision RULE at k=25, not the
+  budget. New instrument: `benchmarks/probe_audition_rule.py`, which
+  reproduces the recorded 4/12 mispicks at k=100 and then explains this
+  kill — at k=25 the shipped rule mispicks `nyc-taxi-green-dec-2016`
+  (this file's own cheapest repro) at 1.452% validation regret, which the
+  rung-3 refit amplifies. Nothing has run at the decision tier.
+- 2026-08-10 (later): **E1 step 1 PASS** — corpus widened 12 → 48 races
+  (`audition-corpus-e1`, uncapped auditions), self-check intact at 4/12.
+  tail@25 replicates its edge (strictly dominates shipped@25, fixes both taxi
+  mispicks) and matches shipped@100 on mispicks 12 = 12; the residual
+  mean-regret gap is one dataset (`analcatdata_supreme`), swinging both ways
+  across seeds. Registered median bar passes but proved nearly vacuous (all
+  medians 0.000%) — recorded so the next pre-registration picks a sharper
+  statistic. Two instrument fixes: `--uncapped-auditions` on the attribution
+  runner (capped curves make the replay circular) and first-fit-per-label in
+  the probe loader (the rung-3 replay refit's empty record was clobbering
+  audition curves). Next: step 2 tier-1 synth, which first needs the arm
+  implemented behind a knob (/experiment territory, separate branch).

--- a/benchmarks/barrier_check.py
+++ b/benchmarks/barrier_check.py
@@ -1,0 +1,183 @@
+"""Check a proposed idea against the barriers this project has already paid for.
+
+`benchmarks/BARRIERS.md` is the source of truth; this script only matches an idea
+description against its tags and prints what the idea owes an argument about. It
+is deliberately dumb -- keyword matching, no model -- because its value is that it
+gets RUN before a `--decide` run is spent, not that it is clever.
+
+A match is not a veto and no match is not a clearance: a barrier says "this
+family has been closed before, say why yours is different, in the plan file,
+before the run."
+
+Usage:
+  python benchmarks/barrier_check.py "cheapen the audition on small data"
+  python benchmarks/barrier_check.py --list          # every barrier, one line each
+  python benchmarks/barrier_check.py --show B2       # one barrier in full
+
+Exit code is 0 always -- this reports, it does not gate.
+"""
+import argparse
+import os
+import re
+import sys
+
+BARRIERS_MD = os.path.join(os.path.dirname(os.path.abspath(__file__)), "BARRIERS.md")
+
+_HEAD = re.compile(r"^###\s+(B\d+)\s+[-—]+\s+(.*)$")
+_TAGS = re.compile(r"^tags:\s*(.*)$", re.IGNORECASE)
+
+
+def _words(text):
+    """Lowercase word list, with '-' and '_' treated as spaces."""
+    return re.findall(r"[a-z0-9]+", re.sub(r"[-_]", " ", text.lower()))
+
+
+def parse_barriers(path=BARRIERS_MD):
+    """Return [{id, title, tags, body}] parsed from BARRIERS.md."""
+    with open(path, encoding="utf-8") as fh:
+        lines = fh.read().splitlines()
+
+    out, cur = [], None
+    for line in lines:
+        head = _HEAD.match(line)
+        if head:
+            cur = {"id": head.group(1), "title": head.group(2).strip(),
+                   "tags": [], "body": []}
+            out.append(cur)
+            continue
+        if cur is None:
+            continue
+        tags = _TAGS.match(line.strip())
+        if tags and not cur["tags"]:
+            cur["tags"] = [t.strip() for t in tags.group(1).split(",") if t.strip()]
+            continue
+        cur["body"].append(line)
+
+    for b in out:
+        # Drop leading/trailing blank lines; keep the prose as written.
+        body = b["body"]
+        while body and not body[0].strip():
+            body.pop(0)
+        while body and not body[-1].strip():
+            body.pop()
+        b["body"] = "\n".join(body)
+    return out
+
+
+def _token_hit(tag_word, idea_word):
+    """A tag word matches an idea word on a shared prefix of >= 5 chars.
+
+    So 'shrink' finds the 'shrinkage' barrier and 'auditions' finds 'audition',
+    while 'cat' does not match 'catch' and 'leaf' does not match 'leaftune'.
+    """
+    if tag_word == idea_word:
+        return True
+    if len(tag_word) < 5 or len(idea_word) < 5:
+        return False
+    return tag_word.startswith(idea_word) or idea_word.startswith(tag_word)
+
+
+def match(idea, barriers):
+    """Return [(barrier, [matched tags])], most-matched first."""
+    idea_words = _words(idea)
+    hits = []
+    for b in barriers:
+        matched = []
+        for tag in b["tags"]:
+            tw = _words(tag)
+            if not tw:
+                continue
+            # Multi-word tags ('small-data') must appear as a contiguous run.
+            for i in range(len(idea_words) - len(tw) + 1):
+                if all(_token_hit(a, c) for a, c in zip(tw, idea_words[i:i + len(tw)])):
+                    matched.append(tag)
+                    break
+        if matched:
+            hits.append((b, matched))
+    hits.sort(key=lambda h: (-len(h[1]), int(h[0]["id"][1:])))
+    return hits
+
+
+def _ascii(text):
+    """Windows consoles here are cp1252; keep printed prose readable."""
+    for src, dst in (("—", "--"), ("–", "-"), ("’", "'"), ("−", "-"),
+                     ("“", '"'), ("”", '"'), ("×", "x"), ("≤", "<="),
+                     ("≥", ">="), ("~", "~")):
+        text = text.replace(src, dst)
+    return text.encode("ascii", "replace").decode("ascii")
+
+
+def first_sentence(body, limit=110):
+    """The barrier's opening claim, reflowed onto one line."""
+    para = []
+    for line in body.splitlines():
+        if not line.strip():
+            break
+        para.append(line.strip())
+    text = _ascii(" ".join(para))
+    cut = text.find(". ")
+    if cut != -1:
+        text = text[:cut + 1]
+    if len(text) > limit:
+        text = text[:limit - 3].rstrip() + "..."
+    return text
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("idea", nargs="*", help="the proposed idea, in a sentence")
+    ap.add_argument("--list", action="store_true", help="every barrier, one line each")
+    ap.add_argument("--show", metavar="ID", help="print one barrier in full (e.g. B2)")
+    args = ap.parse_args(argv)
+
+    barriers = parse_barriers()
+    if not barriers:
+        print(f"no barriers parsed from {BARRIERS_MD} -- check its heading format")
+        return 0
+
+    if args.list:
+        for b in barriers:
+            print(f"{b['id']:>4}  {_ascii(b['title'])}")
+        return 0
+
+    if args.show:
+        want = args.show.strip().upper()
+        for b in barriers:
+            if b["id"] == want:
+                print(f"### {b['id']} - {_ascii(b['title'])}\n")
+                print(_ascii(b["body"]))
+                return 0
+        print(f"no barrier {want}; try --list")
+        return 0
+
+    idea = " ".join(args.idea).strip()
+    if not idea:
+        ap.print_help()
+        return 0
+
+    hits = match(idea, barriers)
+    print(f'idea: "{idea}"')
+    print(f"{len(barriers)} barriers on file, {len(hits)} matched\n")
+
+    if not hits:
+        print("No barrier matched. That is NOT a clearance -- it means the")
+        print("keywords did not land. Read BARRIERS.md yourself before the run,")
+        print("and add tags here if this idea's family is already closed.")
+        return 0
+
+    for b, matched in hits:
+        print(f"{b['id']} - {_ascii(b['title'])}")
+        print(f"     matched on: {', '.join(matched)}")
+        first = first_sentence(b["body"])
+        if first:
+            print(f"     {first}")
+        print(f"     full text: python benchmarks/barrier_check.py --show {b['id']}")
+        print()
+
+    print("Each of these owes an argument in the plan file, written BEFORE the")
+    print("run: which finding is wrong, or why it does not apply here.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/compare_runs.py
+++ b/benchmarks/compare_runs.py
@@ -30,6 +30,17 @@ blends every model's records into the per-dataset mean (fine when both runs
 hold the other models fixed, but the deltas are diluted).
 --model-new names the NEW run's records when they differ (e.g. baseline
 ChimeraBoost vs an arm's ChimeraBoostEns2).
+--expect-inert declares that the change is conditionally gated and must be inert
+somewhere; see THE INERT SLICE IS A CONTROL below.
+
+THE INERT SLICE IS A CONTROL
+----------------------------
+The sign-test bar counts ties against the change, so a conditionally-gated
+change reads worse the better its gating -- that is how a 6W-0L result once read
+FAIL (GATE_ROBUSTNESS.md #4). Every comparison therefore also prints the tie
+count as a CONTROL (an exact tie where the change cannot engage is positive
+evidence that it did what it claims and nothing else) and an engaged-only sign
+test, which answers "when this engaged, did it help?". Neither changes the bar.
 
 NEAR-SOLVED DATASETS
 --------------------
@@ -166,6 +177,10 @@ def main():
     ap.add_argument("--keep-near-solved", action="store_true",
                     help="do NOT exclude near-solved datasets from the mean "
                          "(reproduces pre-fix numbers quoted in older plans).")
+    ap.add_argument("--expect-inert", action="store_true",
+                    help="declare that this change is conditionally gated and "
+                         "MUST be inert on part of the suite; the control line "
+                         "then fails loudly if it engaged everywhere.")
     ap.add_argument("--by-suite", action="store_true",
                     help="report an independent sign test per stratum (suite x "
                          "variant) instead of one over the union -- mandatory "
@@ -288,6 +303,49 @@ def _report(shared, base, new, ds_meta, rmse_b, rmse_n, brier_b, brier_n,
         note = "" if k_verdict == verdict else "   <-- DISAGREES with the bar above"
         print(f"  (excluding near-solved: {kw} wins / {kl} losses / {kt} ties, "
               f"bar {k_need}+ = {k_verdict}){note}")
+
+    _control_line(shared, all_pairs, ties, args)
+
+
+def _control_line(shared, all_pairs, ties, args):
+    """Read the exact ties as a CONTROL rather than as a penalty.
+
+    A conditionally-gated change (size-gated, feature-gated, dtype-gated) is
+    deliberately inert on part of the suite. The bar above counts those ties
+    against it, so the better a change's gating the worse it reads -- that is
+    how a 6W-0L result read FAIL (GATE_ROBUSTNESS.md #4).
+
+    Read the other way round, an exact tie where the change cannot engage is
+    POSITIVE evidence: it did what it claims and nothing else. Two readings
+    follow from that, and both are printed here:
+
+      - the inert slice, which is the control; and
+      - the engaged-only sign test, which answers "when this engaged, did it
+        help?" -- the question the all-dataset bar cannot answer.
+
+    Print-only. No verdict above changes, and the exit code stays 0.
+    """
+    engaged = [(ds, p) for ds, p in zip(shared, all_pairs)
+               if abs(p[1] - p[0]) > 1e-9]
+
+    if ties:
+        print(f"control (inert slice): {ties} of {len(shared)} datasets are exact "
+              f"ties -- the change did not engage there.")
+    else:
+        print(f"control (inert slice): none -- the change engaged on all "
+              f"{len(shared)} datasets.")
+        if args.expect_inert:
+            print("  !! CONTROL FAIL: --expect-inert was declared and nothing "
+                  "was inert. Either the gate is not doing what it claims, or "
+                  "the arm is misconfigured. Find out before reading the bar.")
+
+    if engaged and ties:
+        ew, el, et = _sign_counts([p for _, p in engaged])
+        e_need = len(engaged) // 2 + 1
+        e_verdict = "PASS" if ew >= e_need else "FAIL"
+        plural = "dataset" if len(engaged) == 1 else "datasets"
+        print(f"  engaged only ({len(engaged)} {plural}): {ew} wins / {el} losses, "
+              f"bar {e_need}+ = {e_verdict}   <-- 'when it engaged, did it help?'")
 
 
 if __name__ == "__main__":

--- a/benchmarks/probe_audition_rule.py
+++ b/benchmarks/probe_audition_rule.py
@@ -1,0 +1,197 @@
+"""Replay const-vs-linear audition rules against the recorded step-0 curves.
+
+Zero benchmark cost. `results/pareto-step0.json` holds the FULL validation
+history of both the constant-leaf and linear-leaf regression fits (they were run
+to their own early stop for the attribution table), so any capped decision rule
+can be simulated on them and scored against what the full curves say is actually
+better.
+
+What this answers: the shipped rule mispicks 4 of 12 regression selections at
+k=100 (PARETO_PLAN.md step-0 pre-registration), and PARETO_PLAN's "Known
+residual" reports that no MARGIN rule at k=100 separates the two arms because
+their overlap is total. Those two facts leave open whether a differently-SHAPED
+rule -- reading the curve's late trend instead of its best-so-far -- does better
+at the same cost. That matters more than it used to: the rung-3 refit replays the
+audition winner over all rows, so a mispick propagates (BARRIERS.md B2).
+
+Self-check: the shipped rule at k=100 must reproduce 4/12. If it does not, the
+replay does not match the estimator and nothing below is worth reading.
+
+Usage:
+  python benchmarks/probe_audition_rule.py
+  python benchmarks/probe_audition_rule.py --k 100 200 300 500
+  python benchmarks/probe_audition_rule.py --corpus results/audition-corpus-e1.json
+"""
+import argparse
+import json
+import os
+import sys
+
+import numpy as np
+
+_BENCH = os.path.dirname(os.path.abspath(__file__))
+STEP0 = os.path.join(_BENCH, "results", "pareto-step0.json")
+
+
+def load_races(path):
+    """[(dataset, seed, const_curve, linear_curve)] for every recorded race."""
+    with open(path, encoding="utf-8") as fh:
+        records = json.load(fh)
+    races = []
+    for r in records:
+        # First fit per label. The audition fits come first in fit order; a
+        # rung-3 replay refit appends a fourth record that REUSES the winner's
+        # label with an empty valid_history (it has no validation loop), and
+        # last-wins would let it clobber the real audition curve.
+        fits = {}
+        for f in r["fits"]:
+            fits.setdefault(f["label"], f)
+        if "const" not in fits or "linear" not in fits:
+            continue          # binary/multiclass: no const-vs-linear race
+        c = np.asarray(fits["const"]["valid_history"], dtype=float)
+        l = np.asarray(fits["linear"]["valid_history"], dtype=float)
+        if c.size == 0 or l.size == 0:
+            continue
+        races.append((r["dataset"], r["seed"], c, l))
+    return races
+
+
+# ---------------------------------------------------------------- rules
+# Each rule takes the two capped curves and returns True for "pick linear".
+# The shipped rule's tie-break goes to constant leaves, and every rule here
+# keeps that convention so the comparison is like for like.
+
+def rule_best(c, l):
+    """SHIPPED: best validation loss seen within the cap."""
+    return l.min() < c.min()
+
+
+def rule_last(c, l):
+    """Value at the cap, not best-so-far -- rewards a curve still descending."""
+    return l[-1] < c[-1]
+
+
+def rule_tail_mean(c, l, w=20):
+    """Mean over the last w rounds: best-so-far with the noise averaged out."""
+    return l[-w:].mean() < c[-w:].mean()
+
+
+def rule_extrapolate(c, l, w=20):
+    """Best-so-far, projected forward one window by each curve's recent slope.
+
+    The failure this targets is the recorded one: the races that go wrong are
+    the ones that CROSS LATE, so the arm that is behind at the cap but still
+    falling faster is the one the cap is stealing from.
+    """
+    def proj(v):
+        if v.size <= w:
+            return v.min()
+        slope = (v[-1] - v[-w]) / w          # negative while improving
+        return min(v.min(), v[-1] + slope * w)
+    return proj(l) < proj(c)
+
+
+RULES = [
+    ("best (shipped)", rule_best),
+    ("last value", rule_last),
+    ("tail mean w=20", rule_tail_mean),
+    ("extrapolated w=20", rule_extrapolate),
+]
+
+
+def truth(c, l):
+    """What the FULL curves say: is linear genuinely better? Ties to const."""
+    return l.min() < c.min()
+
+
+def regret(c, l, picked_linear):
+    """Relative validation loss given up by the pick, vs the better full arm."""
+    best = min(c.min(), l.min())
+    got = l.min() if picked_linear else c.min()
+    return (got - best) / abs(best) if abs(best) > 1e-12 else 0.0
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--k", type=int, nargs="+", default=[100, 200, 300, 500],
+                    help="audition caps to simulate")
+    ap.add_argument("--corpus", nargs="*", default=[],
+                    help="extra --attribution result JSONs to widen the race "
+                         "corpus; step-0 always loads and its self-check "
+                         "always runs")
+    args = ap.parse_args(argv)
+
+    if not os.path.exists(STEP0):
+        print(f"missing {STEP0} -- regenerate with "
+              f"`python benchmarks/profile_fit.py --attribution --seeds 3 "
+              f"--out pareto-step0`")
+        return 1
+
+    # Self-check FIRST, on the step-0 races alone, whatever else is loaded:
+    # the shipped rule at k=100 must reproduce the 4/12 mispicks the estimator
+    # actually recorded. If it moves, the instrument is wrong, not the finding.
+    step0 = load_races(STEP0)
+    miss = sum(1 for _, _, c, l in step0
+               if rule_best(c[:100], l[:100]) != truth(c, l))
+    print(f"self-check: shipped rule at k=100 on step-0 races -- "
+          f"{miss}/{len(step0)} mispicks (must be 4/12)")
+    if (miss, len(step0)) != (4, 12):
+        print("SELF-CHECK FAILED: the replay no longer matches the recorded "
+              "estimator decisions. Nothing below is worth reading.")
+        return 1
+
+    races = list(step0)
+    seen = {(d, s) for d, s, *_ in races}
+    for path in args.corpus:
+        p = path if os.path.exists(path) else os.path.join(_BENCH, path)
+        extra = load_races(p)
+        dups = [(d, s) for d, s, *_ in extra if (d, s) in seen]
+        kept = [(d, s, c, l) for d, s, c, l in extra if (d, s) not in seen]
+        seen.update((d, s) for d, s, *_ in kept)
+        races += kept
+        note = f", {len(dups)} duplicate (dataset, seed) skipped" if dups else ""
+        print(f"corpus {path}: +{len(kept)} races{note}")
+    print()
+
+    print(f"{len(races)} recorded const-vs-linear races "
+          f"({len(set(d for d, *_ in races))} datasets x seeds)\n")
+    if not races:
+        print("no races in the file -- nothing to replay")
+        return 1
+
+    truths = [truth(c, l) for _, _, c, l in races]
+    print(f"ground truth (full early stop): linear genuinely better on "
+          f"{sum(truths)} of {len(truths)}\n")
+
+    print(f"{'rule':22s} {'k':>5s} {'mispicks':>9s} {'median regret':>14s} "
+          f"{'worst regret':>13s}   worst dataset")
+    for k in args.k:
+        for name, rule in RULES:
+            wrong, regrets, worst = 0, [], ("", 0.0)
+            for (ds, seed, c, l), want in zip(races, truths):
+                ck, lk = c[:k], l[:k]
+                if ck.size == 0 or lk.size == 0:
+                    continue
+                got = rule(ck, lk)
+                r = regret(c, l, got)
+                regrets.append(r)
+                if got != want:
+                    wrong += 1
+                if r > worst[1]:
+                    worst = (f"{ds} s{seed}", r)
+            med = float(np.median(regrets)) if regrets else 0.0
+            print(f"{name:22s} {k:5d} {wrong:6d}/{len(regrets):<3d} "
+                  f"{med:13.3%} {worst[1]:12.3%}   {worst[0]}")
+        print()
+
+    print("Read the REGRET column, not the mispick count: a mispick between two")
+    print("arms that are within noise of each other costs nothing, and most of")
+    print("them are (PARETO_PLAN 'Known residual': the overlap is total).")
+    print(f"n is {len(races)} regression races on "
+          f"{len(set(d for d, *_ in races))} datasets -- a pointer, never a gate")
+    print("(GATE_ROBUSTNESS.md #2).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/profile_fit.py
+++ b/benchmarks/profile_fit.py
@@ -28,6 +28,9 @@ validation curve so a raced selector can be simulated offline.
 
 Writes benchmarks/results/<out>.json (full records incl. val curves) and
 benchmarks/results/<out>.md (the report tables), and prints the tables.
+Pass --uncapped-auditions when the output feeds probe_audition_rule.py: under
+the capped selection_rounds default the recorded curves stop at the cap, which
+makes the probe's replayed "full-curve truth" circular.
 
 Bagged attribution mode (BAGGING_PLAN.md Phase 0): fit the DEFAULT single
 estimator AND an n_ensembles=K bag on the same split, and attribute the bag's
@@ -461,9 +464,12 @@ def run_attribution(args):
                 X, y, test_size=0.25, random_state=seed, stratify=strat)
             Est = (ChimeraBoostRegressor if task == "regression"
                    else ChimeraBoostClassifier)
+            kw = {}
+            if args.uncapped_auditions:
+                kw["selection_rounds"] = None
             _ATTR["fits"] = []
             t0 = time.perf_counter()
-            m = Est(random_state=0).fit(Xtr, ytr, cat_features=cat)
+            m = Est(random_state=0, **kw).fit(Xtr, ytr, cat_features=cat)
             total = time.perf_counter() - t0
             fits, _ATTR["fits"] = _ATTR["fits"], None
             rec = {
@@ -632,6 +638,13 @@ def main():
     ap.add_argument("--datasets", nargs="*", default=None,
                     help="attribution mode: run_benchmarks DATASETS keys "
                          "(default: the frozen 9-set panel)")
+    ap.add_argument("--uncapped-auditions", action="store_true",
+                    help="attribution mode: fit with selection_rounds=None so "
+                         "every selection leg runs to its own early stop. "
+                         "REQUIRED when the output will feed "
+                         "probe_audition_rule.py -- under the capped default "
+                         "the recorded curves stop at the cap, which makes "
+                         "the replayed 'full-curve truth' circular.")
     ap.add_argument("--out", default="pareto-step0",
                     help="attribution mode: results/<out>.json|.md")
     args = ap.parse_args()

--- a/benchmarks/research/SUMMARY.md
+++ b/benchmarks/research/SUMMARY.md
@@ -44,20 +44,36 @@ on-permutations machinery operating together, not any single transplantable part
 make it +6% to +27% worse). Its ordered-TS encoding is already near-perfect (Brier
 ~0.024), so any added categorical structure just injects variance it overfits.
 That single dataset is the clearest evidence the defaults are at a good optimum.
-It went with the OpenML registry and the current T0 has no all-categorical
-near-solved set to play the same role; anyone reviving this line should expect to
-find the canary somewhere else before trusting a categorical win.
+It went with the OpenML registry when that was retired.
+
+**Replacement named 2026-08-10: `hc:cjs`.** Same role, and on the numbers a
+sharper version of it — categorical (`has_cats=True`, 34 features, 2097 training
+rows) and saturated past anything kr-vs-kp reached: ChimeraBoost solves it to
+Brier ~1e-51 at F1 1.0. Any categorical lever that "improves" it is chasing
+numerical noise, and any that hurts it is injecting variance into a set that was
+already solved. It is already a member of T0, so it costs nothing to watch.
+
+One limitation, stated so it is not discovered later: cjs is **multiclass**, and
+multiclass is locked out of some levers (cross features raise, linear leaves fall
+back to constant). It is a control for categorical levers, not a drop-in
+all-categorical binary set. Anyone reviving this line on a binary-only lever
+still owes a canary of their own.
 
 ## Engine notes
 - One fit = whole `validation_history_` curve; paired same-split deltas; shared
   baseline cache → each verdict reached in ~25–60s (T0) for ~0 marginal cost.
 - Post-fit ideas (G1) are invisible to the per-round curve → routed straight to
   the promotion tier (`post_fit=True`).
-- `cascade.py --selftest` FAILS as of 2026-08-02: its `linear_leaves` anchor
-  assumes that flag is off by default, and the regressor now auditions it and
-  picks it (bit-identical curves on `pol`). Library drift, not the tier swap —
-  `pol` was in the OpenML-era T0 too. Needs new anchors in `ideas.py`; details in
-  the `selftest` docstring.
+- `cascade.py --selftest` **PASSES again as of 2026-08-10**. It had failed since
+  2026-08-02 on library drift: the `linear_leaves` anchor assumed that flag was
+  off by default and the regressor had begun auditioning and picking it, and
+  `patience300` turned out not to be inert under `early_stopping=False` either.
+  Both anchors were replaced with drift-proof ones — `crossfeat_off` (removing a
+  shipped default; covertype degrades 5.38% at dominance 0.00) and `noop` (no
+  overrides at all; bit-identical on all 8 T0 datasets). The design rule behind
+  the swap is in the `selftest` docstring: an anchor whose premise is "this flag
+  is currently off" expires the moment a default moves, and a self-test that
+  expires silently is worse than none.
 
 ## Queue complete
 Every pre-registered lever has been run (C1, C3, C4, G1, G2, G3, G4) or deferred

--- a/benchmarks/research/cascade.py
+++ b/benchmarks/research/cascade.py
@@ -229,49 +229,59 @@ def cascade(idea_name, tiers, seed, threads, jobs):
 
 def selftest(seed, threads, jobs):
     """Reproduce two known truths on T0, proving the harness discriminates a real
-    win from a no-op:
+    effect from nothing:
 
-      * linear_leaves -- a clear POSITIVE where it is OFF by default. (NOTE: it is
-        already the auto-default for *binary* classification, so it is correctly
-        flat there; the off-by-default win shows on regression -- e.g. pol.) The
-        anchor: at least one dataset improves strongly (min best-val delta well
-        below 0) with high pointwise dominance.
-      * patience300 -- a NO-OP on the fast tier (early stopping is disabled, so
-        patience cannot move the curve): the trajectory is IDENTICAL to baseline.
+      * crossfeat_off -- removing a shipped default that is worth ~1.5% on
+        Grinsztajn. At least one dataset must get visibly WORSE.
+      * noop -- no overrides at all, so the variant IS the baseline. Every curve
+        must come back bit-identical.
 
-    BOTH ANCHORS ARE STALE AND THIS SELF-TEST FAILS TODAY (checked 2026-08-02).
-    The cause is library drift, not the tier: the regressor's linear_leaves=None
-    default now auditions constant-leaf against linear-leaf and keeps the winner,
-    and on pol it picks linear -- so linear_leaves=True is bit-identical to the
-    baseline curve, and the "off by default" premise is simply no longer true
-    anywhere the fast tier can see it (binary auto-enables it, multiclass raises
-    on an explicit True). pol was a member of the OpenML-era T0 too, so this
-    predates the 2026-08-02 tier swap. Separately, early_stopping_rounds is not
-    inert under early_stopping=False -- on hc:kick the patience300 curve reaches
-    0.3208 against the baseline's 0.3230.
+    Anchor history, because it matters for the next person choosing one. The
+    original pair (linear_leaves as a positive, patience300 as a no-op) went
+    stale and this self-test failed from 2026-08-02 to 2026-08-10, on library
+    drift rather than on anything wrong with the engine: the regressor's
+    linear_leaves=None default began auditioning constant against linear and
+    keeping the winner, so on pol the "off by default" premise stopped being
+    true; and early_stopping_rounds turned out not to be inert under
+    early_stopping=False (on hc:kick patience300 reached 0.3208 against the
+    baseline's 0.3230).
 
-    Fixing it means choosing anchors that are still genuinely off-by-default,
-    which is an edit to ideas.py, not here. The thresholds below are deliberately
-    left alone: relaxing them until they pass would destroy the only thing this
-    function is for.
+    The lesson is about anchor DESIGN. An anchor whose premise is "this flag is
+    currently off" expires the moment a default moves, and a self-test that
+    expires silently is worse than none. The pair above cannot expire: one
+    removes a shipped default -- going stale would require un-shipping cross
+    features -- and the other overrides nothing at all, which no library change
+    can invalidate.
+
+    The thresholds stay strict on purpose: relaxing them until they pass would
+    destroy the only thing this function is for.
     """
     print("=== ENGINE SELF-TEST (T0) ===", flush=True)
-    pos = run_fast_tier(ideas.get("linear_leaves")["params"], seed, threads, jobs)
-    print(report.fast_tier(pos, label="linear_leaves (expect a strong "
-                           "off-by-default win, e.g. regression pol)"),
+    sig = run_fast_tier(ideas.get("crossfeat_off")["params"], seed, threads, jobs)
+    print(report.fast_tier(sig, label="crossfeat_off (expect a clear "
+                           "DEGRADATION where cross pairs exist)"),
           flush=True)
-    flat = run_fast_tier(ideas.get("patience300")["params"], seed, threads, jobs)
-    print(report.fast_tier(flat, label="patience300 (expect FLAT / no-op)"),
+    flat = run_fast_tier(ideas.get("noop")["params"], seed, threads, jobs)
+    print(report.fast_tier(flat, label="noop (expect EXACT flatness)"),
           flush=True)
-    min_delta = min((r["best_val_delta_pct"] for r in pos["rows"]), default=0.0)
-    ok_pos = (pos["favorable"] >= 1 and min_delta < -0.01
-              and pos["mean_dominance"] > 0.5)
-    ok_flat = abs(flat["mean_best_delta_pct"]) < 1e-6
-    print(f"\nSELF-TEST: linear_leaves discriminates (min bestD "
-          f"{100*min_delta:+.2f}%, favorable={pos['favorable']})={ok_pos} | "
-          f"patience300 flat={ok_flat} | "
-          f"{'PASS' if ok_pos and ok_flat else 'FAIL'}", flush=True)
-    return ok_pos and ok_flat
+
+    # Signal: some dataset must move materially in the direction removing a
+    # shipped default should move it (worse = positive delta on a
+    # lower-is-better metric).
+    max_delta = max((r["best_val_delta_pct"] for r in sig["rows"]), default=0.0)
+    ok_sig = max_delta > 0.01
+
+    # Flatness: not "small on average" but exactly zero on every row. A mean
+    # near zero can hide two rows cancelling, which is precisely the reading
+    # this control exists to rule out.
+    deltas = [abs(r["best_val_delta_pct"]) for r in flat["rows"]]
+    ok_flat = bool(deltas) and max(deltas) < 1e-12
+
+    print(f"\nSELF-TEST: crossfeat_off discriminates (max bestD "
+          f"{100*max_delta:+.2f}%)={ok_sig} | "
+          f"noop bit-identical on {len(deltas)} datasets={ok_flat} | "
+          f"{'PASS' if ok_sig and ok_flat else 'FAIL'}", flush=True)
+    return ok_sig and ok_flat
 
 
 def main():

--- a/benchmarks/research/ideas.py
+++ b/benchmarks/research/ideas.py
@@ -11,33 +11,48 @@ here as the pre-registered agenda; each flips to implemented as its default-off
 flag lands (one change at a time).
 
 Two ideas with KNOWN outcomes are kept for the engine self-test:
-  * ``linear_leaves``  -- a known POSITIVE (binary-Brier win).
-  * ``patience300``    -- a known NEGATIVE/FLAT (rejected; defaults optimal).
-The harness must re-confirm both, proving it discriminates.
+  * ``crossfeat_off``  -- a known LARGE SIGNAL (removing a shipped default must
+    visibly hurt on the numeric sets where cross features apply).
+  * ``noop``           -- an exact no-op (no overrides at all), which must come
+    back bit-identical.
+The harness must re-confirm both, proving it discriminates a real effect from
+nothing.
+
+Both anchors are chosen to be **drift-proof**, because the previous pair was not
+(see cascade.selftest): ``linear_leaves`` stopped being off-by-default when the
+regressor began auditioning it, and ``patience300`` turned out not to be inert
+under ``early_stopping=False``. An anchor whose premise is "this flag is
+currently off" expires the moment a default moves. These two cannot: one removes
+a default that would have to be un-shipped for the anchor to go stale, and the
+other overrides nothing at all.
 """
 
 # direction: "lower_better" means the variant should DECREASE the primary
 # loss/metric (RMSE/Brier/val-loss) where the hypothesis says it helps.
 IDEAS = {
     # --- self-test anchors (known truths) ----------------------------------
-    "linear_leaves": dict(
-        params={"linear_leaves": True},
+    "crossfeat_off": dict(
+        params={"cross_features": False},
         category="selftest",
         implemented=True,
-        direction="lower_better",
-        hypothesis="Per-leaf ridge slopes lower validation logloss on binary "
-                   "classification (a known broad Brier win); neutral-to-helpful "
-                   "on regression. Self-test anchor: must re-confirm POSITIVE.",
+        direction="higher_worse",
+        hypothesis="Cross features ship on by default and are worth ~1.5% on "
+                   "Grinsztajn (51W/8L when added). Removing them must visibly "
+                   "HURT on the numeric sets where pairs exist, and be inert "
+                   "where they do not. Self-test anchor: must re-confirm a LARGE "
+                   "SIGNAL. Drift-proof: going stale would mean cross features "
+                   "had been un-shipped.",
     ),
-    "patience300": dict(
-        params={"early_stopping_rounds": 300},
+    "noop": dict(
+        params={},
         category="selftest",
         implemented=True,
-        direction="lower_better",
-        hypothesis="Patience only changes WHERE early stopping picks, not the "
-                   "validation trajectory; with early_stopping disabled on the "
-                   "fast tier the curve is IDENTICAL to baseline. Self-test "
-                   "anchor: must re-confirm FLAT/NEGATIVE (rejected).",
+        direction="none",
+        hypothesis="No overrides at all, so the variant IS the baseline. Every "
+                   "curve must come back bit-identical. Self-test anchor: must "
+                   "re-confirm EXACT FLATNESS -- this is the harness's own "
+                   "reproducibility control, and the one anchor no library "
+                   "change can invalidate.",
     ),
 
     # --- C: categorical levers (lead the queue) ----------------------------


### PR DESCRIPTION
Benchmarks, skills, and plan files only — no library code changes.

## Research-discipline ports (from the zeta-campaign transcript review)

- **`benchmarks/BARRIERS.md`** — 14 paid-for closures, one per idea family, each tagged with what was spent to learn it. **`benchmarks/barrier_check.py`** matches a proposed idea against them, to run before any tier-1 spend.
- **`benchmarks/compare_runs.py`** — inert-slice control line, engaged-only sign test, and `--expect-inert` (a structurally inert slice must read as exact ties; engagement there is a bug report). Pre-existing output verified byte-identical.
- **`/experiment` skill** — barrier check and a two-axis forecast (cost + strength, with "where I expect to be wrong") before the run; verdicts record confidence on both axes; kills recorded on both axes.
- **`GATE_ROBUSTNESS.md` §4**, **`PARETO_PLAN.md`** ("The dual re-read", D1–D4), **`SELECT_PLAN.md`** (E1 pre-registration).
- `benchmarks/research/` cascade self-test repaired.

## E1 step 1: the audition-curve corpus, widened 12 → 48 races — kill bar did not fire

`benchmarks/probe_audition_rule.py` replays const-vs-linear audition decision rules against recorded validation curves at zero benchmark cost, self-checking that it reproduces the estimator's recorded 4/12 mispicks at k=100 before reading anything else.

The corpus behind E1's finding was 12 races on 4 datasets with one race carrying the result. Step 1 widened it with `profile_fit.py --attribution` over 12 further regression dataset-variants, stress-weighted with the sel25 kill's worst losers. On 48 races, tail-mean at k=25 still fixes exactly the mispicks that killed sel25 and ties today's shipped rule at k=100 on mispicks (12 = 12); the residual mean-regret gap is one small dataset swinging both directions across seeds. The registered median bar passes but proved nearly vacuous (all medians 0.000%) — recorded in `SELECT_PLAN.md` so the next pre-registration picks a sharper statistic.

Two instrument traps found and fixed:

- An attribution run under the capped `selection_rounds` default records curves that stop at the cap, making the probe's "full-curve truth" circular. `profile_fit.py --attribution` now takes `--uncapped-auditions`.
- The rung-3 replay refit appends a booster-fit record reusing the winner's label with an empty validation curve; the probe's last-wins label dict silently dropped 15 of 36 races. The loader now keeps the first fit per label. Step-0 output verified unchanged after every edit; the 4/12 self-check held throughout.

Next step for E1 (not in this PR): implement the tail-mean-at-k=25 knob in `sklearn_api.py` on its own branch under the /experiment protocol, then tier-1 synth (`--expect-inert`) and tier-2 decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
