### PR TITLE
Complexity stage 3: quantile fit + bagging plumbing (ruff 16/12 -> <=10)

### DIFF
--- a/benchmarks/REFACTOR_AUDIT.md
+++ b/benchmarks/REFACTOR_AUDIT.md
@@ -1,6 +1,6 @@
 # Complexity audit & refactor program
 
-Status: stages 0-2 shipped. Started 2026-08-30.
+Status: stages 0-3 shipped. Started 2026-08-30.
 
 Goal: every non-frozen function at or below ruff C901 complexity 10, enforced
 permanently, with **zero behavior change** — each refactor stage is
@@ -34,7 +34,7 @@ benchmarks.
 | 0 | tooling, snapshot coverage, guards | — | shipped (PR #97, 2026-08-30) |
 | 1 | `sklearn_api._validate_hyperparams` | 25 | shipped (2026-08-30) |
 | 2 | `sklearn_api._validate_fit_input` | 34 | shipped (2026-08-30) |
-| 3 | `quantile_api.fit`, `sklearn_api._fit_bagged` | 16, 12 | pending |
+| 3 | `quantile_api.fit`, `sklearn_api._fit_bagged` | 16, 12 | shipped (2026-08-30) |
 | 4 | the three `booster._fit_impl` loops | 16/14/16 | pending |
 | 5 | classifier `_fit_single` | 31 | pending |
 | 6 | regressor `_fit_single` | 36 | pending |

--- a/chimeraboost/quantile_api.py
+++ b/chimeraboost/quantile_api.py
@@ -302,7 +302,86 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
         tags.input_tags.sparse = False
         return tags
 
-    def fit(self, X, y, cat_features=None, eval_set=None, groups=None,  # noqa: C901 -- complexity baseline, removed in stage 3
+    def _carve_calibration_fold(self, X, y, sample_weight, groups):
+        """Step 1: the conformal calibration fold FIRST, so it sees neither
+        the fit nor the stopping decision. Carved before anything else
+        touches y. Returns ``(cal, X, y, sample_weight, groups)``."""
+        if not self.conformalize:
+            return None, X, y, sample_weight, groups
+        split = _make_eval_split(X, y, self.calibration_fraction,
+                                 self.random_state, groups=groups)
+        if split is None:
+            raise ValueError(
+                "conformalize=True could not carve a calibration fold from "
+                f"{len(y)} rows at calibration_fraction="
+                f"{self.calibration_fraction}. Supply more rows or lower "
+                "the fraction.")
+
+        keep, cal_idx = split
+        cal = (X[cal_idx], y[cal_idx])
+        X, y = X[keep], y[keep]
+        if sample_weight is not None:
+            sample_weight = sample_weight[keep]
+        if groups is not None:
+            groups = np.asarray(groups)[keep]
+        return cal, X, y, sample_weight, groups
+
+    def _carve_es_split(self, X, y, sample_weight, eval_set, groups):
+        """Step 2: the early-stopping split out of whatever remains.
+        Returns ``(X, y, sample_weight, eval_set, es_rounds)``."""
+        es_active = bool(self.early_stopping)
+        if es_active and eval_set is None:
+            split = _make_eval_split(X, y, self.validation_fraction,
+                                     self.random_state, groups=groups)
+            if split is None:
+                es_active = False           # too small to hold anything out
+            else:
+                tr, va = split
+                sw_val = None if sample_weight is None else sample_weight[va]
+                eval_set = (X[va], y[va], sw_val)
+                X, y = X[tr], y[tr]
+                if sample_weight is not None:
+                    sample_weight = sample_weight[tr]
+
+        es_rounds = self.early_stopping_rounds
+        if not es_active:
+            es_rounds = None
+        elif eval_set is not None and es_rounds is None:
+            es_rounds = 50
+        return X, y, sample_weight, eval_set, es_rounds
+
+    def _make_mq_booster(self, taus, es_rounds, cat_features, n_rows):
+        """Resolve the auto defaults and construct the booster."""
+        depth = 4 if self.depth is None else self.depth
+        mcw = (_auto_min_child_weight(taus) if self.min_child_weight is None
+               else self.min_child_weight)
+
+        cat_combos = self.cat_combinations
+        if cat_combos is None:
+            cat_combos = _auto_cat_combinations(
+                cat_features, self.n_features_in_, n_rows)
+
+        return MultiQuantileBoosting(
+            quantiles=taus, split_projection=self.split_projection,
+            exact_splits=self.exact_splits,
+            n_estimators=self.n_estimators, learning_rate=self.learning_rate,
+            depth=depth, l2_leaf_reg=self.l2_leaf_reg, max_bins=self.max_bins,
+            subsample=self.subsample,
+            colsample=1.0 if self.colsample is None else self.colsample,
+            cat_smoothing=self.cat_smoothing,
+            cat_n_permutations=self.cat_n_permutations,
+            early_stopping_rounds=es_rounds, min_child_weight=mcw,
+            thread_count=self.thread_count, random_state=self.random_state,
+            verbose=self.verbose, cat_combinations=cat_combos,
+            quantize_gradients=self.quantize_gradients,
+            # Pinned to the historical flat rate. The size fade became the
+            # booster default in 0.30.0 on RMSE and Brier evidence
+            # (benchmarks/SMALLDATA_PLAN.md), but was never measured against
+            # pinball loss; inheriting it here would ship an unmeasured default
+            # change to the quantile path. Measure before flipping.
+            adaptive_learning_rate=False)
+
+    def fit(self, X, y, cat_features=None, eval_set=None, groups=None,
             sample_weight=None, callbacks=None):
         """Fit the model. Arguments carry the same meaning as
         `ChimeraBoostRegressor.fit`."""
@@ -334,77 +413,13 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
         if sample_weight is not None:
             sample_weight = np.asarray(sample_weight, dtype=np.float64)
 
-        # 1. Calibration fold FIRST, so it sees neither the fit nor the
-        #    stopping decision. Carved before anything else touches y.
-        cal = None
-        if self.conformalize:
-            split = _make_eval_split(X, y, self.calibration_fraction,
-                                     self.random_state, groups=groups)
-            if split is None:
-                raise ValueError(
-                    "conformalize=True could not carve a calibration fold from "
-                    f"{len(y)} rows at calibration_fraction="
-                    f"{self.calibration_fraction}. Supply more rows or lower "
-                    "the fraction.")
+        cal, X, y, sample_weight, groups = self._carve_calibration_fold(
+            X, y, sample_weight, groups)
+        X, y, sample_weight, eval_set, es_rounds = self._carve_es_split(
+            X, y, sample_weight, eval_set, groups)
 
-            keep, cal_idx = split
-            cal = (X[cal_idx], y[cal_idx])
-            X, y = X[keep], y[keep]
-            if sample_weight is not None:
-                sample_weight = sample_weight[keep]
-            if groups is not None:
-                groups = np.asarray(groups)[keep]
-
-        # 2. Early-stopping split out of whatever remains.
-        es_active = bool(self.early_stopping)
-        if es_active and eval_set is None:
-            split = _make_eval_split(X, y, self.validation_fraction,
-                                     self.random_state, groups=groups)
-            if split is None:
-                es_active = False           # too small to hold anything out
-            else:
-                tr, va = split
-                sw_val = None if sample_weight is None else sample_weight[va]
-                eval_set = (X[va], y[va], sw_val)
-                X, y = X[tr], y[tr]
-                if sample_weight is not None:
-                    sample_weight = sample_weight[tr]
-
-        es_rounds = self.early_stopping_rounds
-        if not es_active:
-            es_rounds = None
-        elif eval_set is not None and es_rounds is None:
-            es_rounds = 50
-
-        depth = 4 if self.depth is None else self.depth
-        mcw = (_auto_min_child_weight(taus) if self.min_child_weight is None
-               else self.min_child_weight)
-
-        cat_combos = self.cat_combinations
-        if cat_combos is None:
-            cat_combos = _auto_cat_combinations(
-                cat_features, self.n_features_in_, len(y))
-
-        self.model_ = MultiQuantileBoosting(
-            quantiles=taus, split_projection=self.split_projection,
-            exact_splits=self.exact_splits,
-            n_estimators=self.n_estimators, learning_rate=self.learning_rate,
-            depth=depth, l2_leaf_reg=self.l2_leaf_reg, max_bins=self.max_bins,
-            subsample=self.subsample,
-            colsample=1.0 if self.colsample is None else self.colsample,
-            cat_smoothing=self.cat_smoothing,
-            cat_n_permutations=self.cat_n_permutations,
-            early_stopping_rounds=es_rounds, min_child_weight=mcw,
-            thread_count=self.thread_count, random_state=self.random_state,
-            verbose=self.verbose, cat_combinations=cat_combos,
-            quantize_gradients=self.quantize_gradients,
-            # Pinned to the historical flat rate. The size fade became the
-            # booster default in 0.30.0 on RMSE and Brier evidence
-            # (benchmarks/SMALLDATA_PLAN.md), but was never measured against
-            # pinball loss; inheriting it here would ship an unmeasured default
-            # change to the quantile path. Measure before flipping.
-            adaptive_learning_rate=False)
-
+        self.model_ = self._make_mq_booster(taus, es_rounds, cat_features,
+                                            len(y))
         self.model_.fit(X, y, cat_features=cat_features, eval_set=eval_set,
                         sample_weight=sample_weight, callbacks=callbacks)
 

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -567,7 +567,79 @@ def _member_sample_indices(n, ms, seed, groups):
     return rng.choice(n, size=m, replace=False)
 
 
-def _fit_bagged(estimator, X, y, cat_features, eval_set, groups, sample_weight):  # noqa: C901 -- complexity baseline, removed in stage 3
+def _resolve_worker_layout(estimator, K):
+    """Split the thread budget across member-fitting workers.
+
+    Returns ``(n_workers, member_threads)``: ``thread_count`` if set (else
+    numba's thread count) divided across up to K workers, so a bagged fit
+    uses the same cores a single fit would.
+    """
+    n_jobs = int(estimator.ensemble_n_jobs)
+    if n_jobs == 1:
+        return 1, estimator.thread_count
+    budget = estimator.thread_count
+    if budget is None:
+        import numba
+        budget = numba.config.NUMBA_NUM_THREADS
+    n_workers = max(1, min(K, budget if n_jobs < 0 else n_jobs))
+    return n_workers, max(1, int(budget) // n_workers)
+
+
+def _resolve_member_defaults(estimator):
+    # Bagged-mode member defaults (benchmarks/BAGGING_PLAN.md B3): averaging
+    # tolerates coarser, cheaper members, so params left on auto resolve to the
+    # tuned member values rather than the single-model ones. PMLB-tuned,
+    # holdout-confirmed, decision-suite validated: 54W-17L, +0.28% pooled vs the
+    # previous bagged defaults at par fit cost.
+    #
+    # Explicit user values always win, and the substitution is announced once
+    # per fit -- an opt-in bagged fit should never silently train members on
+    # different defaults. stacklevel 4: this helper + _fit_bagged + fit,
+    # attributing the warning to the user's fit call as the pre-extraction
+    # stacklevel=3 did.
+    member_defaults = {}
+    if estimator.learning_rate is None:
+        member_defaults["learning_rate"] = 0.15
+    if estimator.colsample is None:
+        member_defaults["colsample"] = 0.85
+    estimator.member_params_ = dict(member_defaults)
+    if member_defaults:
+        warnings.warn(
+            "ChimeraBoost bagged mode: member defaults "
+            + ", ".join(f"{k}={v}" for k, v in member_defaults.items())
+            + " (pass explicit values to override; see docs).",
+            UserWarning, stacklevel=4)
+    return member_defaults
+
+
+def _patch_missing_class(idx, y, classes, seed):
+    """Guard a member draw that missed a rare class entirely.
+
+    A member cannot fit on a single class ("Need at least 2 classes" would
+    crash the whole bag on data whose y plainly has two). Inject one row of
+    the most frequent missing class. Draws that already hold two classes --
+    every non-crashing fit before this guard -- are byte-identical: the
+    patch rng is constructed only when the guard fires.
+    """
+    if classes is None or np.unique(y[idx]).size >= 2:
+        return idx
+    patch_rng = np.random.default_rng([int(seed), 1])
+    present = y[idx[0]]
+    missing = [c for c in classes if c != present]
+    counts = {c: int(np.sum(y == c)) for c in missing}
+    donor_class = max(missing, key=lambda c: counts[c])
+    donor = patch_rng.choice(np.where(y == donor_class)[0])
+    if idx.size > 1:
+        idx[patch_rng.integers(0, idx.size)] = donor
+    else:
+        # A one-row draw (tiny n, small max_samples) has no row to
+        # spare: overwriting it just swaps which single class the
+        # member sees, and it crashes again. Grow to two rows instead.
+        idx = np.append(idx, donor)
+    return idx
+
+
+def _fit_bagged(estimator, X, y, cat_features, eval_set, groups, sample_weight):
     """Train ``estimator.n_ensembles`` member clones and return them as a list.
 
     Each member is a clone of ``estimator`` with bagging switched off
@@ -601,42 +673,13 @@ def _fit_bagged(estimator, X, y, cat_features, eval_set, groups, sample_weight):
     groups = None if groups is None else np.asarray(groups)
     n = X.shape[0]
     K = int(estimator.n_ensembles)
-    n_jobs = int(estimator.ensemble_n_jobs)
 
-    if n_jobs == 1:
-        n_workers, member_threads = 1, estimator.thread_count
-    else:
-        budget = estimator.thread_count
-        if budget is None:
-            import numba
-            budget = numba.config.NUMBA_NUM_THREADS
-        n_workers = max(1, min(K, budget if n_jobs < 0 else n_jobs))
-        member_threads = max(1, int(budget) // n_workers)
+    n_workers, member_threads = _resolve_worker_layout(estimator, K)
 
     seeds = np.random.default_rng(estimator.random_state).integers(
         0, 2**31 - 1, size=K)
 
-    # Bagged-mode member defaults (benchmarks/BAGGING_PLAN.md B3): averaging
-    # tolerates coarser, cheaper members, so params left on auto resolve to the
-    # tuned member values rather than the single-model ones. PMLB-tuned,
-    # holdout-confirmed, decision-suite validated: 54W-17L, +0.28% pooled vs the
-    # previous bagged defaults at par fit cost.
-    #
-    # Explicit user values always win, and the substitution is announced once
-    # per fit -- an opt-in bagged fit should never silently train members on
-    # different defaults.
-    member_defaults = {}
-    if estimator.learning_rate is None:
-        member_defaults["learning_rate"] = 0.15
-    if estimator.colsample is None:
-        member_defaults["colsample"] = 0.85
-    estimator.member_params_ = dict(member_defaults)
-    if member_defaults:
-        warnings.warn(
-            "ChimeraBoost bagged mode: member defaults "
-            + ", ".join(f"{k}={v}" for k, v in member_defaults.items())
-            + " (pass explicit values to override; see docs).",
-            UserWarning, stacklevel=3)
+    member_defaults = _resolve_member_defaults(estimator)
 
     def _fit_one(seed):
         # quality=None on members: the recipe is already resolved on the bag
@@ -661,26 +704,8 @@ def _fit_bagged(estimator, X, y, cat_features, eval_set, groups, sample_weight):
         ms = float(estimator.max_samples)
         idx = _member_sample_indices(n, ms, seed, groups)
 
-        # The draw can miss a rare class entirely, and a member cannot fit on a
-        # single class ("Need at least 2 classes" would crash the whole bag on
-        # data whose y plainly has two). Inject one row of the most frequent
-        # missing class. Draws that already hold two classes -- every
-        # non-crashing fit before this guard -- are byte-identical.
-        classes = getattr(estimator, "classes_", None)
-        if classes is not None and np.unique(y[idx]).size < 2:
-            patch_rng = np.random.default_rng([int(seed), 1])
-            present = y[idx[0]]
-            missing = [c for c in classes if c != present]
-            counts = {c: int(np.sum(y == c)) for c in missing}
-            donor_class = max(missing, key=lambda c: counts[c])
-            donor = patch_rng.choice(np.where(y == donor_class)[0])
-            if idx.size > 1:
-                idx[patch_rng.integers(0, idx.size)] = donor
-            else:
-                # A one-row draw (tiny n, small max_samples) has no row to
-                # spare: overwriting it just swaps which single class the
-                # member sees, and it crashes again. Grow to two rows instead.
-                idx = np.append(idx, donor)
+        idx = _patch_missing_class(idx, y, getattr(estimator, "classes_", None),
+                                   seed)
 
         wb = None if sample_weight is None else np.asarray(sample_weight)[idx]
         gb = None if groups is None else groups[idx]


### PR DESCRIPTION
﻿Stage 3 of the complexity ratchet (benchmarks/REFACTOR_AUDIT.md): `quantile_api.fit` 16 -> 5 and `_fit_bagged` 12 -> 4 in ruff C901 units.

The quantile head's fit splits into the calibration carve, the early-stopping carve, and booster construction -- verbatim moves in the original order; both carves are internally seeded so RNG order is untouched. In `_fit_bagged`, worker-layout arithmetic, member-default resolution (warning stacklevel 3 -> 4 for the extra frame), and the rare-class donor patch become module helpers; the `_fit_one` closure stays put because joblib pickles it with its captures.

Gates: identity snapshot 155/155 bit-identical -- the stage-0 `bag` and `mq3_conf` configs exist precisely to pin these two paths; full suite 988 passed, 1 skipped; ruff clean, stage-3 noqas deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
