### PR TITLE
Complexity ratchet stage 0: tooling, gate coverage, baseline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    # The complexity ratchet (C901 at max-complexity 10, see
+    # benchmarks/REFACTOR_AUDIT.md) plus stale-noqa detection (RUF100). Version
+    # pinned to match the dev extra -- McCabe counts and default rules shift
+    # across ruff releases.
+    name: ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ruff==0.16.5
+      - run: ruff check chimeraboost/
+
   test:
     name: py${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ rather than a clear one. Rules:
 - Watch CHANGELOG section headers in merge conflicts — a merge once clobbered a version header.
 
 ## Layout
-- `chimeraboost/` library · `tests/` (395+, incl. numerical-identity goldens — bit-identical refactors must keep them green)
+- `chimeraboost/` library · `tests/` (530+ test functions, incl. numerical-identity goldens — bit-identical refactors must keep them green)
 - `benchmarks/` harness + analysis scripts · `benchmarks/tabarena/` sealed-holdout runners · `benchmarks/research/` cascade engine
 - `images/` committed charts (public_pareto.png is the README/docs headline, from
   `make_public_pareto.py`; pareto.png is the internal north-star chart — refresh both after shipping)

--- a/benchmarks/REFACTOR_AUDIT.md
+++ b/benchmarks/REFACTOR_AUDIT.md
@@ -1,0 +1,87 @@
+# Complexity audit & refactor program
+
+Status: stage 0 of 8 (tooling + gate coverage). Started 2026-08-30.
+
+Goal: every non-frozen function at or below ruff C901 complexity 10, enforced
+permanently, with **zero behavior change** — each refactor stage is
+bit-identical, gated by `benchmarks/identity_snapshot.py` (exact
+`np.array_equal` over ~30 configs) plus the full test suite, never by
+benchmarks.
+
+## The ratchet
+
+- `pyproject.toml`: `select = ["E4", "E7", "E9", "F", "C901", "RUF100"]`,
+  `max-complexity = 10`. The rule set is pinned explicitly (not
+  `extend-select`) and ruff is pinned to `0.16.5` (dev extra + CI), because
+  both default rules and McCabe counts shift across ruff releases and would
+  silently move the ratchet.
+- Baseline: 20 C901 violations at threshold 10, each carrying a `# noqa: C901`
+  marker — temporary ones name the stage that removes them; permanent ones say
+  "frozen" and point here. RUF100 fails the build if a noqa outlives its
+  violation.
+- CI: the `lint` job in `.github/workflows/tests.yml`.
+- Units: this program's planning audit used a stdlib-AST McCabe counter that
+  also counts boolean operands, asserts, ternaries and comprehension clauses —
+  it reads roughly 2× ruff's C901 (e.g. the regressor `_fit_single`: 77 by
+  audit count, 36 by ruff). All ratchet numbers are ruff units.
+- Radon was considered and skipped: different units from the enforcement tool,
+  an extra dependency, no gate integration.
+
+## Refactor stages (one PR each, merged before the next starts)
+
+| Stage | Target | Ruff CC | State |
+|---|---|---|---|
+| 0 | tooling, snapshot coverage, guards | — | this PR |
+| 1 | `sklearn_api._validate_hyperparams` | 25 | pending |
+| 2 | `sklearn_api._validate_fit_input` | 34 | pending |
+| 3 | `quantile_api.fit`, `sklearn_api._fit_bagged` | 16, 12 | pending |
+| 4 | the three `booster._fit_impl` loops | 16/14/16 | pending |
+| 5 | classifier `_fit_single` | 31 | pending |
+| 6 | regressor `_fit_single` | 36 | pending |
+| 7 | `tree.build_oblivious_tree` + closeout | 13 | pending |
+
+Rules for every stage: move code, never rewrite expressions; helpers receive
+rng objects and consume draws in original order; `stacklevel` +1 per frame a
+`warnings.warn` moves down; error messages byte-identical, first-fire order
+unchanged; shared-object identity preserved (`prep_cache`). The verification
+sequence per stage is in the plan file and boils down to: clear the numba
+cache, `identity_snapshot.py check` (trust
+`benchmarks/results/identity_check.txt`), full pytest, ruff, and for stages 4
+and 7 the strict-timing golden run plus `profile_fit.py` before/after.
+
+## Frozen — permanent noqa, never refactored
+
+Numba kernels get no readability payoff from decomposition: njit inlining
+changes codegen, `cache=True` invalidation churns every machine, and
+`parallel=True` semantics are sensitive to function boundaries. Every one is
+already pinned by oracle tests, which provide the safety that CC reduction
+buys elsewhere.
+
+| Function (ruff CC) | Why frozen |
+|---|---|
+| `tree._build_split_descend` (21) | docstring carries a clause-by-clause bit-identity argument vs three oracles |
+| `tree._build_split_descend_q` (21) | deliberate int64 twin — numba has no generics; stays textually parallel to the float sibling |
+| `tree._build_split_descend_vec` (25) | vector-leaf hot path; no safety payoff for recompile risk |
+| `tree._build_and_split` (15) | test oracle (tests/test_tree_kernels.py pins the fused kernel against it) |
+| `tree._best_split` (13) | test oracle, paired with `_build_histograms_into` |
+| `tree._solve_small` (13) | pinned bit-exact vs numpy (tests/test_small_solver.py) |
+| `tree._linear_leaf_fit` (17) | numba, cache=True; churn for zero benefit at threshold 10 |
+| `tree._select_kth` (11) | same |
+| `tree._shap_forest_linear` (24) | deepest nesting in the repo (6), prange body; extraction risks numba inlining behavior |
+| `target_encoding._factorize_numeric` (14) | plain Python but the predict-latency hot path, with an audited (not derived) equivalence to the dict loop; optional post-program candidate |
+
+Not flagged but worth recording: the 8-kernel predict family and the 4-kernel
+leaf-quantile family in `tree.py` look like copy-paste to a metric but are
+intentional — the `_serial` twins exist because `parallel=True` launch
+overhead loses at small n, and the float/quantized/vector variants exist
+because numba cannot express them generically.
+
+## Snapshot coverage note (why stage 0 exists)
+
+The original identity snapshot fit every config on 2,000 rows; with
+`validation_fraction=0.2` that leaves 1,600 post-split — below
+`CROSS_MIN_SAMPLES = 2000` — so no config ever ran the cross-feature race,
+the selection-rounds audition, or forced cross, and there was no bagged or
+conformalized-quantile config. Stage 0 added n=6000 configs plus `bag` and
+`mq3_conf`, with `_EXPECT` assertions that fail the save/check if a pinned
+path ever goes dark again.

