### PR TITLE
E2 pre-registered: rung-1 cross features without the race (step 0)

### DIFF
--- a/benchmarks/SELECT_PLAN.md
+++ b/benchmarks/SELECT_PLAN.md
@@ -652,6 +652,47 @@ step 1 measures the headroom itself before anything is built to chase it.
 3. Tier-2 `--decide --seeds 3 --save` per stratum, plus a within-run ladder
    field (rung-1X, OneLin, NoRefit, default, LightGBM) for the bars.
 
+### Step 1 result (2026-08-10): PASS on the pre-authorized narrow retry
+
+`probe_cross_pairs.py`, 12 sets x 3 seeds = 36 fits, resumable JSONLs in
+`results/probe-cross-pairs-e2*.jsonl` (git-ignored). At the production block
+width (`CROSS_TOP_M=6`): headroom PASS (oracle median +2.200%), fidelity PASS
+(paired probe-minus-oracle median +0.000%), **cost FAIL** (median aug/plain
+ratio 1.74 vs the 1.5 bar). The registered retry — the forced block narrowed
+to the top-4 numerics, no new mechanism — re-run on the same panel:
+
+| bar | statistic | m=6 | m=4 | verdict at m=4 |
+|---|---|--:|--:|---|
+| 1 headroom | oracle median over plain, 36 fits | +2.200% | +2.577% | PASS (bar +0.3%) |
+| 2 fidelity | paired probe-minus-oracle median | +0.000% | +0.000% | PASS |
+| 3 cost | median aug/plain fit ratio, probe incl. | 1.74 | **1.39** | PASS (bar 1.5) |
+
+- Narrowing the block six-to-four **cost nothing on strength** — the oracle
+  median went up, because the dropped columns were mostly noise the split
+  search paid to ignore. The forced mode therefore ships with its own
+  narrower numeric block (top-4); the racing default keeps `CROSS_TOP_M=6`
+  untouched.
+- The 25-round probe's share of arm time is 2-17% (median ~5%) — B12 priced.
+- **Fidelity caveat, recorded**: where the probe's pair set diverges from the
+  oracle's (Jaccard <= 0.35, concentrated on `gr:reg_cat` sets with many
+  gdiff candidates), the probe arm gives back 2-3 points of the oracle's
+  gain (`reg_cat/nyc`: +1.69% vs +4.12%). Not a bar fail — the paired median
+  is exactly zero — but the gdiff ranking is the weak joint if tier 2 reads
+  soft on reg_cat.
+- **The dodged-losses worry is live**: `analcatdata_supreme` s0 reads −9.4%
+  forced (the race would have refereed it away), `cpu_act` s2 −11.8%. Single
+  seeds on a dev panel; the per-fit variance is wild (`cpu_act` spans −11.8%
+  to +24.2% across seeds). The decide tier's sign tests own this.
+- Mean cost (1.92) sits far from the median (1.39): three seeds where cross
+  keeps improving so ES runs long (Brazilian s2 10.5x, sulfur s2 7.8x) — the
+  same fits with the biggest strength gains (+17.9%, +20.9%). Per
+  GATE_ROBUSTNESS #3 the registered median carries the bar; the tail is
+  real wall-clock and the within-run A' bar will price it honestly.
+
+**Consequence: E2 proceeds to step 2** — implement `cross_features="always"`
+(regressor; forced block top-4, probe 25 rounds, all applicability gates
+kept), tier-1 synth screen with `--expect-inert`.
+
 ### Bars
 
 - **A'** (cost): rung-1X mean fit-time multiple <=3.0x within-run AND <=0.65x
@@ -724,3 +765,12 @@ the same change.
   run. Forecast registered on both axes. Nothing has run; step 1 is a
   zero-library-change dev-panel probe with three kill bars (headroom first —
   the E1 magnitude lesson applied prospectively).
