### PR TITLE
Complexity stage 7: build_oblivious_tree (ruff 13 -> 7) + program closeout

### DIFF
--- a/benchmarks/REFACTOR_AUDIT.md
+++ b/benchmarks/REFACTOR_AUDIT.md
@@ -1,6 +1,10 @@
 # Complexity audit & refactor program
 
-Status: stages 0-6 shipped. Started 2026-08-30.
+Status: **COMPLETE** — all 8 stages shipped 2026-08-30. End state: zero C901
+violations at max-complexity 10; exactly 10 permanent frozen-kernel noqas
+(9 in tree.py + `_factorize_numeric`); RUF100 keeps the list honest; the
+lint job gates CI. Every stage was bit-identical (identity snapshot 155/155
+exact on all 29 configs, full suite green, per-stage PRs #97-#104).
 
 Goal: every non-frozen function at or below ruff C901 complexity 10, enforced
 permanently, with **zero behavior change** — each refactor stage is
@@ -38,7 +42,13 @@ benchmarks.
 | 4 | the three `booster._fit_impl` loops | 16/14/16 | shipped (2026-08-30) |
 | 5 | classifier `_fit_single` | 31 | shipped (2026-08-30) |
 | 6 | regressor `_fit_single` | 36 | shipped (2026-08-30) |
-| 7 | `tree.build_oblivious_tree` + closeout | 13 | pending |
+| 7 | `tree.build_oblivious_tree` + closeout | 13 | shipped (2026-08-30) |
+
+Stage-7 perf note: the strict-timing wine ratio and profile_fit both read
+elevated during this stage, but an A/B against unmodified main under the
+same machine state reproduced the elevation exactly (main 18.08 ms/tree
+warm vs branch 17.39; wine failing on main too) -- machine drift, not the
+refactor. The +<=2 Python calls per tree are unmeasurable on real data.
 
 Rules for every stage: move code, never rewrite expressions; helpers receive
 rng objects and consume draws in original order; `stacklevel` +1 per frame a

--- a/chimeraboost/tree.py
+++ b/chimeraboost/tree.py
@@ -2232,7 +2232,48 @@ def build_oblivious_tree_exact(Xb, grad, n_bins_per_feature, max_depth, l2,
     return tree, leaf
 
 
-def build_oblivious_tree(Xb, grad, hess, n_bins_per_feature,  # noqa: C901 -- complexity baseline, removed in stage 7
+def _quantize_setup(grad, hess, n_samples, qbuf, qseed):
+    """Resolve the quantization scales and fill the packed scratch buffer.
+
+    qmax keeps every packed cell and prefix sum overflow-safe (see the
+    _QMAX_CAP comment); the scales map the observed grad/hess range onto
+    [-qmax, qmax] and [0, qmax]. All-zero grad or hess degenerates to
+    qg/qh = 0, which yields zero gains -- the same no-split outcome as the
+    float kernel. Returns ``(qbuf, dg, dh)``.
+    """
+    qmax = min(_QMAX_CAP, (2 ** 31 - 1) // max(n_samples, 1))
+    gmax, hmax = _gh_absmax(grad, hess)
+    inv_dg = qmax / gmax if gmax > 0.0 else 0.0
+    inv_dh = qmax / hmax if hmax > 0.0 else 0.0
+    dg = gmax / qmax if gmax > 0.0 else 0.0
+    dh = hmax / qmax if hmax > 0.0 else 0.0
+    if qbuf is None:
+        qbuf = np.empty(n_samples, dtype=np.int64)
+
+    _quantize_pack(grad, hess, inv_dg, inv_dh, np.int64(qmax),
+                   np.uint64(qseed), qbuf)
+    return qbuf, dg, dh
+
+
+def _fit_linear_leaf_tail(splits_feat, is_numeric, leaf, grad, hess, n_leaves,
+                          centers_std, Xb, l2, linear_lambda, lr):
+    """Attach the per-leaf ridge model over the NUMERIC features the tree
+    actually split on. Returns ``(lin_feats, lin_coef)``, both None when no
+    numeric feature was split."""
+    seen = []
+    for f in splits_feat:
+        if is_numeric[f] and f not in seen:
+            seen.append(f)
+
+    if not seen:
+        return None, None
+    lin_feats = np.array(seen, dtype=np.int64)
+    lin_coef = _linear_leaf_fit(leaf, grad, hess, n_leaves, lin_feats,
+                                centers_std, Xb, l2, linear_lambda, lr)
+    return lin_feats, lin_coef
+
+
+def build_oblivious_tree(Xb, grad, hess, n_bins_per_feature,
                          max_depth, l2, lr, min_gain=1e-8, feature_mask=None,
                          min_child_weight=1.0, hist_buffers=None,
                          linear_leaves=False, centers_std=None, is_numeric=None,
@@ -2285,22 +2326,7 @@ def build_oblivious_tree(Xb, grad, hess, n_bins_per_feature,  # noqa: C901 -- co
         hist = hist_buffers
 
     if quantize:
-        # qmax keeps every packed cell and prefix sum overflow-safe (see the
-        # _QMAX_CAP comment); the scales map the observed grad/hess range onto
-        # [-qmax, qmax] and [0, qmax]. All-zero grad or hess degenerates to
-        # qg/qh = 0, which yields zero gains — the same no-split outcome as the
-        # float kernel.
-        qmax = min(_QMAX_CAP, (2 ** 31 - 1) // max(n_samples, 1))
-        gmax, hmax = _gh_absmax(grad, hess)
-        inv_dg = qmax / gmax if gmax > 0.0 else 0.0
-        inv_dh = qmax / hmax if hmax > 0.0 else 0.0
-        dg = gmax / qmax if gmax > 0.0 else 0.0
-        dh = hmax / qmax if hmax > 0.0 else 0.0
-        if qbuf is None:
-            qbuf = np.empty(n_samples, dtype=np.int64)
-
-        _quantize_pack(grad, hess, inv_dg, inv_dh, np.int64(qmax),
-                       np.uint64(qseed), qbuf)
+        qbuf, dg, dh = _quantize_setup(grad, hess, n_samples, qbuf, qseed)
 
     splits_feat = []
     splits_thr = []
@@ -2351,16 +2377,9 @@ def build_oblivious_tree(Xb, grad, hess, n_bins_per_feature,  # noqa: C901 -- co
 
     lin_feats = lin_coef = None
     if linear_leaves and len(splits_feat) > 0 and centers_std is not None:
-        # Linear term uses the NUMERIC features the tree actually split on.
-        seen = []
-        for f in splits_feat:
-            if is_numeric[f] and f not in seen:
-                seen.append(f)
-
-        if seen:
-            lin_feats = np.array(seen, dtype=np.int64)
-            lin_coef = _linear_leaf_fit(leaf, grad, hess, n_leaves, lin_feats,
-                                        centers_std, Xb, l2, linear_lambda, lr)
+        lin_feats, lin_coef = _fit_linear_leaf_tail(
+            splits_feat, is_numeric, leaf, grad, hess, n_leaves,
+            centers_std, Xb, l2, linear_lambda, lr)
 
     tree = ObliviousTree(sf, st, values, np.array(splits_gain, dtype=np.float64),
                          lin_feats=lin_feats, lin_coef=lin_coef,


### PR DESCRIPTION
﻿Final stage of the complexity ratchet (benchmarks/REFACTOR_AUDIT.md): `build_oblivious_tree` 13 -> 7 in ruff C901 units, and program closeout.

Two verbatim extractions on the hot per-tree path: `_quantize_setup` and `_fit_linear_leaf_tail`, at most two extra Python calls per tree. Because the profile read elevated this session, a controlled A/B against unmodified main under identical machine state was run: main measured 18.08 ms/tree warm vs 17.39 on this branch, and the wine strict-timing flicker reproduces on unmodified main -- machine drift, not the change.

End state of the program: zero C901 violations at max-complexity 10, exactly 10 permanent frozen-kernel noqas (RUF100 fails CI if any goes stale), lint job gating CI, and every one of the 8 stages verified bit-identical against the 155-array identity snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