--- a/benchmarks/identity_snapshot.py
+++ b/benchmarks/identity_snapshot.py
@@ -1,7 +1,10 @@
 """Bit-identity snapshot for output-identical refactors.
 
 The golden panel (tests/test_no_regression.py) pins three losses at a 2%
-band; this pins ~20 configs exactly. Usage:
+band; this pins ~30 configs exactly, including n=6000 configs that arm the
+cross-feature race / selection audition / forced-cross paths (the default-N
+configs never reach CROSS_MIN_SAMPLES post-split) plus bagged and
+conformalized-quantile fits. Usage:
 
     python benchmarks/identity_snapshot.py save    # once, at the base commit
     python benchmarks/identity_snapshot.py check   # after every refactor commit
@@ -97,7 +100,39 @@ def _configs():
     add("mq3", Q, {"quantiles": [0.1, 0.5, 0.9]}, dict(seed=14))
     add("mq3_w_sub", Q, {"quantiles": [0.1, 0.5, 0.9], "subsample": 0.7},
         dict(seed=14), weighted=True)
+    # The default N leaves 1600 post-ES-split rows -- below CROSS_MIN_SAMPLES
+    # (2000), so none of the configs above ever runs the cross-feature race,
+    # the selection-rounds audition, or forced cross. These n=6000 configs
+    # (3840 post-split) arm those paths; _EXPECT asserts each one actually
+    # fired, so gate coverage is proven at save time, not assumed.
+    add("rmse_big", R, {}, dict(seed=15, n=6000))
+    add("rmse_big_race", R, {"selection_rounds": None}, dict(seed=15, n=6000))
+    add("rmse_forced", R, {"cross_features": "always"}, dict(seed=16, n=6000))
+    add("rmse_norefit", R, {"refit_full": False}, dict(seed=15, n=6000))
+    add("logloss_big", C, {}, dict(seed=17, kind="bin", n=6000))
+    add("multiclass_big", C, {}, dict(seed=18, kind="multi", n=6000))
+    add("bag", R, {"n_ensembles": 3}, dict(seed=19))
+    add("mq3_conf", Q, {"quantiles": [0.1, 0.5, 0.9], "conformalize": True},
+        dict(seed=20))
     return cfgs
+
+
+# Path-activation proofs: fitting a config is not evidence the code path it
+# exists for actually ran (the original suite silently skipped the cross race
+# for years of commits). Each check raises at save/check time if its path
+# went dark, e.g. because a constant or split fraction moved.
+_EXPECT = {
+    "rmse_big": lambda e: (e.linear_leaves_selected_ is not None
+                           and e.cross_features_selected_ is not None),
+    "rmse_big_race": lambda e: (e.linear_leaves_selected_ is not None
+                                and e.cross_features_selected_ is not None),
+    "rmse_forced": lambda e: e.cross_features_selected_ is True,
+    "rmse_norefit": lambda e: e.linear_leaves_selected_ is not None,
+    "logloss_big": lambda e: e.cross_features_selected_ is not None,
+    "multiclass_big": lambda e: e.cross_features_selected_ is not None,
+    "bag": lambda e: (e.estimators_ is not None and len(e.estimators_) == 3),
+    "mq3_conf": lambda e: not np.all(e.conformal_scale_ == 1.0),
+}
 
 
 def _run_one(name, cls, params, data_kw, weighted):
@@ -109,14 +144,34 @@ def _run_one(name, cls, params, data_kw, weighted):
     if weighted:
         fit_kw["sample_weight"] = w
     est.fit(X, y, **fit_kw)
+
+    expect = _EXPECT.get(name)
+    if expect is not None and not expect(est):
+        raise AssertionError(
+            f"config {name!r} no longer exercises the path it exists to pin "
+            "-- see _EXPECT; the gate would be silently weaker than saved.")
+
     out = {
         f"{name}__pred": np.asarray(est.predict(Xte), dtype=np.float64),
-        f"{name}__n_trees": np.asarray(len(est.model_.trees_)),
-        f"{name}__valid_hist": np.asarray(est.model_.valid_history_,
-                                          dtype=np.float64),
         f"{name}__imp": np.asarray(est.feature_importances_,
                                    dtype=np.float64),
     }
+    if getattr(est, "estimators_", None) is not None:
+        for i, m in enumerate(est.estimators_):
+            out[f"{name}__m{i}_n_trees"] = np.asarray(len(m.model_.trees_))
+            out[f"{name}__m{i}_valid_hist"] = np.asarray(
+                m.model_.valid_history_, dtype=np.float64)
+    else:
+        out[f"{name}__n_trees"] = np.asarray(len(est.model_.trees_))
+        out[f"{name}__valid_hist"] = np.asarray(est.model_.valid_history_,
+                                                dtype=np.float64)
+    # Calibration outputs are the direct products of the conformal /
+    # temperature blocks -- pin them explicitly rather than only through pred.
+    for attr in ("quantile_offset_", "temperature_", "conformal_scale_"):
+        val = getattr(est, attr, None)
+        if val is not None:
+            out[f"{name}__{attr.rstrip('_')}"] = np.asarray(val,
+                                                            dtype=np.float64)
     if hasattr(est, "predict_proba"):
         out[f"{name}__proba"] = est.predict_proba(Xte)
     return out

--- a/chimeraboost/booster.py
+++ b/chimeraboost/booster.py
@@ -700,7 +700,7 @@ class GradientBoosting(_BaseBooster):
         self.loss_name = loss
         self.loss_kwargs = loss_kwargs or {}
 
-    def _fit_impl(self, X, y, cat_features=None, eval_set=None,
+    def _fit_impl(self, X, y, cat_features=None, eval_set=None,  # noqa: C901 -- complexity baseline, removed in stage 4
                   sample_weight=None, callbacks=None, prep_cache=None):
         """Fit the additive model.
 