+- 2026-08-10 (E2, later): **step 1 PASS on the pre-authorized retry.**
+  Headroom is real and large (+2.6% median over plain rung 1 on a
+  stress-weighted panel), the 25-round probe picks near-oracle pairs at 2-17%
+  of arm time, and the cost bar passes only at the narrowed top-4 block
+  (1.39 vs 1.74 at top-6 — the narrowing was free on strength). New
+  instrument: `probe_cross_pairs.py` (`--top-m N` for the block width).
+  Recorded caveats: gdiff pair ranking is the fidelity weak joint on
+  `reg_cat`; forced mode eats occasional large per-seed losses the race used
+  to referee away. Next: step 2, the knob.

--- a/benchmarks/SELECT_PLAN.md
+++ b/benchmarks/SELECT_PLAN.md
@@ -375,9 +375,9 @@ one `--models` flag.
 ## Still open
 
 - **A "use cross features without auditioning" mode.** Rung 1 currently
-  drops cross features entirely because `cross_features=True` still races
-  (`sklearn_api.py:1443`). A forced-on mode could give a stronger rung 1
-  at the same one-fit cost. Untested.
+  drops cross features entirely because `cross_features=True` still races.
+  A forced-on mode could give a stronger rung 1 near one-fit cost.
+  **Pre-registered 2026-08-10 as E2 below.**
 
 ## E1 — pre-registered 2026-08-10: the rule, not the budget
 
@@ -569,6 +569,111 @@ default arm:
   the tail rule is harmful on real data — low; it is merely useless here, and
   at k=100 step 1 already showed it is worse than shipped.
 