@@ -1074,7 +1074,7 @@ class MulticlassBoosting(_BaseBooster):
     `predict_raw` keeps a fallback for those unpickled forests.
     """
 
-    def _fit_impl(self, X, y, cat_features=None, eval_set=None,
+    def _fit_impl(self, X, y, cat_features=None, eval_set=None,  # noqa: C901 -- complexity baseline, removed in stage 4
                   sample_weight=None, callbacks=None, prep_cache=None):
         """Fit one vector-leaf tree per boosting round under softmax loss.
 
@@ -1518,7 +1518,7 @@ class MultiQuantileBoosting(_BaseBooster):
 
         return basis[0]         # "sum": the literal channel sum
 
-    def _fit_impl(self, X, y, cat_features=None, eval_set=None,
+    def _fit_impl(self, X, y, cat_features=None, eval_set=None,  # noqa: C901 -- complexity baseline, removed in stage 4
                   sample_weight=None, callbacks=None, prep_cache=None):
         """Fit one vector-leaf quantile tree per boosting round.
 

--- a/chimeraboost/quantile_api.py
+++ b/chimeraboost/quantile_api.py
@@ -302,7 +302,7 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
         tags.input_tags.sparse = False
         return tags
 
-    def fit(self, X, y, cat_features=None, eval_set=None, groups=None,
+    def fit(self, X, y, cat_features=None, eval_set=None, groups=None,  # noqa: C901 -- complexity baseline, removed in stage 3
             sample_weight=None, callbacks=None):
         """Fit the model. Arguments carry the same meaning as
         `ChimeraBoostRegressor.fit`."""

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -154,7 +154,7 @@ def _quality_applied(estimator):
             setattr(estimator, k, v)
 
 
-def _validate_hyperparams(estimator):
+def _validate_hyperparams(estimator):  # noqa: C901 -- complexity baseline, removed in stage 1
     """Reject malformed constructor parameters with clear, named errors.
 
     Called at the start of ``fit`` -- sklearn's recommended place for parameter
@@ -541,7 +541,7 @@ def _member_sample_indices(n, ms, seed, groups):
     return rng.choice(n, size=m, replace=False)
 
 
-def _fit_bagged(estimator, X, y, cat_features, eval_set, groups, sample_weight):
+def _fit_bagged(estimator, X, y, cat_features, eval_set, groups, sample_weight):  # noqa: C901 -- complexity baseline, removed in stage 3
     """Train ``estimator.n_ensembles`` member clones and return them as a list.
 
     Each member is a clone of ``estimator`` with bagging switched off
@@ -873,7 +873,7 @@ def _reject_masked(X, where):
             "X.filled(np.nan) -- NaN is treated as missing.")
 
 
-def _validate_fit_input(estimator, X, y, cat_features, sample_weight, *,
+def _validate_fit_input(estimator, X, y, cat_features, sample_weight, *,  # noqa: C901 -- complexity baseline, removed in stage 2
                         classification):
     """Shared fit-time input validation and feature-metadata capture.
 
@@ -2111,7 +2111,7 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
         tags.input_tags.sparse = False
         return tags
 
-    def _fit_single(self, X, y, cat_features, eval_set, groups, sample_weight,
+    def _fit_single(self, X, y, cat_features, eval_set, groups, sample_weight,  # noqa: C901 -- complexity baseline, removed in stage 6
                     callbacks=None):
         """Fit one (non-bagged) model on the data as given."""
         X = as_model_array(X, bool(cat_features))
@@ -2984,7 +2984,7 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         tags.input_tags.sparse = False
         return tags
 
-    def _fit_single(self, X, y, cat_features, eval_set, groups, sample_weight,
+    def _fit_single(self, X, y, cat_features, eval_set, groups, sample_weight,  # noqa: C901 -- complexity baseline, removed in stage 5
                     callbacks=None):
         """Fit one (non-bagged) classifier on the data as given."""
         X = as_model_array(X, bool(cat_features))

--- a/chimeraboost/target_encoding.py
+++ b/chimeraboost/target_encoding.py
@@ -143,7 +143,7 @@ class OrderedTargetEncoder:
         return out
 
 
-def _factorize_numeric(col):
+def _factorize_numeric(col):  # noqa: C901 -- frozen: predict-latency hot path, see benchmarks/REFACTOR_AUDIT.md
     """Vectorized `factorize` for a column whose entries are all real numbers,
     None, or NaN; returns None when anything else is present, and the caller
     falls back to the general loop.

--- a/chimeraboost/tree.py
+++ b/chimeraboost/tree.py
@@ -241,7 +241,7 @@ def _descend_leaves_serial(leaf, Xf, t):
 
 
 @njit(cache=True, parallel=True)
-def _build_and_split(Xb, grad, hess, leaf, active, hist, feat_mask,
+def _build_and_split(Xb, grad, hess, leaf, active, hist, feat_mask,  # noqa: C901 -- frozen numba kernel, see benchmarks/REFACTOR_AUDIT.md
                      n_bins_per_feature, l2, min_child_weight):
     """Fused histogram build + best-split search: one parallel launch per level
     instead of two, with the split scan reading the hist slice the same thread
@@ -352,7 +352,7 @@ def _build_and_split(Xb, grad, hess, leaf, active, hist, feat_mask,
 
 
 @njit(cache=True, parallel=True)
-def _build_split_descend(Xb, grad, hess, leaf, active, hist, feat_mask,
+def _build_split_descend(Xb, grad, hess, leaf, active, hist, feat_mask,  # noqa: C901 -- frozen numba kernel, see benchmarks/REFACTOR_AUDIT.md
                          n_bins_per_feature, l2, min_child_weight, min_gain,
                          small, n_leaves_next, next_active):
     """`_build_and_split` plus the level's follow-up work in the same launch.
@@ -546,7 +546,7 @@ def _quantize_pack(grad, hess, inv_dg, inv_dh, qmax, qseed, out):
 
 
 @njit(cache=True, parallel=True)
-def _build_split_descend_q(Xb, q, leaf, active, histq, feat_mask,
+def _build_split_descend_q(Xb, q, leaf, active, histq, feat_mask,  # noqa: C901 -- frozen numba kernel, see benchmarks/REFACTOR_AUDIT.md
                            n_bins_per_feature, dg, dh, l2, min_child_weight,
                            min_gain, small, n_leaves_next, next_active):
     """Packed-int64 twin of `_build_split_descend` for quantized training.
@@ -660,7 +660,7 @@ def _build_split_descend_q(Xb, q, leaf, active, histq, feat_mask,
 
 
 @njit(cache=True, parallel=True)
-def _best_split(hist, n_bins_per_feature, l2, feat_mask, min_child_weight,
+def _best_split(hist, n_bins_per_feature, l2, feat_mask, min_child_weight,  # noqa: C901 -- frozen numba kernel, see benchmarks/REFACTOR_AUDIT.md
                 n_leaves):
     """Find the (feature, threshold) with the highest total gain.
 
@@ -785,7 +785,7 @@ def _leaf_values(leaf, grad, hess, n_leaves, l2, lr):
 
 
 @njit(cache=True)
-def _solve_small(A, b):
+def _solve_small(A, b):  # noqa: C901 -- frozen numba kernel, see benchmarks/REFACTOR_AUDIT.md
     """Solve ``A x = b`` for a small dense system via LU with partial pivoting.
 
     Drop-in replacement for ``np.linalg.solve`` on the tiny (d x d, d <= depth+1)
@@ -846,7 +846,7 @@ def _solve_small(A, b):
 
 
 @njit(cache=True, parallel=True)
-def _linear_leaf_fit(leaf, grad, hess, n_leaves, lin_feats, centers_std, Xb,
+def _linear_leaf_fit(leaf, grad, hess, n_leaves, lin_feats, centers_std, Xb,  # noqa: C901 -- frozen numba kernel, see benchmarks/REFACTOR_AUDIT.md
                      l2_intercept, lin_lambda, lr):
     """Fit a small hessian-weighted ridge per leaf (local linear-leaf models).
 
@@ -1097,7 +1097,7 @@ def _lerp_np(a, b, t):
 
 
 @njit(cache=True)
-def _select_kth(buf, lo, hi, k):
+def _select_kth(buf, lo, hi, k):  # noqa: C901 -- frozen numba kernel, see benchmarks/REFACTOR_AUDIT.md
     """Quickselect: reorder ``buf[lo:hi]`` so ``buf[k]`` is its (k-lo)-th
     smallest element, everything left of k no greater and everything right no
     smaller. Median-of-three pivot.
@@ -1811,7 +1811,7 @@ def _predict_forest_linear_rm_serial(Xb, feats, thrs, depths, lin_k, featoff,
 
 
 @njit(cache=True, parallel=True)
-def _shap_forest_linear(Xb, Rb, feats, thrs, depths, lin_k, featoff,
+def _shap_forest_linear(Xb, Rb, feats, thrs, depths, lin_k, featoff,  # noqa: C901 -- frozen numba kernel, see benchmarks/REFACTOR_AUDIT.md
                         lin_feat_idx, coefoff, coef, centers_std,
                         feat_orig, n_orig, fact):
     """Exact interventional TreeSHAP for a forest of oblivious (linear-leaf or
@@ -2045,7 +2045,7 @@ def replay_oblivious_tree(donor, Xb, grad, hess, l2, lr, linear_leaves=False,
 
 
 @njit(cache=True, parallel=True)
-def _build_split_descend_vec(Xb, grad, rw, leaf, n_active, hist, histw,
+def _build_split_descend_vec(Xb, grad, rw, leaf, n_active, hist, histw,  # noqa: C901 -- frozen numba kernel, see benchmarks/REFACTOR_AUDIT.md
                              feat_mask, n_bins_per_feature, l2,
                              min_child_weight, min_gain):
     """EXACT multi-channel split search: the K-deep twin of
@@ -2232,7 +2232,7 @@ def build_oblivious_tree_exact(Xb, grad, n_bins_per_feature, max_depth, l2,
     return tree, leaf
 
 
-def build_oblivious_tree(Xb, grad, hess, n_bins_per_feature,
+def build_oblivious_tree(Xb, grad, hess, n_bins_per_feature,  # noqa: C901 -- complexity baseline, removed in stage 7
                          max_depth, l2, lr, min_gain=1e-8, feature_mask=None,
                          min_child_weight=1.0, hist_buffers=None,
                          linear_leaves=False, centers_std=None, is_numeric=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ Repository = "https://github.com/bbstats/chimeraboost"
 chimeraboost-warmup = "chimeraboost.warmup:main"
 
 [project.optional-dependencies]
-dev = ["pytest", "pandas>=1.3"]
+dev = ["pytest", "pandas>=1.3", "ruff==0.16.5"]
 # Everything the benchmark harness needs beyond the library itself. pandas reads
 # the dataset files, pyarrow reads the parquet ones, matplotlib draws the charts.
 bench = ["pandas>=1.3", "pyarrow>=10", "matplotlib>=3.5", "pytest"]
@@ -50,7 +50,17 @@ include = ["chimeraboost*"]
 line-length = 100
 
 [tool.ruff.lint]
+# C901 is the complexity ratchet (benchmarks/REFACTOR_AUDIT.md): the ceiling is
+# 10, the frozen numba kernels carry permanent `# noqa: C901` markers, and
+# RUF100 fails the build if a noqa outlives its violation. The rule set is
+# pinned explicitly (not extend-select) and the ruff version is pinned (dev
+# extra, CI) because both default rules and McCabe counts shift across ruff
+# releases and would silently move the ratchet.
+select = ["E4", "E7", "E9", "F", "C901", "RUF100"]
 # `l` is the established name for a leaf index throughout the tree kernels, where
 # it reads naturally alongside `f` (feature) and `b` (bin); E741 would force a
 # churny rename across the histogram code for no clarity gain.
 ignore = ["E741"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10

--- a/tests/test_bitident_refactors.py
+++ b/tests/test_bitident_refactors.py
@@ -4,12 +4,13 @@ Each guard pins the invariant a refactor leans on, so a later change that
 breaks the invariant fails here instead of silently changing models.
 """
 import pickle
+import warnings
 from types import SimpleNamespace
 
 import numpy as np
 import pytest
 
-from chimeraboost import ChimeraBoostRegressor
+from chimeraboost import ChimeraBoostClassifier, ChimeraBoostRegressor
 from chimeraboost.booster import GradientBoosting
 from chimeraboost.losses import (MAE, RMSE, Huber, MultiQuantile, MultiSoftmax,
                                  Quantile, _SOFTMAX_MAX_K, _softmax,
@@ -356,3 +357,132 @@ def test_multiclass_grad_hess_and_eval_go_through_the_kernel():
         Y * np.log(np.clip(P, 1e-12, 1.0)), axis=1)))
     assert loss.eval(Y, F) == ref_eval
     np.testing.assert_array_equal(loss.transform(F), P)
+
+
+# ---------------------------------------------------------------------------
+# Complexity-refactor guards (stage 0 of the C901 program). The identity
+# snapshot pins model outputs exactly, but two behavior surfaces are invisible
+# to it: which file/line a warning is attributed to (an extracted helper adds
+# a stack frame; without a stacklevel bump the warning moves), and the exact
+# text plus first-fire order of validation errors. Pin both here.
+# ---------------------------------------------------------------------------
+
+def _recorded(warns, match):
+    return [w for w in warns if match in str(w.message)]
+
+
+def test_inert_knob_warnings_keep_their_attribution_and_order():
+    # linear_leaves=True with >= LINEAR_LEAVES_MIN_SAMPLES post-split rows
+    # shadows ordered boosting and leaf refinement; both warnings must keep
+    # firing, in this order, attributed to sklearn_api.py (stacklevel must be
+    # bumped +1 for every frame an extraction adds).
+    X, y, _ = _reg_data(n=2000, seed=5)
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        ChimeraBoostRegressor(
+            n_estimators=15, random_state=0, linear_leaves=True,
+            ordered_boosting=True, leaf_estimation_iterations=3).fit(X, y)
+    ob = _recorded(rec, "ordered_boosting is ignored")
+    lei = _recorded(rec, "leaf_estimation_iterations is ignored")
+    assert len(ob) == 1 and len(lei) == 1
+    assert ob[0].category is UserWarning
+    assert ob[0].filename.endswith("sklearn_api.py")
+    assert lei[0].filename.endswith("sklearn_api.py")
+    assert rec.index(ob[0]) < rec.index(lei[0])
+
+
+def test_multiclass_lei_warning_keeps_its_attribution():
+    rng = np.random.default_rng(6)
+    X = rng.normal(size=(300, 4))
+    y = rng.integers(0, 3, 300)
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        ChimeraBoostClassifier(n_estimators=10, random_state=0,
+                               leaf_estimation_iterations=3).fit(X, y)
+    w = _recorded(rec, "not implemented for multiclass")
+    assert len(w) == 1
+    assert w[0].category is UserWarning
+    assert w[0].filename.endswith("sklearn_api.py")
+
+
+def test_column_vector_y_warning_keeps_its_attribution():
+    X, y, _ = _reg_data(n=200, seed=7)
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        ChimeraBoostRegressor(n_estimators=10, random_state=0,
+                              early_stopping=False).fit(X, y.reshape(-1, 1))
+    w = _recorded(rec, "A column-vector y was passed")
+    assert len(w) == 1
+    assert w[0].filename.endswith("sklearn_api.py")
+
+
+# The refactor contract for the validators: byte-identical messages and
+# unchanged first-fire order. Regex matching would let a reworded message
+# slide through, so compare the full string.
+@pytest.mark.parametrize("params, expected", [
+    ({"n_estimators": 0},
+     "n_estimators must be an integer >= 1; got 0."),
+    ({"depth": 30},
+     "depth must be an integer in [1, 16] or None; got 30."),
+    ({"learning_rate": -0.1},
+     "learning_rate must be in (0.0, inf]; got -0.1."),
+    ({"subsample": 0.0},
+     "subsample must be in (0.0, 1.0]; got 0.0."),
+    ({"loss": "LogCosh"},
+     "loss must be one of ('RMSE', 'MAE', 'Quantile', 'Huber', 'Poisson', "
+     "'Gamma', 'Tweedie') or a custom objective instance; got 'LogCosh'."),
+    ({"refit_full": "yes"},
+     'refit_full must be True, False, "replay" or None; got \'yes\'.'),
+])
+def test_hyperparam_error_messages_are_pinned(params, expected):
+    X, y, _ = _reg_data(n=50)
+    with pytest.raises(ValueError) as e:
+        ChimeraBoostRegressor(**params).fit(X, y)
+    assert str(e.value) == expected
+
+
+def test_forced_cross_on_classifier_message_is_pinned():
+    rng = np.random.default_rng(8)
+    X = rng.normal(size=(50, 3))
+    y = rng.integers(0, 2, 50)
+    with pytest.raises(ValueError) as e:
+        ChimeraBoostClassifier(cross_features="always").fit(X, y)
+    assert str(e.value) == (
+        'cross_features="always" is only supported on the regressor; '
+        "the classifier's cross features are validation-raced "
+        "(cross_features=None or True).")
+
+
+def test_fit_input_error_messages_are_pinned():
+    X, y, w = _reg_data(n=50)
+    est = ChimeraBoostRegressor(n_estimators=10)
+
+    with pytest.raises(ValueError) as e:
+        est.fit(X, None)
+    assert str(e.value) == ("This estimator requires y to be passed, but the "
+                            "target y is None.")
+
+    with pytest.raises(ValueError) as e:
+        est.fit(X, y[:-1])
+    assert str(e.value) == ("X and y have inconsistent lengths: X has 50 "
+                            "samples, y has 49.")
+
+    # The classic slip: fit(X, y, w) binds weights to cat_features.
+    with pytest.raises(ValueError) as e:
+        est.fit(X, y, w)
+    assert str(e.value) == (
+        "cat_features must be integer column indices or column names. Got an "
+        "array of floats -- if these are per-sample weights, pass them by "
+        "keyword: fit(X, y, sample_weight=w).")
+
+    with pytest.raises(ValueError) as e:
+        est.fit(X, y, sample_weight=-w)
+    assert str(e.value) == "sample_weight must be non-negative."
+
+    Xinf = X.copy()
+    Xinf[0, 0] = np.inf
+    with pytest.raises(ValueError) as e:
+        est.fit(Xinf, y)
+    assert str(e.value) == ("X contains infinity. NaN is accepted (treated as "
+                            "missing), but inf is not -- clip or clean it "
+                            "first.")


### PR DESCRIPTION
﻿Stage 0 of the complexity-ratchet program (benchmarks/REFACTOR_AUDIT.md): tooling and gate coverage only, zero behavior change.

**Ratchet.** Ruff C901 at `max-complexity = 10` with the rule set pinned explicitly and ruff pinned to 0.16.5 (default rules and McCabe counts both shift across releases and would silently move the gate). New `lint` job in CI. The 20 current violations carry `# noqa: C901` markers: temporary ones name the stage that deletes them, permanent ones freeze the numba kernels; RUF100 fails the build on any stale marker.

**Identity-gate coverage (the load-bearing fix).** The snapshot's 2000-row fits left 1600 rows post-ES-split -- below `CROSS_MIN_SAMPLES` -- so none of the 21 configs ever executed the cross-feature race, the selection audition, or forced cross, and there was no bagged or conformalized-quantile config. Eight new configs arm those paths; `_EXPECT` assertions fail the save/check if a pinned path ever goes dark; calibration outputs are snapshotted directly. 155 arrays saved, 155/155 identical on a same-commit re-check.

**New guards** in `tests/test_bitident_refactors.py` pin what the identity gate cannot see: warning attribution (`w.filename` -- an extracted helper must bump `stacklevel`) and byte-exact validator error messages.

**Verification.** `comment_only_gate.py`: all 12 library modules AST-identical (comments only). Full suite: 988 passed, 1 skipped. `ruff check chimeraboost/`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