+## E2 — pre-registered 2026-08-10: rung-1 cross features without the race
+
+### The idea
+
+A `cross_features="always"` mode: include the cross-feature block without the
+validation race, so rung 1 (`quality=1`) can have cross features near one-fit
+cost. Today `quality=1` pins `cross_features=False` because `True` still races
+(`sklearn_api.py:1950-2027`), and rung 1's Phase-0 weakness is strength (52.0%
+@ 1.98x; high-card 1W-6L vs the default). The race's verdict is nearly
+constant — the augmented candidate wins 20 of 21 selections (`PARETO_PLAN.md`
+D1) and the racing A/B read 51W-8L, mean +1.5% on Grinsztajn — so at rung 1
+the race is mostly a fee for a known answer.
+
+Design: pairs need base-fit importances (`_cross_candidate_pairs`,
+`sklearn_api.py:1276`). The mode runs a short importance probe (~25 rounds,
+plain matrix) solely to rank features, then ONE full fit on the augmented
+matrix. No decision is taken on any validation curve. The applicability gates
+(`CROSS_MIN_SAMPLES=2000`, RMSE-only, >=2 numerics or 1 numeric + 1 cat) stay.
+
+### Barrier arguments (barrier_check matched B1, B2, B12, B14)
+
+- **B1** — not contested. The mode keeps the 2000-row floor, so small-data
+  strata are structural controls; every screen runs `--expect-inert`.
+- **B2** — the amplification needs a mispick to propagate, and this path makes
+  no pick. `quality=1` pins `refit_full=False` besides. The default path is
+  untouched — byte-identical, goldens must stay green.
+- **B12** — the mode REMOVES a race and adds a ~25-round plain-matrix probe.
+  Priced against the short-fit case: cross is RMSE-only, so the ~100-round
+  multiclass fits are out of scope by construction; step 1 reports the probe's
+  share of total fit time and the cost bar owns it.
+- **B14** — does not apply, and the 25-round probe is not a k=25 audition: no
+  validation-curve decision is made at any budget. The only truncated quantity
+  is the importance RANKING feeding pair choice, whose failure mode is a
+  slightly different pair set (an irrelevant cross costs fit time — the split
+  search ignores it — not a model-class mispick), and whose fidelity step 1
+  measures directly. If anything B14 argues FOR the design: the Sel25/E1 harm
+  lived in truncated race decisions, and this mode removes the decision.
+
+### Forecast (both axes, before any run)
+
+- **Cost** — honest wide uncertainty: the real cost is not the race, it is the
+  augmented matrix (up to 30 pair + 12 gdiff columns on often-narrow
+  Grinsztajn sets). Predicted rung-1X at 2.5-4.0x within-run vs OneLin's
+  ~2.0x; the probe adds only 5-10%. Step 1 times the augmented/plain fit
+  ratio directly before any knob is written.
+- **Strength** (the bet): vs plain rung 1 on the engaged slice (Grinsztajn
+  regression, >=2000 rows), decisive sign test, engaged median +0.3 to +1.0%.
+  Prior: the racing A/B's +1.5% mean is the ceiling; forced-on keeps most of
+  it since the race picks the augmented fit 20 of 21 times, but eats the
+  losses selection used to dodge. Classification and sub-2000-row slices:
+  exact ties.
+- **Where I expect to be wrong**: the referee's dodged losses may be
+  individually large (Brazilian_houses-class), dragging the engaged median
+  toward zero, especially on HC; and the matrix widening may price the mode
+  out of the fast niche entirely, killing the Pareto case at positive
+  strength.
+
+Statistic note (E1's lesson, twice over): every strength bar reads the
+ENGAGED-only sign test and engaged median — an all-rows median over a
+mostly-tie distribution passes vacuously. And the magnitude check comes first:
+step 1 measures the headroom itself before anything is built to chase it.
+
+### Steps, in order
+
+1. **Zero-library-change dev-panel probe** (`probe_cross_pairs.py`, ~12
+   engaged Grinsztajn regression sets x 3 seeds, inner `GradientBoosting`
+   with `cross_pairs` passed directly): fit (i) rung-1 plain, (ii) rung-1 +
+   cross with pairs from a 25-round probe's importances, (iii) rung-1 + cross
+   with pairs from a full fit's importances (the oracle). Kill bars, in
+   order: **headroom** — if (iii) does not clear +0.3% median over (i) on
+   >=30 fits, the effect being chased is too small, stop before writing any
+   knob; **fidelity** — (ii) must hold the oracle's headroom within noise;
+   **cost** — if the median augmented/plain fit-time ratio exceeds 1.5, the
+   fast niche is unreachable (predicted within-run ~= ratio x 2.0x + probe),
+   stop. One retry is pre-authorized on a cost kill only: a narrower forced
+   block (`CROSS_TOP_M=4`), re-priced on the same panel, no new mechanism.
+2. Implement `cross_features="always"` (/experiment branch); tier-1 synth
+   screen with `--expect-inert`; `synth_report` must concentrate the gain in
+   the interaction-depth>=2 numeric slices — the validated cross signature
+   (8/9 backtest). Kill if the mechanism story does not show up.
+3. Tier-2 `--decide --seeds 3 --save` per stratum, plus a within-run ladder
+   field (rung-1X, OneLin, NoRefit, default, LightGBM) for the bars.
+
+### Bars
+
+- **A'** (cost): rung-1X mean fit-time multiple <=3.0x within-run AND <=0.65x
+  of the same-run rung-2 (NoRefit) arm — it must sit clearly between rungs 1
+  and 2 or it is rung 2 minus the referee, which is pointless.
+- **B'** (frontier): strictly above the LightGBM-to-default chord at its own
+  slowdown, all quantities from the same run.
+- **C'** (strength): beats plain rung 1 on the engaged sign test with positive
+  engaged median, AND still beats LightGBM on the primary sign test. HC is
+  sign-tested separately; an HC regression is a documented caveat (rung 1 is
+  numeric-heavy territory) unless decisive.
+
+### Ship target and kill clause
+
+Two-tier ship, decided by A': at <=3.0x, the knob ships AND `quality=1`
+(regressor) pins `cross_features="always"` — a released-preset change, hence
+this full gate. At 3.0-4.0x with B'/C' passing, knob-only, documented in
+`docs/recipes.md`, `quality=1` unchanged. Kill = B' or C' fails, or step 1
+kills: the mode does not ship, the rung-1 open item closes as "cross features
+need the referee", and if the reason generalises it goes to `BARRIERS.md` in
+the same change.
+
 ## Log
 
 - 2026-07-25: pre-registered.
@@ -614,3 +719,8 @@ default arm:
   from both ends; B14 updated; knob branch deleted unmerged. Tier 2 never run
   — spending it would have re-bought the Sel25 kill. Runs:
   `results/20260810-150735.json`, `results/20260810-151216.json`.
+- 2026-08-10 (E2): the rung-1 forced-cross open item pre-registered as **E2**
+  above. `barrier_check` matched B1/B2/B12/B14; arguments recorded before any
+  run. Forecast registered on both axes. Nothing has run; step 1 is a
+  zero-library-change dev-panel probe with three kill bars (headroom first —
+  the E1 magnitude lesson applied prospectively).

--- a/benchmarks/SELECT_PLAN.md
+++ b/benchmarks/SELECT_PLAN.md
@@ -374,10 +374,9 @@ one `--models` flag.
 
 ## Still open
 
-- **A "use cross features without auditioning" mode.** Rung 1 currently
-  drops cross features entirely because `cross_features=True` still races.
-  A forced-on mode could give a stronger rung 1 near one-fit cost.
-  **Pre-registered 2026-08-10 as E2 below.**
+Nothing. The last item — a "use cross features without auditioning" mode —
+was pre-registered 2026-08-10 as E2 below and **SHIPPED 2026-08-16** (PR #91):
+`cross_features="always"` on the regressor, and `quality=1` pins it.
 
 ## E1 — pre-registered 2026-08-10: the rule, not the budget
 
@@ -744,6 +743,40 @@ kills: the mode does not ship, the rung-1 open item closes as "cross features
 need the referee", and if the reason generalises it goes to `BARRIERS.md` in
 the same change.
 
+### Step 3 result (2026-08-16): tier-2 PASS on all three bars — SHIPPED
+
+Decide run `results/20260815-235543.json` — Grinsztajn + high-card +
+variants, 3 seeds, five arms in ONE run (default / OneLin / OneLinX /
+NoRefit / LightGBM), all bar quantities within-run. Suite green before the
+run (940 passed, 1 pre-existing skip).
+
+| bar | requirement | measured | verdict |
+|---|---|---|---|
+| A' cost | <=3.0x within-run AND <=0.65x of rung 2 | 2.7x; 2.7/4.7 = 0.57x | PASS |
+| B' frontier | strictly above the LightGBM→default chord | 49.5% vs 41.7% needed at 2.7x (+7.9 pts) | PASS |
+| C' strength | engaged sign test vs OneLin + beats LightGBM | gr engaged 28W-8L, engaged median +0.60% (n=34 excl. near-solved); LightGBM 43W-16L, median +0.41% | PASS |
+
+- A' hit the <=3.0x tier, so the FULL ship applies: knob + `quality=1`
+  (regressor) pins `cross_features="always"`. PR #91.
+- The forecast band held: engaged median +0.60% vs registered +0.3 to +1.0%.
+  Cost 2.7x vs predicted 2.5-4.0x, at the good end — the top-4 narrowing
+  from step 1's retry is what bought it.
+- Engaged-only reads positive on every stratum that engaged (gr 28W-8L,
+  hc 3W-1L, gr@sus25 3W-1L, gr@sus50 3W-1L, hc@sus50 1W-0L, hc@time 1W-0L);
+  inert slices are exact ties throughout (`--expect-inert` clean). Small
+  strata read as pointers, not gates (GATE_ROBUSTNESS #2).
+- **Pre-registered caveat confirmed, on record**: HC vs LightGBM is 7W-6L —
+  a coin flip, not a regression; rung 1 is numeric-heavy territory. And the
+  dodged-losses worry materialised at tolerable size: worst engaged loss
+  −6.0% (`gr:reg_num/cpu_act`), `analcatdata_supreme` −3.5% — the race used
+  to referee these away; the sign tests absorbed them.
+- Default-is-best-non-ensembling-rung re-check (standing rule): unchanged —
+  the default reads 91.5% @ 6.1x in this field vs rung-1X's 49.5% @ 2.7x;
+  rung 3 stays the default.
+- Post-merge: delete the code branch, refresh `images/pareto.png` +
+  `public_pareto.png` on the next canonical run (`docs/PROJECT_STATUS.md`
+  carries a dated note until then).
+
 ## Log
 
 - 2026-07-25: pre-registered.
@@ -810,3 +843,9 @@ the same change.
   at depth 2–4; additive sets tie). Run `results/20260810-161742.json`,
   knob on `e2/forced-cross-features`. Next: tier-2 decide with the ladder
   field.
+- 2026-08-16 (E2): **tier-2 PASS on all three bars — SHIPPED** (step 3
+  above). A' 2.7x / 0.57x-of-rung-2, B' +7.9 points over the chord, C'
+  28W-8L engaged at median +0.60% plus LightGBM 43W-16L. The <=3.0x tier
+  applies: PR #91 ships the knob AND flips `quality=1` (regressor) to
+  `cross_features="always"`. HC-vs-LightGBM coin flip (7W-6L) recorded as
+  the pre-registered caveat. **E2 closed; no SELECT items remain open.**

--- a/benchmarks/SELECT_PLAN.md
+++ b/benchmarks/SELECT_PLAN.md
@@ -693,6 +693,35 @@ to the top-4 numerics, no new mechanism — re-run on the same panel:
 (regressor; forced block top-4, probe 25 rounds, all applicability gates
 kept), tier-1 synth screen with `--expect-inert`.
 
+### Step 2 result (run 2026-08-10, verdict recorded 2026-08-15): tier-1 PASS
+
+Knob implemented on `e2/forced-cross-features`: regressor-only
+`cross_features="always"` — 25-round importance probe, forced top-4 block,
+all applicability gates kept; the classifier rejects the value with a clear
+error; the raced default path is untouched (goldens green). Tier-1 screen:
+ONE run, three arms (`results/20260810-161742.json`); the default
+`ChimeraBoost` arm reproduces the E1 baselines exactly, validating pairing.
+
+- `--expect-inert`: 116/136 exact ties. Every structural control is clean —
+  classification 0W-0L-88T, `n<2000` 0-0-48, canary&cats 0-0-3, saturated
+  0-0-17. The gates hold exactly where they must.
+- Engaged (20 datasets): **11W-9L, bar 11+ PASS**; engaged mean +2.29%,
+  engaged median +0.44%. Worst engaged loss −2.93% (`syn:v2/553`); no slice
+  sign-tests negative.
+- **Mechanism (the registered kill bar): PASS.** The printed `depth<=2`
+  slice mixes depth-1 with depth-2, so the bar was read from a per-dataset
+  join of engaged deltas against generator metadata: 19/20 engaged sets are
+  `interaction_depth>=2`; every gain above +3% sits at depth 2–4 (+14.6%,
+  +11.7%, +9.5% at the top); additive (depth-1) sets are near-universally
+  exact ties — the design claim that an irrelevant cross block costs fit
+  time, not accuracy, holds. One depth-1 engager won +3.1% (n=1, noted).
+- The 11W-9L margin is a screen read, not a strength verdict — p=0.82. The
+  decide tier owns strength, per the bars below.
+
+**Consequence: E2 proceeds to step 3** — tier-2 `--decide --seeds 3 --save`
+with the within-run ladder field (rung-1X, OneLin, NoRefit, default,
+LightGBM), judged on A'/B'/C'.
+
 ### Bars
 
 - **A'** (cost): rung-1X mean fit-time multiple <=3.0x within-run AND <=0.65x
@@ -774,3 +803,10 @@ the same change.
   Recorded caveats: gdiff pair ranking is the fidelity weak joint on
   `reg_cat`; forced mode eats occasional large per-seed losses the race used
   to referee away. Next: step 2, the knob.
+- 2026-08-15 (E2): **tier-1 synth PASS** (run 2026-08-10; the session died
+  before the verdict was recorded). Engaged 11W-9L (bar 11+), inert controls
+  exact-tie clean, and the registered mechanism bar holds: the gain
+  concentrates on `interaction_depth>=2` (19/20 engaged sets; every big win
+  at depth 2–4; additive sets tie). Run `results/20260810-161742.json`,
+  knob on `e2/forced-cross-features`. Next: tier-2 decide with the ladder
+  field.

--- a/benchmarks/probe_cross_pairs.py
+++ b/benchmarks/probe_cross_pairs.py
@@ -1,0 +1,199 @@
+"""E2 step 1 probe (SELECT_PLAN.md, E2): can rung 1 take cross features
+without the race?
+
+Three arms per (dataset, seed), all the inner GradientBoosting at a
+rung-1-equivalent config (RMSE, linear_leaves=True, n_estimators=2000,
+ES 50 on a 0.2 validation split, auto lr, depth 6 -- quality=1 minus the
+sklearn wrapper, which cannot force cross pairs):
+
+  plain  : cross_pairs=[]                                       (rung 1 today)
+  probe  : cross_pairs from a 25-round probe fit's importances  (the E2 design)
+  oracle : cross_pairs from the plain FULL fit's importances    (the ceiling)
+
+Pair choice is the production `_cross_candidate_pairs` in both cross arms, so
+diff/prod/gdiff and the top-M rules are exactly what would ship.
+
+Kill bars (registered in SELECT_PLAN.md E2 BEFORE this ran), in order:
+  1 headroom : oracle-over-plain test-RMSE gain >= +0.3% median on >= 30 fits
+  2 fidelity : probe holds the oracle's headroom within noise (paired deltas)
+  3 cost     : median augmented/plain fit-time ratio <= 1.5
+
+Also reported: the 25-round probe's share of the arm's time (B12) and the
+probe/oracle pair-set overlap. Results:
+benchmarks/results/probe-cross-pairs-e2.jsonl (resumable, delete to rerun);
+aggregate table printed at the end.
+"""
+
+import json
+import os
+import sys
+import time
+
+import numpy as np
+from sklearn.model_selection import ShuffleSplit, train_test_split
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from research import datasets as rdata  # noqa: E402
+
+from chimeraboost.booster import GradientBoosting  # noqa: E402
+from chimeraboost.sklearn_api import _cross_candidate_pairs  # noqa: E402
+
+TOP_M = None                      # --top-m N: the pre-authorized cost retry
+if "--top-m" in sys.argv:         # (SELECT_PLAN.md E2 step 1) narrows the
+    TOP_M = int(sys.argv[sys.argv.index("--top-m") + 1])   # numeric block
+    import chimeraboost.sklearn_api as _ska
+    _ska.CROSS_TOP_M = TOP_M
+
+RESULTS = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "results",
+    "probe-cross-pairs-e2" + (f"-m{TOP_M}" if TOP_M else "") + ".jsonl")
+SEEDS = (0, 1, 2)
+PROBE_ROUNDS = 25
+
+# 7 sets where the racing A/B improved (cross should help), 4 controls it left
+# flat, plus E1's swing dataset. All >= 2000 train rows, so every fit engages.
+PANEL = [
+    ("gr:reg_num/nyc-taxi-green-dec-2016", "gap"),
+    ("gr:reg_cat/nyc-taxi-green-dec-2016", "gap"),
+    ("gr:reg_num/Brazilian_houses", "gap"),
+    ("gr:reg_cat/Brazilian_houses", "gap"),
+    ("gr:reg_num/cpu_act", "gap"),
+    ("gr:reg_num/sulfur", "gap"),
+    ("gr:reg_num/pol", "gap"),
+    ("gr:reg_num/elevators", "control"),
+    ("gr:reg_num/houses", "control"),
+    ("gr:reg_num/wine_quality", "control"),
+    ("gr:reg_num/abalone", "control"),
+    ("gr:reg_cat/analcatdata_supreme", "swing"),
+]
+
+CFG = dict(loss="RMSE", n_estimators=2000, early_stopping_rounds=50,
+           depth=6, linear_leaves=True, random_state=0)
+
+
+def _fit(Xf, yf, ev, cat, pairs, n_estimators=None, es=True):
+    kw = dict(CFG, cross_pairs=pairs or None)
+    if n_estimators is not None:
+        kw["n_estimators"] = n_estimators
+    if not es:
+        kw["early_stopping_rounds"] = None
+    m = GradientBoosting(**kw)
+    t = time.time()
+    m.fit(Xf, yf, cat_features=cat, eval_set=ev)
+    return m, time.time() - t
+
+
+def _rmse(m, Xte, yte):
+    return float(np.sqrt(np.mean((yte - m.predict_raw(Xte)) ** 2)))
+
+
+def _done_keys():
+    done = set()
+    if os.path.exists(RESULTS):
+        with open(RESULTS) as f:
+            for line in f:
+                r = json.loads(line)
+                done.add((r["dataset"], r["seed"]))
+    return done
+
+
+def main():
+    done = _done_keys()
+    for key, group in PANEL:
+        X, y, cat, task = rdata.load(key)
+        cat = list(cat or [])
+        assert task == "regression", key
+        for seed in SEEDS:
+            if (key, seed) in done:
+                continue
+            Xtr, Xte, ytr, yte = train_test_split(
+                X, y, test_size=0.25, random_state=seed)
+            # The estimator's auto ES split: 0.2 held out of the train rows.
+            tr_idx, va_idx = next(ShuffleSplit(
+                n_splits=1, test_size=0.2, random_state=seed).split(Xtr))
+            Xf, yf = Xtr[tr_idx], ytr[tr_idx]
+            ev = (Xtr[va_idx], ytr[va_idx])
+
+            plain, plain_s = _fit(Xf, yf, ev, cat, None)
+            base = _rmse(plain, Xte, yte)
+
+            pfit, probe_s = _fit(Xf, yf, ev, cat, None,
+                                 n_estimators=PROBE_ROUNDS, es=False)
+            p_pairs = _cross_candidate_pairs(
+                np.asarray(pfit.feature_importances_, dtype=float),
+                cat, X.shape[1])
+            o_pairs = _cross_candidate_pairs(
+                np.asarray(plain.feature_importances_, dtype=float),
+                cat, X.shape[1])
+
+            probe_m, probe_fit_s = _fit(Xf, yf, ev, cat, p_pairs)
+            oracle_m, oracle_fit_s = _fit(Xf, yf, ev, cat, o_pairs)
+
+            inter = len(set(p_pairs) & set(o_pairs))
+            union = len(set(p_pairs) | set(o_pairs))
+            row = {"dataset": key, "seed": seed, "group": group,
+                   "n_train": int(len(yf)), "n_pairs": len(o_pairs),
+                   "pair_jaccard": round(inter / union, 3) if union else 1.0,
+                   "base": base,
+                   "probe": _rmse(probe_m, Xte, yte),
+                   "oracle": _rmse(oracle_m, Xte, yte),
+                   "plain_s": round(plain_s, 2),
+                   "probe_fit_s": round(probe_fit_s, 2),
+                   "oracle_fit_s": round(oracle_fit_s, 2),
+                   "probe_s": round(probe_s, 2)}
+            os.makedirs(os.path.dirname(RESULTS), exist_ok=True)
+            with open(RESULTS, "a") as f:
+                f.write(json.dumps(row) + "\n")
+            print(f"{key} s{seed}: base={base:.5g} "
+                  f"probe={100 * (base - row['probe']) / base:+.2f}% "
+                  f"oracle={100 * (base - row['oracle']) / base:+.2f}% "
+                  f"jac={row['pair_jaccard']:.2f} "
+                  f"fitx={(row['probe_fit_s'] + row['probe_s']) / max(plain_s, 1e-9):.2f}",
+                  flush=True)
+    table()
+
+
+def table():
+    rows = []
+    with open(RESULTS) as f:
+        for line in f:
+            rows.append(json.loads(line))
+    by_ds = {}
+    for r in rows:
+        by_ds.setdefault(r["dataset"], []).append(r)
+
+    print(f"\n{'dataset':40} {'grp':8} {'probe%':>8} {'oracle%':>8} "
+          f"{'jac':>5} {'fitx':>5} {'probeshare':>10}")
+    for ds, rs in sorted(by_ds.items()):
+        p = np.mean([100 * (r["base"] - r["probe"]) / r["base"] for r in rs])
+        o = np.mean([100 * (r["base"] - r["oracle"]) / r["base"] for r in rs])
+        j = np.mean([r["pair_jaccard"] for r in rs])
+        fx = np.mean([(r["probe_fit_s"] + r["probe_s"]) / max(r["plain_s"], 1e-9)
+                      for r in rs])
+        sh = np.mean([r["probe_s"] / max(r["probe_fit_s"] + r["probe_s"], 1e-9)
+                      for r in rs])
+        print(f"{ds:40} {rs[0]['group']:8} {p:+8.2f} {o:+8.2f} {j:5.2f} "
+              f"{fx:5.2f} {sh:10.2f}")
+
+    o_all = [100 * (r["base"] - r["oracle"]) / r["base"] for r in rows]
+    p_all = [100 * (r["base"] - r["probe"]) / r["base"] for r in rows]
+    fid = [p - o for p, o in zip(p_all, o_all)]
+    fx_all = [(r["probe_fit_s"] + r["probe_s"]) / max(r["plain_s"], 1e-9)
+              for r in rows]
+    print(f"\nn fits              : {len(rows)} (bar needs >= 30)")
+    print(f"BAR 1 headroom      : oracle median {np.median(o_all):+.3f}% "
+          f"(mean {np.mean(o_all):+.3f}%)  [bar: >= +0.3%]")
+    print(f"BAR 2 fidelity      : probe median {np.median(p_all):+.3f}% "
+          f"(mean {np.mean(p_all):+.3f}%); paired probe-minus-oracle median "
+          f"{np.median(fid):+.3f}%")
+    print(f"BAR 3 cost          : median aug/plain fit ratio "
+          f"{np.median(fx_all):.2f} (mean {np.mean(fx_all):.2f})  [bar: <= 1.5]")
+    print("(positive = cross arm better than plain rung 1; test RMSE; fitx "
+          "includes the 25-round probe)")
+
+
+if __name__ == "__main__":
+    if "--table-only" in sys.argv:
+        table()
+    else:
+        main()


### PR DESCRIPTION
Records only, no library change. Step 0 of the /experiment protocol for the last open SELECT item: a \`cross_features="always"\` mode so rung 1 can have cross features near one-fit cost.

- \`barrier_check\` matched B1, B2, B12, B14 — an argument for each is written in the plan file before any run. The load-bearing one: B14's harm lived in truncated *race decisions*, and this mode makes no decision on any validation curve; the only truncated quantity is an importance ranking, whose fidelity step 1 measures directly.
- Forecast registered on both axes, with cost honestly wide (the real cost is the augmented matrix, not the race).
- Step 1 is a zero-library-change dev-panel probe with three kill bars in order: headroom (+0.3% median oracle bar — the E1 magnitude lesson applied *before* building anything), fidelity, cost (augmented/plain fit ratio ≤1.5).

Nothing has run yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)