### PR TITLE
Vector-leaf SHAP, proper quantile scoring, and the first real-data quantile benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
   scalar kernel bit for bit, which is the oracle the whole path rests on.
   Multiclass returns `(n_samples, n_features, n_classes)` in softmax-margin
   space; the quantile head returns a channel per level.
+  `shap_values` explains what `predict` returned. Rearranging the levels on
+  delivery relabels them per row, so a cross-row average wants the
+  pre-rearrangement view instead; `shap_importances` uses it automatically and
+  `space="raw"` asks for it directly.
 - **Interval-width attribution.** `model.shap_values(X, kind="width",
   alpha=0.1)` answers "which features make this row's prediction *uncertain*",
   as distinct from higher or lower. Shapley values are linear in the value
@@ -48,6 +52,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
   harness's JSON shape so `compare_runs.py` can sign-test it.
 
 ### Fixed
+- `docs/recipes.md` said raw quantile intervals "come out too wide". They have
+  run slightly narrow since 0.28.0 replaced the narrowing budget with per-row
+  rearrangement; the page had never been updated and told users the opposite of
+  the truth. A nominal 80% interval delivers about 77% coverage.
 - `shap_values` silently subsampled any background over 200 rows while the
   docs said cost scaled linearly with background size. `max_background` and
   `random_state` are now exposed on the estimators, and the docs say the cap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,63 @@
 All notable changes to ChimeraBoost are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+### Added
+- **SHAP for the quantile head and for multiclass.** The SHAP kernel was
+  scalar-leaf only, so the two models with K-vector leaves could not be
+  explained: `ChimeraBoostQuantileRegressor.shap_values` raised
+  `AttributeError`, and multiclass raised `NotImplementedError`. Both work now,
+  through one new numba kernel — the vector twin of the existing one, with the
+  same coalition enumeration over the few features an oblivious tree touches
+  and a channel axis added. At K=1 on a constant-leaf forest it reproduces the
+  scalar kernel bit for bit, which is the oracle the whole path rests on.
+  Multiclass returns `(n_samples, n_features, n_classes)` in softmax-margin
+  space; the quantile head returns a channel per level.
+- **Interval-width attribution.** `model.shap_values(X, kind="width",
+  alpha=0.1)` answers "which features make this row's prediction *uncertain*",
+  as distinct from higher or lower. Shapley values are linear in the value
+  function, so the difference between two levels' attributions is exactly the
+  attribution of their difference. No per-level-model approach can produce
+  this, because it needs both levels to come from one model.
+- **Quantile scoring: the proper rules.** `quantile_metrics` gains
+  `interval_score` (Winkler — coverage and width in one number, ungameable in
+  either direction), `pit_values` / `pit_histogram` (where the model is wrong,
+  not just that it is), `quantile_skill_score` (1 perfect, 0 no better than
+  ignoring every feature — the same scale as the project's other headline
+  numbers), and `sharpness`. `crps(convention="full")` gives the textbook
+  scale for comparing against `properscoring` or `scoringrules`; the default
+  is unchanged. `model.report()` carries all of it.
+- **`chimeraboost.metrics` and `report()` on every estimator.** The quantile
+  head had the only `.report()` in the library. Regressors and classifiers now
+  have one too, reporting error alongside a skill score — an RMSE of 3.1 means
+  nothing alone, an R2 of 0.02 does — plus, for classification, the CORP
+  miscalibration gap that temperature scaling exists to keep near zero.
+  Definitions match `benchmarks/run_benchmarks.py`, so a number a user reads
+  is comparable with the project's own tables.
+- **Three more ways to read a fitted quantile grid**, all free from what is
+  already stored: `predict(kind="median")`, `predict(kind="cdf",
+  thresholds=...)` for `P(y <= t)`, and `predict(kind="sample", n_samples=...)`
+  for seeded inverse-transform draws.
+- **`benchmarks/quantile_suite.py`**, a real-data quantile benchmark. The head
+  shipped in 0.26.0 and had never been scored on real data, nor ever against
+  CatBoost's `MultiQuantile` — the design the docs cite as precedent. It runs
+  the Grinsztajn regression suite against that, against K LightGBM quantile
+  boosters, and against K of our own single-level models, and writes the
+  harness's JSON shape so `compare_runs.py` can sign-test it.
+
+### Fixed
+- `shap_values` silently subsampled any background over 200 rows while the
+  docs said cost scaled linearly with background size. `max_background` and
+  `random_state` are now exposed on the estimators, and the docs say the cap
+  exists.
+- A model pickled before the SHAP background sample existed raised
+  `AttributeError` on `shap_values`; it now reports what is missing and what
+  to do about it.
+
+### Changed
+- Nothing about how any model fits. Every item above is additive, and the
+  exact-output snapshot is bit-identical on all 155 configurations.
+
 ## [0.31.0] - 2026-08-30
 ### Changed
 - **Multiclass fits are ~40% faster; predictions are bit-identical.** The

--- a/benchmarks/QUANTILE_PLAN.md
+++ b/benchmarks/QUANTILE_PLAN.md
@@ -1,5 +1,42 @@
 # Shared-tree multi-quantile head
 
+## Status, 2026-08-30
+
+Three things landed around the head. None of them changes how it fits — the
+identity snapshot is bit-identical on all 155 configurations.
+
+1. **It can be explained.** `shap_values` with a channel per level, plus
+   `kind="width"`, which attributes the width of an interval rather than its
+   position. See `docs/quantiles.md`. The kernel is `tree._shap_forest_vec`,
+   pinned bit-for-bit against the frozen scalar kernel at K=1.
+2. **It can be scored properly.** `quantile_metrics` gained the Winkler
+   interval score, PIT, a CRPS skill score and sharpness.
+3. **It is finally benchmarked on real data**, by `benchmarks/quantile_suite.py`
+   — Grinsztajn regression, against CatBoost `MultiQuantile`, K LightGBM
+   quantile boosters and K of our own single-level models. This is the first
+   time the head has been scored on anything but synthetic draws and three
+   probe datasets, and the first time CatBoost's version of the same idea has
+   been run at all. Results below.
+
+**Measured while building the SHAP path, and worth recording:** on the default
+19-level grid, roughly 40% of rows have at least one adjacent pair *out of
+order in the raw scores* before delivery-time rearrangement; on a 3-level grid
+it is about 0%. The delivered crossing rate is still exactly 0 — that is what
+the sort is for — but the sort is doing real work on the default grid, not
+acting as a no-op. This is why the SHAP path distinguishes raw from delivered
+channels rather than pretending the two are interchangeable.
+
+### Still open
+
+- **`adaptive_learning_rate` is pinned False for this head**
+  (`quantile_api.py`, "Measure before flipping") and has never been measured
+  against pinball. That is a default flip on a strength surface, so it needs
+  its own pre-registration and the full `/experiment` protocol. Not attempted
+  here. Recorded 2026-08-30.
+- The acceptance-ledger rows below (fit-speed MISS, CQR coverage FAIL) were
+  measured on synthetic data. `quantile_suite.py` is the instrument for
+  re-reading them on real data; doing so is a separate piece of work.
+
 One booster, an arbitrary tau grid, a K-vector in every leaf. Replaces "fit K
 independent quantile boosters" for estimating a whole predictive
 distribution.

--- a/benchmarks/QUANTILE_PLAN.md
+++ b/benchmarks/QUANTILE_PLAN.md
@@ -26,6 +26,52 @@ the sort is for — but the sort is doing real work on the default grid, not
 acting as a no-op. This is why the SHAP path distinguishes raw from delivered
 channels rather than pretending the two are interchangeable.
 
+### First real-data result (2026-08-30)
+
+`quantile-20260830-175359.json` — 36 Grinsztajn regression datasets, 3 seeds,
+K=19, shared early-stopping split and budget for every arm. Sign tests per
+dataset (seeds averaged), never the mean of CRPS, which is dominated by
+whichever dataset has the largest target scale.
+
+| head vs | CRPS | interval score (90%) |
+|:--|:--|:--|
+| our own K per-level models | **32W-4L**, p<0.0001, median +1.65% | **34W-2L**, p<0.0001, +3.46% |
+| K LightGBM quantile boosters | 23W-13L, p=0.13, +0.43% — a tie | **31W-5L**, p<0.0001, +5.20% |
+| CatBoost MultiQuantile | **7W-29L**, p=0.0003, −0.45% — a loss | **25W-11L**, p=0.029, +0.41% |
+
+Other columns, all 36 datasets:
+
+| arm | coverage at nominal 0.90 (mean abs error) | crossing | median fit vs head |
+|:--|:--|:--|:--|
+| head | 0.869 (0.040) | **0.0000, on 36/36** | 1.00x |
+| our per-level | 0.908 (**0.011**) | 0.163, crosses on 36/36 | 3.41x |
+| LightGBM per-level | 0.827 (0.079, worst 0.67) | 0.224, crosses on 36/36 | 1.53x |
+| CatBoost MultiQuantile | 0.825 (0.075, worst 0.64) | 0.063, crosses on 36/36 | 8.33x |
+
+**What this settles.**
+
+1. **The shared structure earns its place.** Against our own K independent
+   single-level models it wins 32 of 36 on CRPS and 34 of 36 on interval
+   score, at a third of the fit time. That was never measured before.
+2. **CatBoost's MultiQuantile is genuinely sharper on CRPS** — a significant
+   loss for us, and the first time the two have been compared. It costs them a
+   median 8.3x our fit time, and their intervals are badly calibrated (worst
+   coverage error 0.64 against nominal 0.90), so on the interval score, which
+   charges width and miscoverage together, we still win. Recorded as a real
+   deficit on the sharpness axis, not explained away.
+3. **The LightGBM claim in the docs was synthetic-only and did not survive.**
+   `quantile_head.py` measured pinball 1-3% better and 3.0-6.2x faster. On real
+   data with both arms early-stopping it is a tie on CRPS (p=0.13) and a median
+   1.53x on speed. `docs/quantiles.md` has been corrected. The old numbers were
+   not wrong for what they measured; they were measured on fixed-round
+   synthetic fits, which flatter us.
+4. **Non-crossing is the one uncontested win.** Exactly zero on all 36
+   datasets. Every other arm, CatBoost included, crosses on every dataset.
+
+**Next question this raises** (not started): the CRPS gap to CatBoost is a
+sharpness deficit, which is the same axis P14 left open against the rigid
+offset. Worth a pre-registration of its own.
+
 ### Still open
 
 - **`adaptive_learning_rate` is pinned False for this head**

--- a/benchmarks/REFACTOR_AUDIT.md
+++ b/benchmarks/REFACTOR_AUDIT.md
@@ -1,9 +1,11 @@
 # Complexity audit & refactor program
 
 Status: **COMPLETE** — all 8 stages shipped 2026-08-30. End state: zero C901
-violations at max-complexity 10; exactly 10 permanent frozen-kernel noqas
-(9 in tree.py + `_factorize_numeric`); RUF100 keeps the list honest; the
-lint job gates CI. Every stage was bit-identical (identity snapshot 155/155
+violations at max-complexity 10; exactly 11 permanent frozen-kernel noqas
+(10 in tree.py + `_factorize_numeric`); RUF100 keeps the list honest; the
+lint job gates CI. The eleventh, `tree._shap_forest_vec`, arrived after the
+program closed (vector-leaf SHAP, 2026-08-30) and joined the table below on
+the same terms. Every stage was bit-identical (identity snapshot 155/155
 exact on all 29 configs, full suite green, per-stage PRs #97-#104).
 
 Goal: every non-frozen function at or below ruff C901 complexity 10, enforced
@@ -78,6 +80,7 @@ buys elsewhere.
 | `tree._linear_leaf_fit` (17) | numba, cache=True; churn for zero benefit at threshold 10 |
 | `tree._select_kth` (11) | same |
 | `tree._shap_forest_linear` (24) | deepest nesting in the repo (6), prange body; extraction risks numba inlining behavior |
+| `tree._shap_forest_vec` (22) | the vector-leaf twin of the above, same prange body and the same inlining exposure; pinned bit-exact against it at K=1 (tests/test_tree_kernels.py) |
 | `target_encoding._factorize_numeric` (14) | plain Python but the predict-latency hot path, with an audited (not derived) equivalence to the dict loop; optional post-program candidate |
 
 Not flagged but worth recording: the 8-kernel predict family and the 4-kernel

--- a/benchmarks/compare_runs.py
+++ b/benchmarks/compare_runs.py
@@ -3,7 +3,7 @@
 Usage:
     python benchmarks/compare_runs.py BASE.json NEW.json [base_label new_label]
                                       [--model ChimeraBoost] [--by-suite]
-                                      [--metric brier]
+                                      [--metric brier|crps]
 
 Compares the per-dataset mean of the 'primary' metric (always higher-is-better:
 negative RMSE for regression, F1/accuracy for classification). Reports per-dataset
@@ -25,6 +25,9 @@ is a derived view of its parent dataset, so a pooled test counts the same rows
 twice. The tool warns loudly if you pool strata without it.
 --metric brier judges on Brier instead: classification sets only (regression
 records carry no Brier), oriented so NEW wins = lower Brier.
+--metric crps judges on CRPS, for quantile_suite.py runs, oriented so NEW wins
+= lower CRPS. Those runs already store primary = -CRPS, so the default reads
+the same ordering; --metric crps exists to print the CRPS itself.
 --model filters records to one model first. Without it, a multi-model JSON
 blends every model's records into the per-dataset mean (fine when both runs
 hold the other models fixed, but the deltas are diluted).
@@ -89,7 +92,8 @@ def load_run(path, model=None, metric="primary"):
     metric because the near-solved test needs them."""
     with open(path, encoding="utf-8") as fh:
         data = json.load(fh)
-    sign = -1.0 if metric == "brier" else 1.0   # orient higher = better
+    # Both alternatives are losses, so flip them to "higher = better".
+    sign = -1.0 if metric in ("brier", "crps") else 1.0
     bucket, rmse, brier = defaultdict(list), defaultdict(list), defaultdict(list)
     for r in data["records"]:
         if model is not None and r["model"] != model:
@@ -121,6 +125,12 @@ def is_near_solved(ds, ds_meta, rmse_b, rmse_n, brier_b, brier_n):
     metadata at all -- a Brier below 1e-3 is solved whatever the record says --
     so it still applies to anything that recorded one. Regression records carry
     no Brier, so they cannot be caught by it accidentally.
+
+    Quantile runs (`quantile_suite.py`, task "quantile") are never excluded:
+    they carry neither RMSE nor Brier, so both rules fall through to False.
+    That is the safe direction -- nothing is dropped that should have been
+    counted -- and it only affects the MEAN, which is never the verdict here.
+    Add a CRPS/y_std rule if a near-solved quantile dataset ever distorts one.
     """
     meta = ds_meta.get(ds) or {}
     if meta.get("task") == "regression":
@@ -171,9 +181,11 @@ def main():
                     help="restrict to one model's records (e.g. ChimeraBoost).")
     ap.add_argument("--model-new", default=None,
                     help="model name for the NEW run's records (default: --model).")
-    ap.add_argument("--metric", choices=["primary", "brier"], default="primary",
+    ap.add_argument("--metric", choices=["primary", "brier", "crps"],
+                    default="primary",
                     help="judge metric; brier = classification only, "
-                         "oriented so NEW wins = lower Brier.")
+                         "oriented so NEW wins = lower Brier; crps = "
+                         "quantile_suite.py runs, lower is better too.")
     ap.add_argument("--keep-near-solved", action="store_true",
                     help="do NOT exclude near-solved datasets from the mean "
                          "(reproduces pre-fix numbers quoted in older plans).")

--- a/benchmarks/quantile_suite.py
+++ b/benchmarks/quantile_suite.py
@@ -1,0 +1,333 @@
+"""Real-data quantile benchmark: the shared-tree head against the field.
+
+Why this exists. The multi-quantile head shipped in 0.26.0 and had never been
+scored on real data. `quantile_head.py` runs on synthetic draws against
+LightGBM only; `probe_quantile_band.py` runs three datasets. Neither has ever
+run CatBoost's `MultiQuantile`, which `docs/quantiles.md` names as the design
+precedent, and neither emits a `run_benchmarks`-shaped JSON, so
+`compare_runs.py` cannot sign-test either of them.
+
+This runs the Grinsztajn regression suite -- the same datasets the decision
+tier uses -- and writes the harness's own JSON shape, so the existing analysis
+stack works on the output unchanged:
+
+    python benchmarks/quantile_suite.py --seeds 3 --save
+    python benchmarks/compare_runs.py BASE.json NEW.json --metric crps
+
+Deliberately NOT wired into `run_benchmarks.py --decide`. That tier is
+protocol-gated, and a third task kind would ripple through the variant
+families, the per-stratum sign tests and the Pareto panels for no gain. This
+borrows the harness's dataset registry and its split, and nothing else.
+
+Arms
+----
+ChimeraBoostQuantile   the head: one booster, K-vector leaves
+ChimeraBoostPerLevel   K independent `ChimeraBoostRegressor(loss="Quantile")`
+                       -- the in-house baseline, which is what the shared
+                       structure has to justify itself against
+LightGBMPerLevel       K independent LightGBM quantile boosters
+CatBoostMultiQuantile  CatBoost `MultiQuantile`, the same idea as ours
+
+Scoring is `chimeraboost.quantile_metrics`, so the numbers here and the ones a
+user reads from `model.report()` are the same numbers.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import run_benchmarks as rb  # noqa: E402  (the repo's one dataset loader)
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from chimeraboost import (ChimeraBoostQuantileRegressor,  # noqa: E402
+                          ChimeraBoostRegressor)
+from chimeraboost import quantile_metrics as qm  # noqa: E402
+
+RESULTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                           "results")
+
+# The head's own default. Nineteen symmetric levels, so every central interval
+# from 90% down to 10% is an adjacent column pair.
+TAUS = np.round(np.arange(0.05, 0.9501, 0.05), 10)
+
+# Reported alphas: the ones a user actually asks for.
+ALPHAS = (0.1, 0.2, 0.5)
+
+
+def _fit_chimera_head(split, Xte, cat, threads, taus):
+    Xf, Xv, yf, yv = split
+    m = ChimeraBoostQuantileRegressor(
+        quantiles=taus, n_estimators=rb.MAX_ITERS,
+        early_stopping_rounds=rb.PATIENCE, thread_count=threads,
+        random_state=0)
+    t = time.time()
+    m.fit(Xf, yf, cat_features=cat or None, eval_set=(Xv, yv))
+    fit_s = time.time() - t
+    t = time.time()
+    Q = m.predict(Xte)
+    return Q, fit_s, time.time() - t, m.best_iteration_
+
+
+def _fit_chimera_per_level(split, Xte, cat, threads, taus):
+    """K independent `loss="Quantile"` boosters, sharing nothing.
+
+    The comparison the head has to justify itself against: same budget per
+    level, K times the work, and no structural reason the levels come out
+    ordered.
+    """
+    Xf, Xv, yf, yv = split
+    cols, fit_s, pred_s, iters = [], 0.0, 0.0, []
+    for tau in taus:
+        m = ChimeraBoostRegressor(
+            loss="Quantile", alpha=float(tau), n_estimators=rb.MAX_ITERS,
+            early_stopping_rounds=rb.PATIENCE, thread_count=threads,
+            random_state=0)
+        t = time.time()
+        m.fit(Xf, yf, cat_features=cat or None, eval_set=(Xv, yv))
+        fit_s += time.time() - t
+        t = time.time()
+        cols.append(np.asarray(m.predict(Xte), dtype=np.float64).ravel())
+        pred_s += time.time() - t
+        iters.append(m.best_iteration_)
+    return (np.column_stack(cols), fit_s, pred_s,
+            int(np.mean([i for i in iters if i is not None] or [0])))
+
+
+def _fit_lightgbm_per_level(split, Xte, cat, threads, taus):
+    import lightgbm as lgb
+    Xf, Xv, yf, yv = split
+    if cat:
+        Xf_in, Xv_in, Xte_in = rb._lgb_prepare(Xf, Xv, Xte, list(cat))
+    else:
+        Xf_in, Xv_in, Xte_in = Xf, Xv, Xte
+
+    cols, fit_s, pred_s, iters = [], 0.0, 0.0, []
+    for tau in taus:
+        m = lgb.LGBMRegressor(objective="quantile", alpha=float(tau),
+                              n_estimators=rb.MAX_ITERS, n_jobs=threads or -1,
+                              random_state=0, verbosity=-1)
+        fit_kw = dict(eval_set=[(Xv_in, yv)],
+                      callbacks=[lgb.early_stopping(rb.PATIENCE,
+                                                    verbose=False)])
+        if cat:
+            fit_kw["categorical_feature"] = list(cat)
+        t = time.time()
+        m.fit(Xf_in, yf, **fit_kw)
+        fit_s += time.time() - t
+        t = time.time()
+        cols.append(np.asarray(m.predict(Xte_in), dtype=np.float64).ravel())
+        pred_s += time.time() - t
+        iters.append(m.best_iteration_)
+    return (np.column_stack(cols), fit_s, pred_s,
+            int(np.mean([i for i in iters if i is not None] or [0])))
+
+
+def _fit_catboost_mq(split, Xte, cat, threads, taus):
+    """CatBoost's own shared-head design, the one `docs/quantiles.md` cites.
+
+    `MultiQuantile` early-stops on itself, so this arm gets the same budget
+    and the same validation rows as every other -- fit times here are
+    like-for-like.
+    """
+    from catboost import CatBoostRegressor
+    Xf, Xv, yf, yv = split
+    levels = ",".join(f"{t:g}" for t in taus)
+    m = CatBoostRegressor(
+        loss_function=f"MultiQuantile:alpha={levels}",
+        allow_writing_files=False, iterations=rb.MAX_ITERS,
+        early_stopping_rounds=rb.PATIENCE,
+        thread_count=threads or -1, random_seed=0, verbose=False)
+    t = time.time()
+    m.fit(Xf, yf, cat_features=cat or None, eval_set=(Xv, yv))
+    fit_s = time.time() - t
+    t = time.time()
+    Q = np.asarray(m.predict(Xte), dtype=np.float64)
+    return Q, fit_s, time.time() - t, int(m.tree_count_)
+
+
+ARMS = {
+    "ChimeraBoostQuantile": _fit_chimera_head,
+    "ChimeraBoostPerLevel": _fit_chimera_per_level,
+    "LightGBMPerLevel": _fit_lightgbm_per_level,
+    "CatBoostMultiQuantile": _fit_catboost_mq,
+}
+
+
+def score(y, Q, taus, y_train):
+    """Every number this benchmark judges on, from the shipped scorer.
+
+    `primary` is negated CRPS so that higher is better, which is the
+    convention `compare_runs.py` and `summarize.py` already assume for
+    regression (`-rmse`).
+    """
+    Q = np.asarray(Q, dtype=np.float64)
+    rep = qm.quantile_report(y, Q, taus, baseline=y_train)
+    out = {
+        "primary": -rep["crps"],
+        "crps": rep["crps"],
+        "crps_skill": rep["skill"],
+        "crossing_rate": rep["crossing_rate"],
+        "pinball_median": float(rep["pinball"][len(taus) // 2]),
+    }
+    by_nominal = {round(iv["nominal"], 4): iv for iv in rep["intervals"]}
+    for a in ALPHAS:
+        iv = by_nominal.get(round(1.0 - a, 4))
+        if iv is None:
+            continue
+        tag = f"{int(round((1 - a) * 100))}"
+        out[f"coverage_{tag}"] = iv["coverage"]
+        out[f"width_{tag}"] = iv["width"]
+        out[f"interval_score_{tag}"] = iv["score"]
+    return out
+
+
+def run_one(ds_name, seed, taus, threads, models):
+    X, y, cat, _ = rb.DATASETS[ds_name](1, np.random.default_rng(seed))
+    from sklearn.model_selection import train_test_split
+    Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.25,
+                                          random_state=seed)
+    # One early-stopping split, shared by every arm, so no model is judged on
+    # more data than another. Same carve the harness uses.
+    split = rb._val_split(Xtr, ytr, "regression", 0)
+
+    meta = {"task": "quantile", "n_train": int(Xtr.shape[0]),
+            "n_total": int(X.shape[0]), "n_features": int(X.shape[1]),
+            "has_cats": bool(cat), "variant": None,
+            "y_std": float(np.std(y)), "y_std_test": float(np.std(yte)),
+            # The no-skill CRPS: what the unconditional grid scores. This is
+            # the quantile twin of y_std / class_prior, so a reader can form a
+            # skill score without rebuilding the dataset.
+            "crps_marginal": float(qm.crps(
+                yte, qm.marginal_grid(split[2], taus, len(yte)), taus))}
+
+    out = {}
+    for name in models:
+        try:
+            Q, fit_s, pred_s, best = ARMS[name](split, Xte, cat, threads,
+                                                taus)
+            out[name] = (score(yte, Q, taus, split[2]), fit_s, pred_s, best)
+        except Exception as e:
+            # Same convention as run_benchmarks: a model that structurally
+            # cannot handle a dataset is recorded as skipped, not allowed to
+            # abort the run.
+            print(f"  [skip] {name} on {ds_name} (seed {seed}): "
+                  f"{type(e).__name__}: {e}")
+            out[name] = None
+    return meta, out
+
+
+def aggregate(records, models):
+    """Mean of each metric per model, over every (dataset, seed) it ran."""
+    keys = ["crps", "crps_skill", "coverage_90", "width_90",
+            "interval_score_90", "coverage_80", "crossing_rate"]
+    rows = {}
+    for m in models:
+        vals = [r["metrics"] for r in records if r["model"] == m]
+        if not vals:
+            continue
+        rows[m] = {k: float(np.mean([v[k] for v in vals if k in v]))
+                   for k in keys if any(k in v for v in vals)}
+        rows[m]["fit_s"] = float(np.mean(
+            [r["fit_time"] for r in records if r["model"] == m]))
+        rows[m]["n"] = len(vals)
+    return rows
+
+
+def format_table(rows, base="ChimeraBoostQuantile"):
+    head = (f"{'model':24s}{'CRPS':>10s}{'skill':>9s}{'cov90':>8s}"
+            f"{'width90':>10s}{'IS90':>10s}{'cross':>8s}{'fit s':>9s}"
+            f"{'vs head':>9s}")
+    lines = [head, "-" * len(head)]
+    ref = rows.get(base, {}).get("fit_s")
+    for m, r in sorted(rows.items(), key=lambda kv: kv[1].get("crps", 9e9)):
+        rel = (f"{r['fit_s'] / ref:8.2f}x" if ref else "        -")
+        lines.append(
+            f"{m:24s}{r.get('crps', float('nan')):10.4f}"
+            f"{r.get('crps_skill', float('nan')):9.3f}"
+            f"{r.get('coverage_90', float('nan')):8.3f}"
+            f"{r.get('width_90', float('nan')):10.4f}"
+            f"{r.get('interval_score_90', float('nan')):10.4f}"
+            f"{r.get('crossing_rate', float('nan')):8.4f}"
+            f"{r['fit_s']:9.2f}{rel:>9s}")
+    return "\n".join(lines)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--seeds", type=int, default=1)
+    ap.add_argument("--threads", type=int, default=None,
+                    help="thread budget per model (None = all cores).")
+    ap.add_argument("--models", nargs="+", default=list(ARMS),
+                    choices=list(ARMS))
+    ap.add_argument("--datasets", nargs="+", default=None,
+                    help="dataset keys; default = every Grinsztajn regression "
+                         "set")
+    ap.add_argument("--quantiles", type=float, nargs="+", default=None,
+                    help="tau grid; default = the head's own 19 levels")
+    ap.add_argument("--list-datasets", action="store_true")
+    ap.add_argument("--save", action="store_true")
+    args = ap.parse_args(argv)
+
+    rb._add_grinsztajn_datasets()
+    names = args.datasets or sorted(
+        k for k in rb.DATASETS
+        if k.startswith("gr:") and rb._task_of(k) == "regression")
+    taus = (np.asarray(args.quantiles, dtype=np.float64) if args.quantiles
+            else TAUS)
+
+    if args.list_datasets:
+        for n in names:
+            print(n)
+        print(f"\n{len(names)} datasets x {args.seeds} seeds x "
+              f"{len(args.models)} models, K={len(taus)}")
+        return 0
+
+    print(f"{len(names)} datasets, {args.seeds} seed(s), K={len(taus)} levels, "
+          f"models: {', '.join(args.models)}", flush=True)
+
+    records, ds_meta = [], {}
+    for ds in names:
+        for seed in range(args.seeds):
+            t0 = time.time()
+            meta, out = run_one(ds, seed, taus, args.threads, args.models)
+            ds_meta[ds] = meta
+            for name, got in out.items():
+                if got is None:
+                    continue
+                m, fit_s, pred_s, best = got
+                records.append({"dataset": ds, "model": name, "seed": seed,
+                                "metrics": m, "fit_time": fit_s,
+                                "predict_time": pred_s, "best_iter": best})
+            # Flushed: a full run is long enough that a buffered log is
+            # indistinguishable from a hung process.
+            print(f"  {ds} seed {seed}: {time.time() - t0:.1f}s",
+                  flush=True)
+
+    rows = aggregate(records, args.models)
+    print()
+    print(format_table(rows))
+
+    if args.save:
+        os.makedirs(RESULTS_DIR, exist_ok=True)
+        stamp = time.strftime("%Y%m%d-%H%M%S")
+        path = os.path.join(RESULTS_DIR, f"quantile-{stamp}.json")
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump({
+                "config": {"seeds": args.seeds, "models": args.models,
+                           "quantiles": [float(t) for t in taus],
+                           "timing": "fit_only", "suite": "quantile"},
+                "provenance": rb._provenance(sys.argv, {}),
+                "datasets": ds_meta,
+                "records": records,
+            }, fh, indent=1)
+        print(f"\nsaved -> {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/chimeraboost/__init__.py
+++ b/chimeraboost/__init__.py
@@ -15,6 +15,7 @@ Public API:
   >>> from chimeraboost import ChimeraBoostRegressor, ChimeraBoostClassifier
   >>> model = ChimeraBoostClassifier().fit(X, y, cat_features=[0, 3])
   >>> proba = model.predict_proba(X_test)
+  >>> print(model.report(X_test, y_test))   # log loss, Brier skill, calibration
 """
 
 import os as _os

--- a/chimeraboost/__init__.py
+++ b/chimeraboost/__init__.py
@@ -25,7 +25,7 @@ from .sklearn_api import (
 )
 from .quantile_api import ChimeraBoostQuantileRegressor
 from .losses import CustomObjective
-from . import quantile_metrics
+from . import metrics, quantile_metrics
 from .warmup import warmup, _warmup_from_env
 
 # CHIMERABOOST_WARMUP=1 -> compile the numba kernels at import ("background"
@@ -38,6 +38,7 @@ __all__ = [
     "ChimeraBoostClassifier",
     "ChimeraBoostQuantileRegressor",
     "CustomObjective",
+    "metrics",
     "quantile_metrics",
     "warmup",
 ]

--- a/chimeraboost/booster.py
+++ b/chimeraboost/booster.py
@@ -26,6 +26,7 @@ from .tree import (build_oblivious_tree, replay_oblivious_tree,
                    _predict_forest_linear,
                    _predict_forest_linear_rm, _predict_forest_linear_rm_serial,
                    pack_forest_linear, _shap_forest_linear,
+                   _shap_forest_vec,
                    _mvs_lambda_scan, _mvs_weights, _mvs_weights_serial)
 
 
@@ -701,6 +702,91 @@ class _BaseBooster:
         s = imp.sum()
         return imp / s if s > 0 else imp
 
+    def _capture_shap_background(self, Xb, n_samples):
+        """Keep a small sample of the binned training rows as the default SHAP
+        background -- the reference distribution interventional TreeSHAP
+        integrates over. Capped so it never bloats the pickled model.
+
+        Shared by every booster that can explain itself. `Xb` is feature-major,
+        so the sample is a column selection.
+        """
+        bg_n = min(n_samples, SHAP_BACKGROUND_SIZE)
+        bg_idx = np.random.default_rng(self.random_state).choice(
+            n_samples, bg_n, replace=False)
+        self._shap_background_ = np.ascontiguousarray(Xb[:, bg_idx])
+
+    def _resolve_shap_background(self, background, max_background, random_state):
+        """Binned, feature-major background matrix for a `shap_values` call.
+
+        `None` falls back to the sample captured at fit; anything larger than
+        `max_background` is subsampled, because cost is linear in it. Read with
+        `getattr` so a model pickled before the capture existed reports the
+        absence instead of raising `AttributeError`.
+        """
+        if background is None:
+            Rb = getattr(self, "_shap_background_", None)
+            if Rb is None:
+                raise ValueError(
+                    "This model carries no SHAP background -- it was fitted by "
+                    "a version that did not capture one. Pass `background=` "
+                    "(or `X_background=`) explicitly, or refit.")
+        else:
+            bg = as_model_array(background, bool(self.prep_.cat_features_))
+            Rb = np.ascontiguousarray(self.prep_.transform(bg).T)
+
+        if Rb.shape[1] > max_background:
+            sel = np.random.default_rng(random_state).choice(
+                Rb.shape[1], max_background, replace=False)
+            Rb = np.ascontiguousarray(Rb[:, sel])
+        return Rb
+
+    def _shap_values_vec(self, X, background=None,
+                         max_background=SHAP_BACKGROUND_SIZE, random_state=0):
+        """Exact interventional TreeSHAP for a VECTOR-LEAF forest.
+
+        Returns ``(phi, base)`` with ``phi`` of shape ``(n_samples,
+        n_input_features, K)`` and ``base`` of shape ``(K,)``, satisfying
+        Shapley efficiency one channel at a time:
+
+            phi[i, :, k].sum() + base[k] == <raw forest output>[i, k]
+
+        "Raw" means before any delivery transform the subclass applies -- the
+        quantile head's monotone rearrangement, in particular. Each subclass
+        wraps this with its own account of what a channel means.
+        """
+        X = as_model_array(X, bool(self.prep_.cat_features_))
+        Xb = np.ascontiguousarray(self.prep_.transform(X).T)   # feature-major
+        n_orig = self.prep_.n_input_features_
+        K = self.init_.shape[0]
+
+        if not self.trees_:
+            return (np.zeros((Xb.shape[1], n_orig, K)),
+                    np.asarray(self.init_, dtype=np.float64).copy())
+
+        if any(isinstance(t, list) for t in self.trees_):
+            raise NotImplementedError(
+                "This model was pickled by a version that stored one tree per "
+                "class per round. SHAP needs the vector-leaf forest layout "
+                "introduced in 0.25.0; refit the model to explain it.")
+
+        Rb = self._resolve_shap_background(background, max_background,
+                                           random_state)
+
+        if getattr(self, "_forest_", None) is None:
+            self._forest_ = pack_forest_vec(self.trees_, self.depth)
+        feats, thrs, depths, vals, voff, Kf = self._forest_
+
+        phi = _shap_forest_vec(Xb, Rb, feats, thrs, depths, vals, voff, Kf,
+                               self.prep_.feature_map_, n_orig,
+                               _factorials(self.depth))
+
+        # The SHAP kernel is feature-major; the forest predictor is row-major.
+        # Transposing the wrong one here returns a silently wrong answer of
+        # exactly the right shape.
+        base = _predict_forest_vec_rm(np.ascontiguousarray(Rb.T), feats, thrs,
+                                      depths, vals, voff, Kf, self.init_)
+        return phi, base.mean(axis=0)
+
 
 class GradientBoosting(_BaseBooster):
     """Scalar booster: regression and binary classification."""
@@ -744,13 +830,7 @@ class GradientBoosting(_BaseBooster):
         qbuf = (np.empty(n_samples, dtype=np.int64)
                 if self.quantize_gradients else None)
 
-        # Keep a small sample of the binned training rows as the default SHAP
-        # background -- the reference distribution interventional TreeSHAP
-        # integrates over. Capped so it never bloats the pickled model.
-        bg_n = min(n_samples, SHAP_BACKGROUND_SIZE)
-        bg_idx = np.random.default_rng(self.random_state).choice(
-            n_samples, bg_n, replace=False)
-        self._shap_background_ = np.ascontiguousarray(Xb[:, bg_idx])
+        self._capture_shap_background(Xb, n_samples)
 
         yv = Fv = wv = None
         if eval_set is not None:
@@ -1050,16 +1130,8 @@ class GradientBoosting(_BaseBooster):
         if not self.trees_:
             return np.zeros((Xb.shape[1], n_orig)), float(self.init_)
 
-        if background is None:
-            Rb = self._shap_background_
-        else:
-            bg = as_model_array(background, bool(self.prep_.cat_features_))
-            Rb = np.ascontiguousarray(self.prep_.transform(bg).T)
-
-        if Rb.shape[1] > max_background:
-            sel = np.random.default_rng(random_state).choice(
-                Rb.shape[1], max_background, replace=False)
-            Rb = np.ascontiguousarray(Rb[:, sel])
+        Rb = self._resolve_shap_background(background, max_background,
+                                            random_state)
 
         cs = getattr(self, "_centers_std_", None)
         if cs is not None:
@@ -1101,6 +1173,21 @@ class MulticlassBoosting(_BaseBooster):
     `predict_raw` keeps a fallback for those unpickled forests.
     """
 
+
+    def shap_values(self, X, background=None,
+                    max_background=SHAP_BACKGROUND_SIZE, random_state=0):
+        """Exact interventional TreeSHAP, one channel per class.
+
+        Returns ``(phi, base)`` with ``phi`` of shape ``(n_samples,
+        n_features, n_classes)``. Attributions live in MARGIN space -- the raw
+        softmax scores -- because softmax is not linear and there is no exact
+        way to push an additive decomposition through it. Rows therefore
+        reconstruct ``predict_raw(X)``, not ``predict_proba(X)``, which is
+        where the wider SHAP ecosystem puts multiclass attributions too.
+        """
+        return self._shap_values_vec(X, background, max_background,
+                                     random_state)
+
     def _fit_impl(self, X, y, cat_features=None, eval_set=None,
                   sample_weight=None, callbacks=None, prep_cache=None):
         """Fit one vector-leaf tree per boosting round under softmax loss.
@@ -1127,6 +1214,7 @@ class MulticlassBoosting(_BaseBooster):
                                       cat_features, eval_set, prep_cache, w)
         n_bins = self.prep_.n_bins_
         hist_buffers = self._alloc_hist_buffers(Xb.shape[0], n_bins)
+        self._capture_shap_background(Xb, n_samples)
 
         # Packed quantized grad/hess scratch, reused across every class tree.
         qbuf = (np.empty(n_samples, dtype=np.int64)
@@ -1549,6 +1637,27 @@ class MultiQuantileBoosting(_BaseBooster):
 
         return basis[0]         # "sum": the literal channel sum
 
+
+    def shap_values(self, X, background=None,
+                    max_background=SHAP_BACKGROUND_SIZE, random_state=0):
+        """Exact interventional TreeSHAP, one channel per quantile level.
+
+        Returns ``(phi, base)`` explaining the RAW per-level scores -- what the
+        booster accumulated, before `_predict_raw_impl` rearranges each row.
+        Rows reconstruct the unsorted forest output channel by channel.
+
+        The rearrangement is deliberately left to the caller. It is a per-row
+        permutation, so it relabels channels rather than transforming their
+        values, and it cannot be folded into a Shapley game over one tree's
+        features: sorting acts on the summed forest score, so pushing it inside
+        the coalition enumeration would make the game range over every input
+        feature instead of the <= D a single tree touches. See
+        `ChimeraBoostQuantileRegressor.shap_values`, which handles the
+        relabeling explicitly and says what it costs.
+        """
+        return self._shap_values_vec(X, background, max_background,
+                                     random_state)
+
     def _fit_impl(self, X, y, cat_features=None, eval_set=None,
                   sample_weight=None, callbacks=None, prep_cache=None):
         """Fit one vector-leaf quantile tree per boosting round.
@@ -1575,6 +1684,7 @@ class MultiQuantileBoosting(_BaseBooster):
 
         hist_buffers, qbuf, exact_hist = self._alloc_mq_buffers(
             Xb, n_bins, K, n_samples)
+        self._capture_shap_background(Xb, n_samples)
 
         yv = Fv = wv = None
         if eval_set is not None:
@@ -1752,10 +1862,15 @@ class MultiQuantileBoosting(_BaseBooster):
         """
         return super()._val_score(yv, np.sort(Fv, axis=1), wv)
 
-    def _predict_raw_impl(self, X, cat_ctx=None):
-        """Return the (n_samples, n_quantiles) matrix of quantile estimates, each
-        row sorted. See the class docstring: monotone rearrangement is where the
-        non-crossing guarantee is enforced."""
+    def _raw_scores(self, X, cat_ctx=None):
+        """The accumulated (n_samples, n_quantiles) score matrix BEFORE
+        rearrangement -- one channel per level, in grid order, free to cross.
+
+        Split out from `_predict_raw_impl` because SHAP needs it: the sort is a
+        per-row permutation, and recovering that permutation requires the
+        unsorted scores it was derived from. Nothing on the fit path calls
+        this; `F` is accumulated directly there.
+        """
         X = as_model_array(X, bool(self.prep_.cat_features_))
         Xb = self.prep_.transform(X, cat_ctx)       # row-major
         if not self.trees_:
@@ -1768,8 +1883,13 @@ class MultiQuantileBoosting(_BaseBooster):
         kernel = (_predict_forest_vec_rm_serial
                   if Xb.shape[0] <= _SERIAL_PREDICT_N
                   else _predict_forest_vec_rm)
-        return np.sort(
-            kernel(Xb, feats, thrs, depths, vals, voff, K, self.init_), axis=1)
+        return kernel(Xb, feats, thrs, depths, vals, voff, K, self.init_)
+
+    def _predict_raw_impl(self, X, cat_ctx=None):
+        """Return the (n_samples, n_quantiles) matrix of quantile estimates, each
+        row sorted. See the class docstring: monotone rearrangement is where the
+        non-crossing guarantee is enforced."""
+        return np.sort(self._raw_scores(X, cat_ctx), axis=1)
 
     def staged_predict_raw(self, X):
         """Yield the (n, K) quantile matrix after each successive tree.

--- a/chimeraboost/metrics.py
+++ b/chimeraboost/metrics.py
@@ -1,0 +1,142 @@
+"""Scoring for a fitted regressor or classifier.
+
+`chimeraboost.quantile_metrics` does this for a predicted quantile grid; this
+is the same idea for the two point estimators, so that every model in the
+library can be asked how it did without wiring up sklearn by hand.
+
+Two things it does that a bare `mean_squared_error` call does not:
+
+  * **Skill, not just error.** Every headline number is reported alongside a
+    skill score against the no-skill forecast -- the training mean for
+    regression, the class prior for classification. 1 is perfect, 0 is no
+    better than ignoring every feature, negative is worse than that. An RMSE
+    of 3.1 means nothing on its own; an R2 of 0.02 does.
+  * **Calibration.** For classification, how much a monotone recalibration
+    would improve the Brier score (the CORP miscalibration measure). This
+    library temperature-scales `predict_proba`, and this is the number that
+    says whether that worked.
+
+Definitions match `benchmarks/run_benchmarks.py` exactly, so a number here is
+comparable with the project's own benchmark tables.
+"""
+
+import numpy as np
+
+
+def regression_report(y, pred, sample_weight=None, baseline=None):
+    """Score point predictions: ``rmse``, ``mae``, ``r2``, ``n``.
+
+    ``r2`` is the skill score against a constant forecast -- 1 perfect, 0 no
+    better than always predicting the mean, negative worse. ``baseline`` sets
+    which mean: pass the training targets to score against what the model
+    actually had available, or leave it to use ``y`` itself, which is the
+    conservative reading (the best constant forecast in hindsight).
+    """
+    y = np.asarray(y, dtype=np.float64).ravel()
+    pred = np.asarray(pred, dtype=np.float64).ravel()
+    if pred.shape != y.shape:
+        raise ValueError(f"pred has shape {pred.shape} but y has {y.shape}.")
+
+    err = y - pred
+    mse = float(np.average(err ** 2, weights=sample_weight))
+    ref = y if baseline is None else np.asarray(baseline,
+                                                dtype=np.float64).ravel()
+    mu = float(np.average(ref, weights=None))
+    var = float(np.average((y - mu) ** 2, weights=sample_weight))
+    return {
+        "n": int(y.shape[0]),
+        "rmse": float(np.sqrt(mse)),
+        "mae": float(np.average(np.abs(err), weights=sample_weight)),
+        "r2": float("nan") if var <= 0.0 else 1.0 - mse / var,
+    }
+
+
+def _onehot(y, classes):
+    return (np.asarray(y)[:, None] == np.asarray(classes)[None, :]
+            ).astype(np.float64)
+
+
+def classification_report(y, proba, classes, sample_weight=None):
+    """Score predicted probabilities: ``log_loss``, ``brier``,
+    ``brier_skill``, ``accuracy``, ``f1_macro``, ``calibration_mcb``, ``n``.
+
+    ``brier`` is the multiclass form, the mean over rows of
+    ``sum_k (p_k - onehot_k)**2`` -- a proper scoring rule like log loss, but
+    bounded, so it aggregates across datasets without an unbounded tail. Binary
+    uses the same K=2 sum, so both tasks share one definition.
+
+    ``brier_skill`` scores it against the class prior: 1 perfect, 0 no better
+    than predicting the base rates.
+
+    ``calibration_mcb`` is the CORP miscalibration measure
+    (Dimitriadis, Gneiting & Jordan): how much an optimal *monotone*
+    recalibration would improve the per-class Brier score. 0 means already
+    perfectly calibrated, higher is worse. Fitted in-sample on the scored fold,
+    which is the standard CORP diagnostic.
+    """
+    from sklearn.isotonic import IsotonicRegression
+    from sklearn.metrics import f1_score, log_loss
+
+    classes = np.asarray(classes)
+    proba = np.asarray(proba, dtype=np.float64)
+    if proba.ndim != 2 or proba.shape[1] != classes.shape[0]:
+        raise ValueError(
+            f"proba must be (n_samples, {classes.shape[0]}); got "
+            f"{proba.shape}.")
+    if proba.shape[0] != len(y):
+        raise ValueError(f"proba has {proba.shape[0]} rows but y has {len(y)}.")
+
+    onehot = _onehot(y, classes)
+    pred = classes[proba.argmax(axis=1)]
+
+    brier = float(np.average(np.sum((proba - onehot) ** 2, axis=1),
+                             weights=sample_weight))
+    prior = np.average(onehot, axis=0, weights=sample_weight)
+    brier_ref = float(np.average(np.sum((prior[None, :] - onehot) ** 2, axis=1),
+                                 weights=sample_weight))
+
+    mcb_k = []
+    for k in range(proba.shape[1]):
+        p, yk = proba[:, k], onehot[:, k]
+        recal = IsotonicRegression(increasing=True,
+                                   out_of_bounds="clip").fit_transform(p, yk)
+        mcb_k.append(np.mean((p - yk) ** 2) - np.mean((recal - yk) ** 2))
+
+    return {
+        "n": int(len(y)),
+        "log_loss": float(log_loss(y, proba, labels=classes,
+                                   sample_weight=sample_weight)),
+        "brier": brier,
+        "brier_skill": (float("nan") if brier_ref <= 0.0
+                        else 1.0 - brier / brier_ref),
+        "accuracy": float(np.average((pred == np.asarray(y)).astype(float),
+                                     weights=sample_weight)),
+        "f1_macro": float(f1_score(y, pred, average="macro",
+                                   sample_weight=sample_weight)),
+        "calibration_mcb": float(np.mean(mcb_k)),
+    }
+
+
+_LABELS = {
+    "rmse": "RMSE (lower better)",
+    "mae": "MAE (lower better)",
+    "r2": "R2 skill vs the mean (1 perfect, 0 no better)",
+    "log_loss": "log loss (lower better)",
+    "brier": "Brier score (lower better)",
+    "brier_skill": "Brier skill vs the prior (1 perfect, 0 no better)",
+    "accuracy": "accuracy",
+    "f1_macro": "F1 macro",
+    "calibration_mcb": "miscalibration (0 is perfectly calibrated)",
+}
+
+
+def format_report(report, title=None):
+    """Render `regression_report` or `classification_report` as a fixed-width
+    text block, skill scores last so the eye lands on them."""
+    lines = [title] if title else []
+    lines.append(f"rows scored: {report['n']}")
+    width = max(len(v) for v in _LABELS.values())
+    for key, label in _LABELS.items():
+        if key in report:
+            lines.append(f"{label:<{width}s}  {report[key]:>10.6f}")
+    return "\n".join(lines)

--- a/chimeraboost/quantile_api.py
+++ b/chimeraboost/quantile_api.py
@@ -621,28 +621,28 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
                                                 baseline)
 
     def _delivered_shap(self, phi_raw, base_raw, raw):
-        """Move raw-channel attributions onto the levels `predict` delivers.
+        """Move raw-level attributions onto the levels `predict` delivers.
 
         Two transforms, in the order `predict` applies them.
 
-        **The sort.** `_predict_raw_impl` returns `np.sort(raw, axis=1)`, which
-        for row i is a permutation sigma_i, so delivered level k carries raw
-        channel sigma_i(k). Gathering `phi` and the baseline by sigma_i keeps
-        Shapley efficiency exactly, because a permutation relabels channels
-        without touching their values. What it does NOT give is the Shapley
-        value of the sorted map itself: that game would apply the sort inside
-        every coalition evaluation, and since the sort acts on the summed
-        forest score it cannot be decomposed per tree -- the coalitions would
-        have to span every input feature rather than the <= D one tree touches,
-        which is the exact blow-up obliviousness buys us out of. So these are
-        exact attributions of "whichever level landed here", and the baseline
-        is per-row because different rows reorder differently.
+        **The sort** is a per-row permutation, so gathering `phi` and the
+        baseline by it relabels levels without touching their values and
+        efficiency is preserved exactly. The baseline becomes per-row because
+        different rows reorder differently.
 
-        **The conformal rescale.** `_conformalize` is linear in the channel
-        vector with no constant term, so it pushes through onto `phi` and the
-        baseline unchanged and efficiency survives. Its matrix is obtained by
-        pushing the identity through `_conformalize` itself rather than being
-        rewritten here, so it cannot drift from what `predict` does.
+        These are therefore exact attributions of "whichever level landed
+        here", not of the sorted map as a function. The latter is not
+        available at any price: the sort acts on the SUMMED forest score, so it
+        cannot be decomposed per tree, and a coalition game over every input
+        feature instead of the <= D one tree touches is the exact blow-up
+        obliviousness buys us out of. Recorded because it looks like an
+        oversight otherwise.
+
+        **The conformal rescale** is linear in the level vector with no
+        constant term, so it pushes through onto `phi` and the baseline alike.
+        Its matrix comes from pushing the identity through `_conformalize`
+        itself rather than being rewritten here, so it cannot drift from what
+        `predict` does.
         """
         # Stable, so tied channels break the same way on every numpy version.
         # An unstable sort would pick a different -- still self-consistent --
@@ -658,32 +658,11 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
         return phi, base
 
     def shap_values(self, X, X_background=None, kind="quantiles", alpha=None,
-                    quantile=None, space="raw"):
-        """Exact interventional TreeSHAP for the whole quantile grid.
+                    quantile=None, space="delivered"):
+        """Exact interventional TreeSHAP for a predicted quantile grid.
 
-        Returns contributions in the model's additive space and sets
-        ``expected_value_`` to the matching baseline, so that contributions
-        plus baseline reconstruct the explained quantity (Shapley efficiency).
-
-        ``space`` decides what a channel means. The two answers differ only on
-        rows whose raw grid crosses:
-
-        * ``"raw"`` (default) explains the per-level scores the booster
-          accumulated, before rearrangement, against a single
-          ``(n_quantiles,)`` baseline. This is the exact Shapley decomposition
-          of level k's own model, and it is the one to aggregate across rows --
-          global importances, beeswarm plots -- because every row is then
-          measuring the same game. Conformal rescaling is not applied, since it
-          is defined on the delivered grid.
-        * ``"delivered"`` explains what ``predict`` returns, rearrangement and
-          conformal rescaling included, against a per-row ``(n_samples,
-          n_quantiles)`` baseline. Use it to explain a single prediction in the
-          levels you actually read off. `_delivered_shap` says exactly what the
-          sort does and does not buy you.
-
-        On a 3-level grid the raw scores essentially never cross and the two
-        agree; on the default 19-level grid roughly 40% of rows cross at least
-        one adjacent pair, so the choice is not cosmetic.
+        Explains what ``predict`` returned. Contributions plus
+        ``expected_value_`` (set by this call) reconstruct it, level by level.
 
         ``kind`` selects the explained quantity:
 
@@ -691,12 +670,23 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
           ``(n_samples, n_features)`` when ``quantile`` names one fitted level.
         * ``"mean"`` -- the tau-integrated point prediction.
         * ``"width"`` -- the width of the central ``1 - alpha`` interval: which
-          features make this row's prediction more uncertain. Shapley values
-          are linear in the value function, so the difference of two levels'
-          attributions is exactly the attribution of their difference.
+          features make this row's prediction more uncertain, as opposed to
+          higher or lower. Shapley values are linear in the value function, so
+          the difference of two levels' attributions is exactly the attribution
+          of their difference.
 
-        ``"mean"`` and ``"width"`` read the delivered grid by construction --
-        both are order-dependent -- so they ignore ``space``.
+        ``space`` is for one specific job and most callers can ignore it.
+        Predictions are rearranged on delivery, which relabels a row's levels,
+        so the default ``"delivered"`` measures each row against its own
+        reordering of the background and ``expected_value_`` is
+        ``(n_samples, n_quantiles)``. Aggregating those across rows mixes rows
+        that were reordered differently. ``space="raw"`` explains the
+        pre-rearrangement levels instead, against one shared
+        ``(n_quantiles,)`` baseline, which is what makes a cross-row average
+        meaningful -- `shap_importances` uses it for exactly that reason. The
+        two agree on any row whose levels were already in order.
+        ``"mean"`` and ``"width"`` are order-dependent by construction and
+        always read the delivered grid.
         """
         if space not in ("raw", "delivered"):
             raise ValueError(
@@ -759,13 +749,14 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
         """Global SHAP importance: ``mean(abs(shap_values(X)))`` per feature.
 
         Averaged over the whole grid by default, or over one level when
-        ``quantile`` names it. Always computed in ``space="raw"``, because
-        averaging delivered attributions would mix a different game per row.
+        ``quantile`` names it. Uses ``space="raw"`` so that every row is
+        measured on the same footing -- see `shap_values` -- which is what a
+        cross-row average needs.
 
         Returns a structured ``(feature, importance)`` array sorted descending,
         or a ``{feature: importance}`` dict when ``prettified=True``.
         """
-        phi = self.shap_values(X, quantile=quantile)
+        phi = self.shap_values(X, quantile=quantile, space="raw")
         imp = np.abs(phi).mean(axis=0)
         if imp.ndim == 2:                      # (n_features, n_quantiles)
             imp = imp.mean(axis=1)

--- a/chimeraboost/quantile_api.py
+++ b/chimeraboost/quantile_api.py
@@ -468,7 +468,8 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
                 "levels in `quantiles`.")
         return i, j
 
-    def predict(self, X, kind="quantiles", alpha=None):
+    def predict(self, X, kind="quantiles", alpha=None, thresholds=None,
+                n_samples=None, random_state=None):
         """Predict the conditional distribution.
 
         ``kind="quantiles"`` (default) returns (n_samples, n_quantiles),
@@ -483,6 +484,25 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
         function over tau: trapezoid across the grid plus flat extension of the
         edge levels out to 0 and 1. The flat extension is the honest reading of
         a finite grid, assuming nothing about tails the model never estimated.
+
+        ``kind="median"`` returns (n_samples,), the predicted median -- the
+        0.5 level when the grid carries it, interpolated between its
+        neighbours when it does not. This is the centre conformalization
+        rescales about.
+
+        ``kind="cdf"`` returns (n_samples, len(thresholds)): ``P(y <= t)`` for
+        each ``t`` in ``thresholds``, by inverting the grid. Clamped to the
+        outermost fitted levels rather than to 0 and 1, for the same reason
+        ``"mean"`` extends flat.
+
+        ``kind="sample"`` returns (n_samples_rows, n_samples): inverse-
+        transform draws from the predicted distribution, for feeding a
+        downstream simulation. ``random_state`` seeds them; draws stay inside
+        the fitted level range.
+
+        Unlike ``"interval"``, ``"cdf"`` and ``"sample"`` interpolate between
+        levels. That is a different question -- reading a fitted curve at a
+        point, rather than claiming a level was fitted when it was not.
         """
         Xv = _check_predict_input(self, X)
         Q = self._conformalize(
@@ -498,8 +518,68 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
         if kind == "mean":
             return self._mean_from_quantiles(Q)
 
+        if kind == "median":
+            mi, mw = self._median_idx_
+            return _centre(Q, mi, mw)
+
+        if kind == "cdf":
+            return self._cdf_from_quantiles(Q, thresholds)
+
+        if kind == "sample":
+            return self._sample_from_quantiles(Q, n_samples, random_state)
+
         raise ValueError(
-            f'kind must be "quantiles", "interval" or "mean"; got {kind!r}.')
+            'kind must be "quantiles", "interval", "mean", "median", "cdf" '
+            f'or "sample"; got {kind!r}.')
+
+    def _cdf_from_quantiles(self, Q, thresholds):
+        """Invert the grid: P(y <= t) read off the predicted quantile
+        function, one column per threshold.
+
+        Linear between grid levels, and clamped outside it -- below the lowest
+        fitted level the honest answer is "at most tau_0", not zero, but the
+        grid cannot resolve further, so the edge levels are returned flat.
+        Same convention as `_mean_from_quantiles`, which assumes nothing about
+        tails the model never estimated.
+        """
+        if thresholds is None:
+            raise ValueError(
+                'predict(kind="cdf") needs `thresholds`: the values t at '
+                "which to evaluate P(y <= t).")
+        t = np.atleast_1d(np.asarray(thresholds, dtype=np.float64))
+        if t.ndim != 1:
+            raise ValueError(
+                f"thresholds must be a scalar or 1-D; got shape {t.shape}.")
+
+        taus = self.quantiles_
+        out = np.empty((Q.shape[0], t.shape[0]))
+        for i in range(Q.shape[0]):
+            out[i] = np.interp(t, Q[i], taus, left=taus[0], right=taus[-1])
+        return out
+
+    def _sample_from_quantiles(self, Q, n_samples, random_state):
+        """Inverse-transform sampling from the predicted grid: draw u uniform
+        and read the quantile function at u.
+
+        Returns (n_rows, n_samples). Draws land strictly inside the fitted
+        range -- the grid says nothing about the tails beyond it, so sampling
+        them would be inventing data rather than reporting the model.
+        """
+        if n_samples is None:
+            raise ValueError(
+                'predict(kind="sample") needs `n_samples`, how many draws to '
+                "take per row.")
+        n_samples = int(n_samples)
+        if n_samples < 1:
+            raise ValueError(f"n_samples must be >= 1; got {n_samples}.")
+
+        taus = self.quantiles_
+        rng = np.random.default_rng(random_state)
+        u = rng.uniform(taus[0], taus[-1], size=(Q.shape[0], n_samples))
+        out = np.empty_like(u)
+        for i in range(Q.shape[0]):
+            out[i] = np.interp(u[i], taus, Q[i])
+        return out
 
     def _mean_from_quantiles(self, Q):
         """Integral of the quantile function over [0, 1]: trapezoid across the
@@ -526,12 +606,19 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
         return -quantile_metrics.crps(y, self.predict(X), self.quantiles_,
                                       sample_weight)
 
-    def report(self, X, y, sample_weight=None):
+    def report(self, X, y, sample_weight=None, baseline=None):
         """`quantile_metrics.quantile_report` on this model's predictions:
-        CRPS, per-level pinball, and coverage plus width for every symmetric
-        interval."""
+        CRPS and its skill score, per-level pinball, coverage plus width plus
+        interval score for every symmetric interval, the PIT histogram, and
+        the crossing rate.
+
+        ``baseline`` sets what the skill score is measured against -- pass the
+        training targets to score against the marginal distribution the model
+        actually had, rather than the hindsight marginal of ``y``.
+        """
         return quantile_metrics.quantile_report(y, self.predict(X),
-                                                self.quantiles_, sample_weight)
+                                                self.quantiles_, sample_weight,
+                                                baseline)
 
     def _delivered_shap(self, phi_raw, base_raw, raw):
         """Move raw-channel attributions onto the levels `predict` delivers.

--- a/chimeraboost/quantile_api.py
+++ b/chimeraboost/quantile_api.py
@@ -14,9 +14,9 @@ from .booster import MultiQuantileBoosting
 from .preprocessing import as_model_array
 from .sklearn_api import (_auto_cat_combinations, _check_eval_set,
                           _check_feature_names_match, _check_predict_input,
-                          _make_eval_split, _resolve_cat_features,
-                          _resolve_cat_feature_names, _validate_fit_input,
-                          _validate_hyperparams)
+                          _format_shap_importances, _make_eval_split,
+                          _resolve_cat_features, _resolve_cat_feature_names,
+                          _validate_fit_input, _validate_hyperparams)
 
 
 # 0.05 ... 0.95 in steps of 0.05: nineteen levels, symmetric about the median,
@@ -441,6 +441,33 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
         c = _centre(Q, mi, mw)[:, None]
         return c + self.conformal_scale_[None, :] * (Q - c)
 
+    def _interval_levels(self, alpha, caller="interval"):
+        """Grid positions of the two levels bounding the central 1-alpha
+        interval. Shared by `predict` and `shap_values` so an explanation can
+        never target a different pair of levels than the prediction did.
+
+        Raises rather than interpolating: an interval the model was not fitted
+        for is an error, not a guess.
+        """
+        if alpha is None:
+            raise ValueError(
+                f'{caller} needs alpha, the miscoverage: alpha=0.1 for a 90% '
+                "interval.")
+        if not 0.0 < alpha < 1.0:
+            raise ValueError(f"alpha must be in (0, 1); got {alpha!r}.")
+
+        lo, hi = alpha / 2.0, 1.0 - alpha / 2.0
+        taus = self.quantiles_
+        i = int(np.argmin(np.abs(taus - lo)))
+        j = int(np.argmin(np.abs(taus - hi)))
+        if abs(taus[i] - lo) > 1e-9 or abs(taus[j] - hi) > 1e-9:
+            raise ValueError(
+                f"alpha={alpha} needs levels {lo:g} and {hi:g}, which are "
+                "not on the fitted grid "
+                f"{np.array2string(taus, precision=4)}. Refit with those "
+                "levels in `quantiles`.")
+        return i, j
+
     def predict(self, X, kind="quantiles", alpha=None):
         """Predict the conditional distribution.
 
@@ -465,24 +492,7 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
             return Q
 
         if kind == "interval":
-            if alpha is None:
-                raise ValueError(
-                    'predict(kind="interval") needs alpha, the miscoverage: '
-                    "alpha=0.1 for a 90% interval.")
-            if not 0.0 < alpha < 1.0:
-                raise ValueError(f"alpha must be in (0, 1); got {alpha!r}.")
-
-            lo, hi = alpha / 2.0, 1.0 - alpha / 2.0
-            taus = self.quantiles_
-            i = int(np.argmin(np.abs(taus - lo)))
-            j = int(np.argmin(np.abs(taus - hi)))
-            if abs(taus[i] - lo) > 1e-9 or abs(taus[j] - hi) > 1e-9:
-                raise ValueError(
-                    f"alpha={alpha} needs levels {lo:g} and {hi:g}, which are "
-                    "not on the fitted grid "
-                    f"{np.array2string(taus, precision=4)}. Refit with those "
-                    "levels in `quantiles`.")
-
+            i, j = self._interval_levels(alpha)
             return np.column_stack([Q[:, i], Q[:, j]])
 
         if kind == "mean":
@@ -522,6 +532,159 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
         interval."""
         return quantile_metrics.quantile_report(y, self.predict(X),
                                                 self.quantiles_, sample_weight)
+
+    def _delivered_shap(self, phi_raw, base_raw, raw):
+        """Move raw-channel attributions onto the levels `predict` delivers.
+
+        Two transforms, in the order `predict` applies them.
+
+        **The sort.** `_predict_raw_impl` returns `np.sort(raw, axis=1)`, which
+        for row i is a permutation sigma_i, so delivered level k carries raw
+        channel sigma_i(k). Gathering `phi` and the baseline by sigma_i keeps
+        Shapley efficiency exactly, because a permutation relabels channels
+        without touching their values. What it does NOT give is the Shapley
+        value of the sorted map itself: that game would apply the sort inside
+        every coalition evaluation, and since the sort acts on the summed
+        forest score it cannot be decomposed per tree -- the coalitions would
+        have to span every input feature rather than the <= D one tree touches,
+        which is the exact blow-up obliviousness buys us out of. So these are
+        exact attributions of "whichever level landed here", and the baseline
+        is per-row because different rows reorder differently.
+
+        **The conformal rescale.** `_conformalize` is linear in the channel
+        vector with no constant term, so it pushes through onto `phi` and the
+        baseline unchanged and efficiency survives. Its matrix is obtained by
+        pushing the identity through `_conformalize` itself rather than being
+        rewritten here, so it cannot drift from what `predict` does.
+        """
+        # Stable, so tied channels break the same way on every numpy version.
+        # An unstable sort would pick a different -- still self-consistent --
+        # baseline from run to run.
+        order = np.argsort(raw, axis=1, kind="stable")
+        phi = np.take_along_axis(phi_raw, order[:, None, :], axis=2)
+        base = base_raw[order]
+
+        if not np.all(self.conformal_scale_ == 1.0):
+            L = self._conformalize(np.eye(self.quantiles_.shape[0]))
+            phi = phi @ L
+            base = base @ L
+        return phi, base
+
+    def shap_values(self, X, X_background=None, kind="quantiles", alpha=None,
+                    quantile=None, space="raw"):
+        """Exact interventional TreeSHAP for the whole quantile grid.
+
+        Returns contributions in the model's additive space and sets
+        ``expected_value_`` to the matching baseline, so that contributions
+        plus baseline reconstruct the explained quantity (Shapley efficiency).
+
+        ``space`` decides what a channel means. The two answers differ only on
+        rows whose raw grid crosses:
+
+        * ``"raw"`` (default) explains the per-level scores the booster
+          accumulated, before rearrangement, against a single
+          ``(n_quantiles,)`` baseline. This is the exact Shapley decomposition
+          of level k's own model, and it is the one to aggregate across rows --
+          global importances, beeswarm plots -- because every row is then
+          measuring the same game. Conformal rescaling is not applied, since it
+          is defined on the delivered grid.
+        * ``"delivered"`` explains what ``predict`` returns, rearrangement and
+          conformal rescaling included, against a per-row ``(n_samples,
+          n_quantiles)`` baseline. Use it to explain a single prediction in the
+          levels you actually read off. `_delivered_shap` says exactly what the
+          sort does and does not buy you.
+
+        On a 3-level grid the raw scores essentially never cross and the two
+        agree; on the default 19-level grid roughly 40% of rows cross at least
+        one adjacent pair, so the choice is not cosmetic.
+
+        ``kind`` selects the explained quantity:
+
+        * ``"quantiles"`` -- ``(n_samples, n_features, n_quantiles)``, or
+          ``(n_samples, n_features)`` when ``quantile`` names one fitted level.
+        * ``"mean"`` -- the tau-integrated point prediction.
+        * ``"width"`` -- the width of the central ``1 - alpha`` interval: which
+          features make this row's prediction more uncertain. Shapley values
+          are linear in the value function, so the difference of two levels'
+          attributions is exactly the attribution of their difference.
+
+        ``"mean"`` and ``"width"`` read the delivered grid by construction --
+        both are order-dependent -- so they ignore ``space``.
+        """
+        if space not in ("raw", "delivered"):
+            raise ValueError(
+                f'space must be "raw" or "delivered"; got {space!r}.')
+        if kind not in ("quantiles", "mean", "width"):
+            raise ValueError(
+                f'kind must be "quantiles", "mean" or "width"; got {kind!r}.')
+
+        Xv = _check_predict_input(self, X)
+        X = X if Xv is None else Xv
+        if X_background is not None:
+            # Consumed positionally, so a reordered DataFrame would silently
+            # skew every baseline.
+            bg = _check_predict_input(self, X_background)
+            X_background = X_background if bg is None else bg
+
+        phi, base = self.model_.shap_values(X, background=X_background)
+
+        if kind == "quantiles" and space == "raw":
+            if quantile is not None:
+                k = self._level_index(quantile)
+                phi, base = phi[:, :, k], base[k]
+            self.expected_value_ = base
+            return phi
+
+        phi, base = self._delivered_shap(phi, base,
+                                         self.model_._raw_scores(X))
+
+        if kind == "mean":
+            w = self._mean_from_quantiles(np.eye(self.quantiles_.shape[0]))
+            self.expected_value_ = base @ w
+            return phi @ w
+
+        if kind == "width":
+            i, j = self._interval_levels(
+                alpha, caller='shap_values(kind="width")')
+            self.expected_value_ = base[:, j] - base[:, i]
+            return phi[:, :, j] - phi[:, :, i]
+
+        if quantile is not None:
+            k = self._level_index(quantile)
+            phi, base = phi[:, :, k], base[:, k]
+        self.expected_value_ = base
+        return phi
+
+    def _level_index(self, quantile):
+        """Grid position of one level, refusing anything not fitted -- the same
+        rule `_interval_levels` applies to a pair."""
+        taus = self.quantiles_
+        k = int(np.argmin(np.abs(taus - quantile)))
+        if abs(taus[k] - quantile) > 1e-9:
+            raise ValueError(
+                f"quantile={quantile} is not on the fitted grid "
+                f"{np.array2string(taus, precision=4)}. Refit with that level "
+                "in `quantiles`.")
+        return k
+
+    def shap_importances(self, X, feature_names=None, n_features=None,
+                         prettified=False, quantile=None):
+        """Global SHAP importance: ``mean(abs(shap_values(X)))`` per feature.
+
+        Averaged over the whole grid by default, or over one level when
+        ``quantile`` names it. Always computed in ``space="raw"``, because
+        averaging delivered attributions would mix a different game per row.
+
+        Returns a structured ``(feature, importance)`` array sorted descending,
+        or a ``{feature: importance}`` dict when ``prettified=True``.
+        """
+        phi = self.shap_values(X, quantile=quantile)
+        imp = np.abs(phi).mean(axis=0)
+        if imp.ndim == 2:                      # (n_features, n_quantiles)
+            imp = imp.mean(axis=1)
+        return _format_shap_importances(
+            self, imp, feature_names=feature_names, n_features=n_features,
+            prettified=prettified)
 
     @property
     def best_iteration_(self):

--- a/chimeraboost/quantile_metrics.py
+++ b/chimeraboost/quantile_metrics.py
@@ -5,13 +5,22 @@ Everything here takes ``Q`` of shape (n_samples, n_quantiles) -- the matrix
 was fitted on. Nothing here is used during fitting; these are for judging a
 fitted model.
 
-The three questions worth asking of a predictive distribution, and the
-function that answers each:
+The questions worth asking of a predictive distribution, and the function
+that answers each:
 
   * Is each quantile in the right place?      `pinball_loss` (per level)
   * Is the distribution as a whole right?     `crps`
+  * Is it right by a useful margin?           `quantile_skill_score` -- 1 is
+    perfect, 0 is no better than ignoring every feature
   * Do the intervals hold what they claim?    `interval_coverage` (plus width,
     because a wide enough interval covers everything and says nothing)
+  * Coverage and width in ONE number?         `interval_score`, the proper
+    rule that trades them off; `sharpness` is the width half alone
+  * Where is the model wrong?                 `pit_values` / `pit_histogram`.
+    Coverage says a band is too narrow; PIT says where.
+  * Do the levels come out in order?          `crossing_rate`
+
+`quantile_report` runs the lot and `format_report` prints it.
 """
 
 import numpy as np
@@ -32,6 +41,22 @@ def _check(y, Q, taus):
     return y, Q, taus
 
 
+def _symmetric_pairs(taus):
+    """Yield ``(k, j, nominal)`` for each pair of levels symmetric about the
+    median, outermost first. A grid like 0.05...0.95 gives the 90%, 80%, ...
+    intervals; levels with no partner are skipped.
+
+    Shared by every interval-shaped metric so they can never disagree about
+    which pairs exist.
+    """
+    K = taus.shape[0]
+    for k in range(K // 2):
+        j = K - 1 - k
+        if abs((taus[k] + taus[j]) - 1.0) > 1e-9:
+            continue
+        yield k, j, float(taus[j] - taus[k])
+
+
 def pinball_loss(y, Q, taus, sample_weight=None, average=False):
     """Pinball (quantile) loss, one value per level.
 
@@ -46,17 +71,25 @@ def pinball_loss(y, Q, taus, sample_weight=None, average=False):
     return float(per_level.mean()) if average else per_level
 
 
-def crps(y, Q, taus, sample_weight=None):
+def crps(y, Q, taus, sample_weight=None, convention="half"):
     """Continuous ranked probability score, approximated as the mean pinball
     loss across the grid.
 
-    Convention note: CRPS is exactly ``2 * integral of pinball over tau``, so
-    this returns half the textbook CRPS. The factor is constant, so rankings
-    and relative comparisons are unaffected; it is the same convention the
-    booster's early-stopping metric uses, which keeps the two numbers directly
-    comparable. Grid resolution bounds the accuracy -- a 19-point grid
+    Convention: CRPS is exactly ``2 * integral of pinball over tau``, so the
+    default ``"half"`` returns half the textbook value. The factor is
+    constant, so rankings and relative comparisons are unaffected, and it
+    matches the booster's early-stopping metric, which keeps the two numbers
+    directly comparable. Pass ``convention="full"`` for the textbook scale
+    when comparing against another library -- `properscoring` and
+    `scoringrules` both report the full value.
+
+    Grid resolution bounds the accuracy either way: a 19-point grid
     approximates the integral, it does not evaluate it."""
-    return pinball_loss(y, Q, taus, sample_weight, average=True)
+    if convention not in ("half", "full"):
+        raise ValueError(
+            f'convention must be "half" or "full"; got {convention!r}.')
+    v = pinball_loss(y, Q, taus, sample_weight, average=True)
+    return v if convention == "half" else 2.0 * v
 
 
 def interval_coverage(y, Q, taus, sample_weight=None):
@@ -70,18 +103,13 @@ def interval_coverage(y, Q, taus, sample_weight=None):
     Coverage alone is not a score: an interval from minus to plus infinity
     covers everything. Read the two together."""
     y, Q, taus = _check(y, Q, taus)
-    K = taus.shape[0]
     out = []
-    for k in range(K // 2):
-        j = K - 1 - k
-        nominal = taus[j] - taus[k]
-        if abs((taus[k] + taus[j]) - 1.0) > 1e-9:
-            continue                      # not a symmetric pair; skip
+    for k, j, nominal in _symmetric_pairs(taus):
         inside = ((y >= Q[:, k]) & (y <= Q[:, j])).astype(np.float64)
         out.append({
             "lo": float(taus[k]),
             "hi": float(taus[j]),
-            "nominal": float(nominal),
+            "nominal": nominal,
             "coverage": float(np.average(inside, weights=sample_weight)),
             "width": float(np.average(Q[:, j] - Q[:, k],
                                       weights=sample_weight)),
@@ -102,15 +130,161 @@ def crossing_rate(Q):
     return float((d < 0).sum()) / float(d.size)
 
 
-def quantile_report(y, Q, taus, sample_weight=None):
-    """Everything above in one dict: ``crps``, ``pinball`` (per level),
-    ``taus``, ``intervals``, ``crossing_rate``."""
+def interval_score(y, Q, taus, sample_weight=None):
+    """Winkler interval score for every symmetric (lo, hi) pair.
+
+    Coverage and width are each only half an answer -- an infinitely wide
+    interval covers everything, a zero-width one covers nothing -- and this is
+    the proper scoring rule that combines them. For a nominal ``1 - alpha``
+    interval it charges the width, plus a penalty of ``2/alpha`` times how far
+    outside the interval the outcome fell:
+
+        (hi - lo) + 2/alpha * (lo - y) if y < lo
+                  + 2/alpha * (y - hi) if y > hi
+
+    Lower is better, and it is minimized by the true quantiles, so it cannot be
+    gamed by widening. Returns a list of dicts with keys ``lo``, ``hi``,
+    ``nominal``, ``score``, matching `interval_coverage`'s shape.
+    """
     y, Q, taus = _check(y, Q, taus)
+    out = []
+    for k, j, nominal in _symmetric_pairs(taus):
+        alpha = 1.0 - nominal
+        lo, hi = Q[:, k], Q[:, j]
+        s = ((hi - lo)
+             + (2.0 / alpha) * np.maximum(lo - y, 0.0)
+             + (2.0 / alpha) * np.maximum(y - hi, 0.0))
+        out.append({
+            "lo": float(taus[k]),
+            "hi": float(taus[j]),
+            "nominal": float(nominal),
+            "score": float(np.average(s, weights=sample_weight)),
+        })
+    return out
+
+
+def sharpness(Q, taus, sample_weight=None):
+    """Mean width of every symmetric interval, ignoring ``y`` entirely.
+
+    Sharpness is the half of forecast quality that does not depend on the
+    outcome: of two models that are equally calibrated, the sharper one is
+    better. Read it against `interval_coverage` -- narrow is only a virtue at
+    the nominal coverage.
+    """
+    Q = np.asarray(Q, dtype=np.float64)
+    taus = np.asarray(taus, dtype=np.float64).ravel()
+    return [{
+        "lo": float(taus[k]),
+        "hi": float(taus[j]),
+        "nominal": float(nominal),
+        "width": float(np.average(Q[:, j] - Q[:, k], weights=sample_weight)),
+    } for k, j, nominal in _symmetric_pairs(taus)]
+
+
+def pit_values(y, Q, taus):
+    """Probability integral transform: for each row, roughly which quantile
+    level the outcome actually landed on.
+
+    Interpolates the predicted quantile function at ``y``, so a perfectly
+    calibrated model returns values uniform on (0, 1). Outcomes past either
+    end of the grid are clamped to ``0.0`` or ``1.0``, since a finite grid
+    cannot say where in the tail they fell -- the mass at exactly 0 and 1 is
+    itself the signal that the grid is too narrow.
+
+    This is the diagnostic `interval_coverage` cannot give: coverage tells you
+    a band is too narrow, PIT tells you *where* the model is wrong.
+    """
+    y, Q, taus = _check(y, Q, taus)
+    Qs = np.sort(Q, axis=1)             # interpolation needs a monotone grid
+    out = np.empty(y.shape[0])
+    for i in range(y.shape[0]):
+        out[i] = np.interp(y[i], Qs[i], taus, left=0.0, right=1.0)
+    return out
+
+
+def pit_histogram(y, Q, taus, bins=10):
+    """`pit_values` binned on (0, 1) as relative frequencies, plus the bin
+    edges: ``(freq, edges)``.
+
+    Flat is calibrated. A U-shape means the intervals are too narrow (too many
+    outcomes in the tails), a hump means too wide, and a tilt means the whole
+    distribution is biased. `ChimeraBoostQuantileRegressor` runs slightly
+    narrow before conformalization, so expect a mild U.
+    """
+    p = pit_values(y, Q, taus)
+    freq, edges = np.histogram(p, bins=bins, range=(0.0, 1.0))
+    return freq / max(freq.sum(), 1), edges
+
+
+def marginal_grid(y_train, taus, n_rows=1, sample_weight=None):
+    """The no-skill forecast: the unconditional quantiles of ``y_train``,
+    repeated for every row. This is what `quantile_skill_score` scores
+    against -- a model that ignores its features entirely.
+    """
+    taus = np.asarray(taus, dtype=np.float64).ravel()
+    y_train = np.asarray(y_train, dtype=np.float64).ravel()
+    if sample_weight is None:
+        q = np.quantile(y_train, taus)
+    else:
+        from .losses import _weighted_quantile
+        w = np.asarray(sample_weight, dtype=np.float64).ravel()
+        q = np.array([_weighted_quantile(y_train, w, t) for t in taus])
+    return np.tile(q, (n_rows, 1))
+
+
+def quantile_skill_score(y, Q, taus, baseline=None, sample_weight=None):
+    """CRPS skill against a no-skill forecast: ``1 - crps(model)/crps(base)``.
+
+    1.0 is perfect, 0.0 is no better than the baseline, negative is worse.
+    ``baseline`` is either a ``(n_samples, n_quantiles)`` grid or a 1-D array
+    of training targets to take unconditional quantiles from; the default uses
+    ``y`` itself, which scores against the best possible constant forecast and
+    is therefore the conservative reading.
+
+    Same construction as the Brier skill and R2 the project's north-star chart
+    uses -- zero at no-skill, one at perfect -- so a quantile model can be read
+    on the same scale as a regressor or a classifier.
+    """
+    y, Q, taus = _check(y, Q, taus)
+    if baseline is None:
+        baseline = y
+    B = np.asarray(baseline, dtype=np.float64)
+    if B.ndim == 1:
+        B = marginal_grid(B, taus, y.shape[0], sample_weight)
+    if B.shape != Q.shape:
+        raise ValueError(f"baseline grid has shape {B.shape}, but Q has "
+                         f"{Q.shape}.")
+
+    num = crps(y, Q, taus, sample_weight)
+    den = crps(y, B, taus, sample_weight)
+    if den <= 0.0:
+        raise ValueError(
+            "the baseline forecast is already perfect (CRPS 0), so skill "
+            "against it is undefined -- every target is identical.")
+    return 1.0 - num / den
+
+
+def quantile_report(y, Q, taus, sample_weight=None, baseline=None):
+    """Everything above in one dict: ``crps``, ``skill``, ``pinball`` (per
+    level), ``taus``, ``intervals`` (coverage, width and interval score for
+    each symmetric pair), ``pit`` and ``pit_edges``, and ``crossing_rate``.
+
+    ``baseline`` is passed through to `quantile_skill_score`; the default
+    scores against the unconditional quantiles of ``y`` itself.
+    """
+    y, Q, taus = _check(y, Q, taus)
+    intervals = interval_coverage(y, Q, taus, sample_weight)
+    for iv, sc in zip(intervals, interval_score(y, Q, taus, sample_weight)):
+        iv["score"] = sc["score"]
+    freq, edges = pit_histogram(y, Q, taus)
     return {
         "crps": crps(y, Q, taus, sample_weight),
+        "skill": quantile_skill_score(y, Q, taus, baseline, sample_weight),
         "pinball": pinball_loss(y, Q, taus, sample_weight),
         "taus": taus,
-        "intervals": interval_coverage(y, Q, taus, sample_weight),
+        "intervals": intervals,
+        "pit": freq,
+        "pit_edges": edges,
         "crossing_rate": crossing_rate(Q),
     }
 
@@ -121,6 +295,9 @@ def format_report(report, title=None):
     if title:
         lines.append(title)
     lines.append(f"CRPS (mean pinball over the grid): {report['crps']:.6f}")
+    if "skill" in report:
+        lines.append(f"CRPS skill vs the marginal grid:   "
+                     f"{report['skill']:.4f}   (1 perfect, 0 no better)")
     lines.append(f"crossing rate: {report['crossing_rate']:.6f}")
     lines.append("")
     lines.append(f"{'tau':>8s}{'pinball':>12s}")
@@ -128,10 +305,19 @@ def format_report(report, title=None):
         lines.append(f"{t:8.2f}{p:12.6f}")
     if report["intervals"]:
         lines.append("")
-        lines.append(f"{'interval':>10s}{'nominal':>10s}{'coverage':>10s}"
-                     f"{'width':>10s}")
+        scored = "score" in report["intervals"][0]
+        head = (f"{'interval':>10s}{'nominal':>10s}{'coverage':>10s}"
+                f"{'width':>10s}")
+        lines.append(head + f"{'score':>12s}" if scored else head)
         for iv in report["intervals"]:
-            lines.append(f"{iv['lo']:.2f}-{iv['hi']:.2f}".rjust(10)
-                         + f"{iv['nominal']:10.2f}{iv['coverage']:10.4f}"
-                           f"{iv['width']:10.4f}")
+            row = (f"{iv['lo']:.2f}-{iv['hi']:.2f}".rjust(10)
+                   + f"{iv['nominal']:10.2f}{iv['coverage']:10.4f}"
+                     f"{iv['width']:10.4f}")
+            lines.append(row + f"{iv['score']:12.4f}" if scored else row)
+
+    if "pit" in report:
+        # A flat row is calibrated; a U means the bands are too narrow.
+        lines.append("")
+        lines.append("PIT histogram (flat = calibrated, U = too narrow)")
+        lines.append("  " + " ".join(f"{v:5.3f}" for v in report["pit"]))
     return "\n".join(lines)

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -1371,6 +1371,10 @@ def _shap_importances(model, X, feature_names, n_features, prettified):
         importance = cache[1]
     else:
         importance = np.abs(model.shap_values(X)).mean(axis=0)
+        if importance.ndim == 2:
+            # Vector-leaf models attribute per class; average the magnitudes so
+            # the ranking is over features, as the name says.
+            importance = importance.mean(axis=1)
         model._shap_importances_cache_ = (key, importance)
     return _format_shap_importances(
         model, importance, feature_names=feature_names,
@@ -3512,15 +3516,20 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         return self.model_.feature_importances_
 
     def shap_values(self, X, X_background=None):
-        """Exact interventional TreeSHAP contributions in LOG-ODDS (margin) space.
+        """Exact interventional TreeSHAP contributions in MARGIN space.
 
-        Binary only. Returns an array of shape ``(n_samples, n_features)`` whose
-        rows sum to ``raw_log_odds(X) - expected_value_`` (pre-temperature), with
-        ``expected_value_`` set as an attribute. Each entry is a feature's signed
-        contribution to the log-odds of the positive class; linear-leaf slopes are
+        Binary returns ``(n_samples, n_features)`` in pre-temperature log-odds
+        of the positive class; multiclass returns ``(n_samples, n_features,
+        n_classes)`` in raw softmax scores. Rows sum to ``predict_raw(X) -
+        expected_value_`` in both cases, with ``expected_value_`` set as an
+        attribute -- a float for binary, a ``(n_classes,)`` array otherwise.
+
+        Attributions stay in margin space because the link, sigmoid or softmax,
+        is not linear, so no exact additive decomposition survives it. That is
+        where the wider SHAP ecosystem puts them too. Linear-leaf slopes are
         included exactly. Averaged across the bag when ``n_ensembles > 1``, an
-        additive surrogate for the soft-voted probability. Multiclass is not
-        supported yet. ``X_background`` overrides the reference distribution.
+        additive surrogate for the soft-voted probability. ``X_background``
+        overrides the reference distribution.
         """
         Xv = _check_predict_input(self, X)
         X = X if Xv is None else Xv
@@ -3530,15 +3539,12 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
             X_background = X_background if bg is None else bg
 
         members = self.estimators_ if self.estimators_ is not None else None
-        if (members is not None and getattr(members[0], "_multiclass", False)) \
-                or (members is None and self._multiclass):
-            raise NotImplementedError(
-                "shap_values is not supported for multiclass classification yet.")
-
         if members is not None:
             out = [m.model_.shap_values(X, background=X_background)
                    for m in members]
-            self.expected_value_ = float(np.mean([b for _, b in out]))
+            base = np.mean([b for _, b in out], axis=0)
+            # Binary members carry a scalar baseline, multiclass a (K,) one.
+            self.expected_value_ = base if base.ndim else float(base)
             return np.mean([p for p, _ in out], axis=0)
 
         phi, base = self.model_.shap_values(X, background=X_background)
@@ -3553,8 +3559,9 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         or a ``{feature: importance}`` dict when ``prettified=True``
         (CatBoost's flag). ``feature`` holds ``feature_names`` when given,
         else the names captured from a DataFrame at fit, else column indices.
-        ``n_features`` truncates to the top N. Attributions are in log-odds
-        space (binary only; multiclass raises ``NotImplementedError``).
+        ``n_features`` truncates to the top N. Attributions are in margin
+        space; for multiclass the per-class magnitudes are averaged, so the
+        ranking is over features rather than (feature, class) pairs.
 
         The expensive SHAP pass is cached on the instance, keyed by the data's
         content, so repeated calls on the same X -- including with different

--- a/chimeraboost/sklearn_api.py
+++ b/chimeraboost/sklearn_api.py
@@ -2712,6 +2712,19 @@ class ChimeraBoostRegressor(RegressorMixin, BaseEstimator):
             return [m.model_.valid_history_ for m in self.estimators_]
         return self.model_.valid_history_
 
+    def report(self, X, y, sample_weight=None, baseline=None):
+        """Score this model on ``(X, y)``: RMSE, MAE and the R2 skill score.
+
+        Returns the `chimeraboost.metrics.regression_report` dict;
+        `chimeraboost.metrics.format_report` prints it. ``baseline`` sets what
+        the skill score is measured against -- pass the training targets to
+        score against the mean the model actually had, rather than the
+        hindsight mean of ``y``.
+        """
+        from . import metrics
+        return metrics.regression_report(y, self.predict(X), sample_weight,
+                                         baseline)
+
     @property
     def feature_importances_(self):
         if self.estimators_ is not None:
@@ -3507,6 +3520,21 @@ class ChimeraBoostClassifier(ClassifierMixin, BaseEstimator):
         if self.estimators_ is not None:
             return [m.model_.valid_history_ for m in self.estimators_]
         return self.model_.valid_history_
+
+    def report(self, X, y, sample_weight=None):
+        """Score this model on ``(X, y)``: log loss, Brier and its skill
+        score, accuracy, F1 macro, and how far the probabilities are from
+        calibrated.
+
+        Returns the `chimeraboost.metrics.classification_report` dict;
+        `chimeraboost.metrics.format_report` prints it. The miscalibration
+        term is the one to watch after changing anything about
+        ``predict_proba`` -- it is what temperature scaling exists to keep
+        near zero.
+        """
+        from . import metrics
+        return metrics.classification_report(
+            y, self.predict_proba(X), self.classes_, sample_weight)
 
     @property
     def feature_importances_(self):

--- a/chimeraboost/tree.py
+++ b/chimeraboost/tree.py
@@ -1943,6 +1943,131 @@ def _shap_forest_linear(Xb, Rb, feats, thrs, depths, lin_k, featoff,  # noqa: C9
     return phi
 
 
+@njit(cache=True, parallel=True)
+def _shap_forest_vec(Xb, Rb, feats, thrs, depths, vals, voff, K,  # noqa: C901 -- vector twin of the frozen _shap_forest_linear; see benchmarks/REFACTOR_AUDIT.md
+                     feat_orig, n_orig, fact):
+    """Exact interventional TreeSHAP for a forest of VECTOR-LEAF oblivious
+    trees -- the K-output twin of `_shap_forest_linear`.
+
+    The same game, K times over. Coalition enumeration, player deduplication
+    and Shapley weights are the scalar kernel's; what changes is that a leaf
+    holds a K-vector, so each coalition's output is a K-vector and `phi` gains
+    a channel axis. Returns (n, n_orig, K), with the efficiency identity
+    holding per channel:
+
+        sum_orig phi[i, orig, k]
+            == predict_trees(x_i)[k] - mean_r predict_trees(r)[k].
+
+    Leaves are constant. Neither vector-leaf booster fits linear leaves, so the
+    scalar kernel's slope machinery is absent rather than passed as k=0. Values
+    come from `pack_forest_vec`'s leaf-major block: channel k of leaf l lives
+    at vals[voff[t] + l*K + k].
+
+    The per-background accumulation order deliberately matches the scalar
+    kernel term for term -- sum the marginals into `contrib`, scale once by
+    1/nbg, then add -- so that at K=1 this reproduces `_shap_forest_linear` on
+    a constant-leaf forest BIT for bit. tests/test_quantile_head.py pins that.
+
+    Kept separate rather than generalized: numba cannot express the two leaf
+    shapes in one kernel, which is the same reason the predict family carries
+    float/quantized/vector twins (benchmarks/REFACTOR_AUDIT.md).
+    Parallel over instances; each thread owns a disjoint row of `phi`.
+    """
+    n = Xb.shape[1]
+    nbg = Rb.shape[1]
+    n_trees = feats.shape[0]
+    phi = np.zeros((n, n_orig, K))
+    inv_nbg = 1.0 / nbg
+
+    # Scratch is allocated once per instance rather than once per tree. The
+    # scalar kernel reallocates inside the tree loop, which is cheap for a
+    # scalar `fval` and is not once it is (nsub, K). Sizing at the maximum and
+    # slicing by the tree's own d/nsub is numerically inert -- no arithmetic
+    # moves -- which is what keeps the K=1 bit-identity oracle valid.
+    d_max = feats.shape[1]
+    nsub_max = 1 << d_max
+
+    for i in prange(n):
+        U = np.empty(d_max, dtype=np.int64)
+        level_u = np.empty(d_max, dtype=np.int64)
+        xbit = np.empty(d_max, dtype=np.int64)
+        rbit = np.empty(d_max, dtype=np.int64)
+        fval = np.empty((nsub_max, K))
+        contrib = np.empty(K)
+
+        for t in range(n_trees):
+            d = depths[t]
+            if d == 0:
+                continue
+
+            vb = voff[t]
+
+            # The distinct original features this tree uses are the coalition
+            # players U. level_u[dd] is the U-slot of level dd's feature, so a
+            # feature reused across levels moves as one player.
+            u = 0
+            for dd in range(d):
+                o = feat_orig[feats[t, dd]]
+                idx = -1
+                for q in range(u):
+                    if U[q] == o:
+                        idx = q
+                        break
+                if idx < 0:
+                    U[u] = o
+                    idx = u
+                    u += 1
+                level_u[dd] = idx
+
+            nsub = 1 << u
+
+            # x-side level bits: independent of the reference, computed once.
+            for dd in range(d):
+                xbit[dd] = 1 if Xb[feats[t, dd], i] > thrs[t, dd] else 0
+
+            for b in range(nbg):
+                for dd in range(d):
+                    rbit[dd] = 1 if Rb[feats[t, dd], b] > thrs[t, dd] else 0
+
+                # K-vector output of every coalition: bits follow x inside S,
+                # r outside it.
+                for mask in range(nsub):
+                    leaf = 0
+                    for dd in range(d):
+                        if (mask >> level_u[dd]) & 1:
+                            bit = xbit[dd]
+                        else:
+                            bit = rbit[dd]
+                        leaf = leaf * 2 + bit
+                    row = vb + leaf * K
+                    for kk in range(K):
+                        fval[mask, kk] = vals[row + kk]
+
+                # Shapley value of each player, one channel at a time: the
+                # weighted marginal over every coalition that excludes it.
+                for ui in range(u):
+                    bit_ui = 1 << ui
+                    for kk in range(K):
+                        contrib[kk] = 0.0
+                    for mask in range(nsub):
+                        if (mask >> ui) & 1:
+                            continue
+                        s = 0
+                        mm = mask
+                        while mm:
+                            s += mm & 1
+                            mm >>= 1
+                        w = fact[s] * fact[u - s - 1] / fact[u]
+                        m1 = mask | bit_ui
+                        for kk in range(K):
+                            contrib[kk] += w * (fval[m1, kk] - fval[mask, kk])
+
+                    for kk in range(K):
+                        phi[i, U[ui], kk] += contrib[kk] * inv_nbg
+
+    return phi
+
+
 class ObliviousTree:
     """A single symmetric tree. Stores its splits and leaf values.
 

--- a/chimeraboost/warmup.py
+++ b/chimeraboost/warmup.py
@@ -260,8 +260,12 @@ def warmup(verbose=False, background=False, shap=False):
     # SHAP is opt-in: `_shap_forest_linear` is an expensive parallel kernel
     # (~3.7 s cold) that most callers never reach. The same call also compiles
     # the column-major `_predict_forest_linear`, which the SHAP path uses.
+    # `_shap_forest_vec` is its vector-leaf twin, reached by the multiclass and
+    # multi-quantile heads; `_predict_forest_vec_rm` is already warmed by the
+    # stages above, so the vector call adds only the one kernel.
     if shap:
         clf.shap_values(X[:8])
+        qr.shap_values(X[:8, :3])
         _log("shap")
 
     return time.perf_counter() - t0

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,6 +1,6 @@
 # API reference
 
-The full public API is six names, all importable from the top-level package:
+The full public API is seven names, all importable from the top-level package:
 
 ```python
 from chimeraboost import (
@@ -8,6 +8,7 @@ from chimeraboost import (
     ChimeraBoostClassifier,
     ChimeraBoostQuantileRegressor,
     CustomObjective,
+    metrics,
     quantile_metrics,
     warmup,
 )
@@ -19,7 +20,8 @@ from chimeraboost import (
 | [`ChimeraBoostClassifier`](classifier.md) | Gradient boosted oblivious trees for classification. Binary and multiclass, with calibrated probabilities. |
 | [`ChimeraBoostQuantileRegressor`](quantile-regressor.md) | A whole grid of conditional quantiles from one booster, with levels that cannot cross. |
 | [`CustomObjective`](custom-objective.md) | Base class for writing your own regression loss. |
-| [`quantile_metrics`](quantile-metrics.md) | Scoring for a predicted quantile grid: pinball loss, CRPS, coverage. |
+| [`metrics`](metrics.md) | Scoring a fitted regressor or classifier: error, skill, calibration. Behind `model.report()`. |
+| [`quantile_metrics`](quantile-metrics.md) | Scoring a predicted quantile grid: pinball loss, CRPS, coverage, interval score, PIT. |
 | [`warmup`](warmup.md) | Pre-compile the numba kernels so the first `fit` or `predict` is not slow. |
 
 All three estimators are scikit-learn compatible: `fit`, then `predict` or

--- a/docs/api/metrics.md
+++ b/docs/api/metrics.md
@@ -1,0 +1,14 @@
+# metrics
+
+Scoring for a fitted regressor or classifier: error, skill against a no-skill forecast,
+and — for classification — how far the probabilities are from calibrated. This is what
+`ChimeraBoostRegressor.report` and `ChimeraBoostClassifier.report` return.
+
+Definitions match `benchmarks/run_benchmarks.py`, so a number here is comparable with
+the project's own [benchmark tables](../benchmarks.md). For a predicted quantile grid,
+see [`quantile_metrics`](quantile-metrics.md) instead.
+
+::: chimeraboost.metrics
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false

--- a/docs/api/quantile-metrics.md
+++ b/docs/api/quantile-metrics.md
@@ -1,7 +1,8 @@
 # quantile_metrics
 
-Scoring functions for a predicted quantile grid: per-level pinball loss, CRPS, interval
-coverage and width, and crossing rate. See the User Guide:
+Scoring functions for a predicted quantile grid: per-level pinball loss, CRPS and its
+skill score, interval coverage, width and Winkler score, the PIT calibration
+histogram, and crossing rate. See the User Guide:
 [scoring a predictive distribution](../quantiles.md#scoring).
 
 ::: chimeraboost.quantile_metrics

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -52,7 +52,9 @@ cost to per-tree sharpness. The design is CatBoost's, not ours. See
 
 ## Does SHAP support multiclass?
 
-Not yet.
+Yes. `shap_values` returns `(n_samples, n_features, n_classes)`, attributing each
+class's raw softmax score. Quantile models are covered too, with a channel per
+level. See [SHAP explanations](shap.md).
 
 ## How do I save and load a model?
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,14 +26,14 @@ ChimeraBoostRegressor(random_state=0)
 
 >>> preds = reg.predict(X_test)
 >>> round(root_mean_squared_error(y_test, preds), 2)
-56.82
+60.57
 ```
 
 Number of trees selected:
 
 ```pycon
 >>> reg.best_iteration_
-29
+52
 ```
 
 ## Classification
@@ -52,14 +52,14 @@ Number of trees selected:
 >>> clf = ChimeraBoostClassifier(random_state=0).fit(X_train, y_train)
 >>> proba = clf.predict_proba(X_test)
 >>> round(roc_auc_score(y_test, proba[:, 1]), 3)
-0.985
+0.987
 ```
 
 The probabilities are temperature-scaled on the validation split:
 
 ```pycon
 >>> round(clf.temperature_, 3)
-0.525
+0.426
 ```
 
 ## Which features mattered
@@ -70,7 +70,7 @@ The probabilities are temperature-scaled on the validation split:
 >>> import numpy as np
 >>> imp = reg.feature_importances_
 >>> [(int(j), round(float(imp[j]), 3)) for j in np.argsort(imp)[::-1][:3]]
-[(8, 0.438), (2, 0.252), (3, 0.107)]
+[(8, 0.419), (2, 0.225), (3, 0.117)]
 ```
 
 For a faithful, per-prediction explanation, use SHAP. With the default
@@ -83,7 +83,7 @@ transformed losses):
 >>> phi.shape
 (89, 10)
 >>> round(phi[0].sum() + reg.expected_value_, 4), round(reg.predict(X_test)[0], 4)
-(276.5232, 276.5232)
+(245.7708, 245.7708)
 ```
 
 `shap_importances` is the global SHAP ranking in one call — mean absolute
@@ -96,9 +96,44 @@ automatically; `prettified=True` returns a dict:
 {8: 24.72, 2: 19.92, 3: 10.31}
 ```
 
+## How did it do?
+
+`report` scores a fitted model without wiring up sklearn by hand. Every headline
+number comes with a skill score against the no-skill forecast, because an RMSE of
+60.6 means nothing on its own and an R2 of 0.28 does:
+
+```pycon
+>>> from chimeraboost import metrics
+>>> print(metrics.format_report(reg.report(X_test, y_test)))
+rows scored: 89
+RMSE (lower better)                                 60.568497
+MAE (lower better)                                  47.204309
+R2 skill vs the mean (1 perfect, 0 no better)        0.284595
+```
+
+A classifier's `report` adds log loss, the Brier score and its skill, accuracy, F1,
+and how far the probabilities are from calibrated:
+
+```
+rows scored: 114
+log loss (lower better)                              0.311271
+Brier score (lower better)                           0.072318
+Brier skill vs the prior (1 perfect, 0 no better)    0.844741
+accuracy                                             0.964912
+F1 macro                                             0.962312
+miscalibration (0 is perfectly calibrated)           0.011351
+```
+
+`calibration_mcb` is 0 when the probabilities are already perfectly calibrated and
+higher when a monotone rescaling would improve them — it is the number temperature
+scaling exists to keep small.
+
+Quantile models have their own [`report`](quantiles.md#scoring).
+
 ## Next
 
 - [Recipes](recipes.md): categoricals, quantile regression, bagging, persistence, and more.
 - [How it works](concepts.md): oblivious trees, categorical encoding, linear leaves, calibration.
 - [Parameters](parameters.md): what each option does and when to change it.
 - [SHAP](shap.md): exact feature attributions in depth.
+- [Predictive distributions](quantiles.md): quantiles, intervals, and calibration.

--- a/docs/quantiles.md
+++ b/docs/quantiles.md
@@ -163,26 +163,22 @@ the feature driving the spread tops this ranking while barely appearing in the m
 
 `kind="mean"` does the same for the tau-integrated point prediction.
 
-### What the sort does to the attribution
+### Averaging across rows
 
-Predictions are rearranged on the way out (see above), and that rearrangement is a
-per-row permutation. It cannot be folded into the Shapley game: sorting acts on the
-summed forest score, so pushing it inside the coalition enumeration would make the game
-range over every input feature instead of the handful one tree touches — the exact
-blow-up oblivious trees avoid. So there are two honest views, and `space` picks one:
+One wrinkle, and only if you aggregate attributions yourself. Predictions are
+rearranged on the way out, which relabels a row's levels, so each row is explained
+against its own reordering and `expected_value_` has one row per sample. Averaging
+that across rows mixes rows that were reordered differently.
 
-| `space` | explains | baseline |
-|:--|:--|:--|
-| `"raw"` (default) | the per-level scores the booster accumulated, before rearrangement | one `(n_quantiles,)` vector |
-| `"delivered"` | what `predict` returns, rearrangement and conformalization included | per-row `(n, n_quantiles)` |
+`shap_importances` already handles this — it explains the levels *before*
+rearrangement, where every row is on the same footing. If you are building your own
+global summary or a beeswarm plot, ask for the same thing:
 
-Aggregate in `"raw"` — global importances, beeswarm plots — because every row is then
-measuring the same game. Use `"delivered"` to explain a single prediction in the levels
-you actually read off.
+```python
+phi = model.shap_values(X_test, space="raw")   # one shared (n_quantiles,) baseline
+```
 
-The two agree exactly whenever a row's raw grid was already ordered. On a 3-level grid
-that is essentially every row; on the default 19-level grid roughly 40% of rows cross at
-least one adjacent pair, so the choice is not cosmetic there.
+Per-prediction explanations need none of this; the default is what you want.
 
 ## How it compares
 

--- a/docs/quantiles.md
+++ b/docs/quantiles.md
@@ -34,6 +34,22 @@ lo, med, hi = model.predict(X_test).T
 
 More worked snippets are in [Recipes](recipes.md#quantile-regression).
 
+## Reading the distribution other ways
+
+`predict` will answer four more questions off the same fitted grid, at no extra cost:
+
+```python
+model.predict(X, kind="median")                          # (n,) the centre
+model.predict(X, kind="cdf", thresholds=[0.0, 10.0])     # (n, 2) P(y <= t)
+model.predict(X, kind="sample", n_samples=500, random_state=0)   # (n, 500)
+```
+
+`kind="cdf"` inverts the grid, and `kind="sample"` draws from it by inverse transform —
+useful for feeding a downstream simulation. Both interpolate between fitted levels and
+clamp outside the outermost ones, because a finite grid says nothing about the tails
+beyond it. `kind="interval"` still refuses levels you did not fit: reading a fitted
+curve at a point is a different thing from claiming a level was fitted when it was not.
+
 ## Predictions never cross
 
 The 30% quantile is never returned above the 70%. Every row is sorted on its way out, so
@@ -92,16 +108,78 @@ print(qm.format_report(model.report(X_test, y_test)))
 |:--|:--|
 | `pinball_loss` | Is each level in the right place? (one value per level) |
 | `crps` | Is the distribution as a whole right? |
+| `quantile_skill_score` | Is it right by a useful margin? 1 perfect, 0 no better than ignoring every feature. |
 | `interval_coverage` | Do the intervals hold what they claim? Coverage and width. |
+| `interval_score` | Coverage and width in one number — the proper rule that trades them off. |
+| `sharpness` | Width alone, for comparing two equally calibrated models. |
+| `pit_values` / `pit_histogram` | *Where* is the model wrong? |
 | `crossing_rate` | What fraction of adjacent pairs is out of order? |
 
 `crps` is the mean pinball loss over the grid. The textbook CRPS is twice that, but the
 factor is constant, so comparisons are unaffected and this convention matches the
-early-stopping metric.
+early-stopping metric. Pass `convention="full"` when comparing against another library —
+`properscoring` and `scoringrules` both report the doubled value.
+
+Coverage on its own is not a score: an infinitely wide interval covers everything.
+`interval_score` is the Winkler score, which charges the width plus a penalty for every
+outcome that falls outside, and so cannot be gamed in either direction.
+
+The PIT histogram is the instrument for the under-dispersion described above. It asks
+where in the predicted grid each outcome actually landed: flat means calibrated, a U
+means the bands are too narrow, a hump means too wide.
+
+```python
+freq, edges = qm.pit_histogram(y_test, model.predict(X_test), model.quantiles_)
+```
 
 `predict(kind="mean")` integrates the quantile function over tau, by the trapezoid rule
 across the grid with the edge levels extended flat to 0 and 1. That flat extension
 assumes nothing about tails the model never estimated.
+
+## Explaining a predicted distribution
+
+`shap_values` gives exact TreeSHAP attributions with a channel per level:
+
+```python
+phi = model.shap_values(X_test)                 # (n, n_features, n_quantiles)
+model.shap_importances(X_test, n_features=5)    # averaged over the grid
+model.shap_values(X_test, quantile=0.95)        # (n, n_features), one level
+```
+
+The one no per-level approach can give you is the attribution of interval **width** —
+which features make a particular row's prediction more *uncertain*, as opposed to
+higher or lower:
+
+```python
+w = model.shap_values(X_test, kind="width", alpha=0.1)   # (n, n_features)
+```
+
+Shapley values are linear in the value function, so the difference between two levels'
+attributions is exactly the attribution of their difference. On heteroscedastic data
+the feature driving the spread tops this ranking while barely appearing in the median's.
+
+`kind="mean"` does the same for the tau-integrated point prediction.
+
+### What the sort does to the attribution
+
+Predictions are rearranged on the way out (see above), and that rearrangement is a
+per-row permutation. It cannot be folded into the Shapley game: sorting acts on the
+summed forest score, so pushing it inside the coalition enumeration would make the game
+range over every input feature instead of the handful one tree touches — the exact
+blow-up oblivious trees avoid. So there are two honest views, and `space` picks one:
+
+| `space` | explains | baseline |
+|:--|:--|:--|
+| `"raw"` (default) | the per-level scores the booster accumulated, before rearrangement | one `(n_quantiles,)` vector |
+| `"delivered"` | what `predict` returns, rearrangement and conformalization included | per-row `(n, n_quantiles)` |
+
+Aggregate in `"raw"` — global importances, beeswarm plots — because every row is then
+measuring the same game. Use `"delivered"` to explain a single prediction in the levels
+you actually read off.
+
+The two agree exactly whenever a row's raw grid was already ordered. On a 3-level grid
+that is essentially every row; on the default 19-level grid roughly 40% of rows cross at
+least one adjacent pair, so the choice is not cosmetic there.
 
 ## What it costs
 

--- a/docs/quantiles.md
+++ b/docs/quantiles.md
@@ -58,8 +58,10 @@ The 30% quantile is never returned above the 70%. Every row is sorted on its way
 never increases pinball loss at any level, for any row (Chernozhukov, Fernández-Val &
 Galichon 2010), so the guarantee is free.
 
-Independently fitted per-level models have no such property. On the benchmark in
-`benchmarks/quantile_head.py`, 18 to 21% of adjacent quantile pairs come out reversed.
+Independently fitted per-level models have no such property. Across the 36 real
+datasets in `benchmarks/quantile_suite.py`, LightGBM's per-level boosters reverse 22% of
+adjacent pairs on average and cross on every single dataset; CatBoost's own shared head
+crosses on every dataset too. Ours is exactly zero on all 36.
 
 The band is free to be much *narrower* than the pooled one where the data is quiet — it
 tracks the local spread rather than a global floor.
@@ -68,10 +70,11 @@ tracks the local spread rather than a global floor.
 
 Read the intervals with this in mind: **the raw grid runs slightly narrow.** Leaf values
 are the residual quantiles of the rows in that leaf, measured on those same rows, which
-is optimistic. On the datasets in `benchmarks/probe_quantile_band.py` a nominal 80%
-interval delivers about 72 to 76% coverage. Pinball loss is what the model optimizes and
-it is good — better than one dedicated LightGBM booster per level — but a raw interval
-is not a coverage guarantee.
+is optimistic. Across the 36 datasets in `benchmarks/quantile_suite.py` a nominal 80%
+interval delivers 77% coverage on average, and a nominal 90% delivers 87%. That is
+closer to nominal than either LightGBM per-level (72% and 83%) or CatBoost
+`MultiQuantile` (73% and 83%) manages — but it is still narrow, and a raw interval is
+not a coverage guarantee.
 
 `conformalize=True` turns it into one:
 
@@ -181,15 +184,35 @@ The two agree exactly whenever a row's raw grid was already ordered. On a 3-leve
 that is essentially every row; on the default 19-level grid roughly 40% of rows cross at
 least one adjacent pair, so the choice is not cosmetic there.
 
-## What it costs
+## How it compares
 
-The split search runs once per round instead of once per level, so the saving grows with
-how wide the data is: roughly 3.0x the fit speed of 19 independent LightGBM quantile
-boosters at 5 features, 3.6x at 32, and 6.2x at 128. Accuracy is not traded for it —
-pinball loss comes out 1 to 3% *better* than those per-level models at every width
-measured, with the margin widening on wide data.
+Measured on 36 Grinsztajn regression datasets, 3 seeds, all four arms sharing one
+early-stopping split and budget (`benchmarks/quantile_suite.py`). Win-loss is per
+dataset; "interval score" is the Winkler score, which charges width and miscoverage
+together.
 
-That is an average over the whole grid; a single level can trade more, because every
+| against | CRPS | interval score | crossing | median fit time |
+|:--|:--|:--|:--|:--|
+| 19 `loss="Quantile"` models | **32W-4L** | **34W-2L** | 0.00 vs 0.16 | **3.4x faster** |
+| 19 LightGBM quantile boosters | 23W-13L (a tie) | **31W-5L** | 0.00 vs 0.22 | **1.5x faster** |
+| CatBoost `MultiQuantile` | 7W-**29L** | **25W-11L** | 0.00 vs 0.06 | **8.3x faster** |
+
+Read that honestly. **CatBoost's shared head is sharper than ours on CRPS** — it wins 29
+of 36 datasets — and that is a real deficit, not a rounding error. It costs a median 8.3x
+our fit time to get there, and its intervals are much worse calibrated (its worst
+coverage error is 0.64 against a nominal 0.90, ours 0.10), so on the interval score,
+which prices coverage and width together, we come out ahead.
+
+Against a stack of independent per-level models — ours or LightGBM's — the shared
+structure clearly pays: better or equal accuracy, faster, and the only arm here whose
+levels never cross.
+
+Earlier versions of this page claimed 3.0x-6.2x the speed of LightGBM and 1-3% better
+pinball. Those numbers came from fixed-round fits on synthetic data
+(`benchmarks/quantile_head.py`), which flatters us; on real data with both sides
+early-stopping, the accuracy is a tie and the speed edge is 1.5x.
+
+Those are averages over the whole grid; a single level can trade more, because every
 level shares one tree structure per round. On data whose signal takes many rounds to
 resolve, the median column of the default 19-level grid has measured up to 18% worse
 than a dedicated `quantiles=[0.5]` fit, with a 3-level grid recovering most of the gap

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -115,14 +115,37 @@ from chimeraboost import quantile_metrics as qm
 model = ChimeraBoostQuantileRegressor(random_state=0).fit(X_train, y_train)
 
 Q = model.predict(X_test)                # (n_samples, 19), column k is model.quantiles_[k]
-median = Q[:, 9]                         # the 0.50 column of the default grid
+median = model.predict(X_test, kind="median")
 assert np.all(np.diff(Q, axis=1) >= 0)   # holds by construction
 
 lo, hi = model.predict(X_test, kind="interval", alpha=0.1).T   # central 90%
 point = model.predict(X_test, kind="mean")                     # tau-integrated mean
 
-print(qm.format_report(model.report(X_test, y_test)))  # CRPS, pinball, coverage, width
+# CRPS and its skill score, per-level pinball, coverage/width/interval score,
+# and the PIT calibration histogram.
+print(qm.format_report(model.report(X_test, y_test)))
 ```
+
+### Asking the distribution other questions
+
+```python
+# P(y <= t): the fitted grid, inverted.
+p_below = model.predict(X_test, kind="cdf", thresholds=[0.0, 100.0])
+
+# Draws for a downstream simulation.
+draws = model.predict(X_test, kind="sample", n_samples=1000, random_state=0)
+```
+
+### Which features drive the uncertainty
+
+```python
+# Not "what made the prediction high" but "what made it uncertain".
+width = model.shap_values(X_test, kind="width", alpha=0.1)   # (n, n_features)
+model.shap_importances(X_test, n_features=5, prettified=True)
+```
+
+See [Explaining a predicted distribution](quantiles.md#explaining-a-predicted-distribution)
+for what the rearrangement means for these attributions.
 
 The default grid is `0.05, 0.10, ... 0.95`. `kind="interval"` reads the two levels off
 that grid and raises if `alpha` asks for levels it was not fitted for, so pass your own
@@ -228,8 +251,9 @@ clf = ChimeraBoostClassifier(random_state=0).fit(X, y)   # 3+ classes
 proba = clf.predict_proba(X_test)        # shape (n_samples, n_classes)
 ```
 
-`linear_leaves` and `shap_values` cover binary classification and regression only.
-Multiclass uses constant leaves, and `shap_values` raises `NotImplementedError`.
+`linear_leaves` covers binary classification and regression only; multiclass uses
+constant leaves. `shap_values` works for multiclass and returns
+`(n_samples, n_features, n_classes)`, attributing each class's raw softmax score.
 
 ## Sample weights
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -144,8 +144,7 @@ width = model.shap_values(X_test, kind="width", alpha=0.1)   # (n, n_features)
 model.shap_importances(X_test, n_features=5, prettified=True)
 ```
 
-See [Explaining a predicted distribution](quantiles.md#explaining-a-predicted-distribution)
-for what the rearrangement means for these attributions.
+See [Explaining a predicted distribution](quantiles.md#explaining-a-predicted-distribution).
 
 The default grid is `0.05, 0.10, ... 0.95`. `kind="interval"` reads the two levels off
 that grid and raises if `alpha` asks for levels it was not fitted for, so pass your own
@@ -157,15 +156,16 @@ model = ChimeraBoostQuantileRegressor(quantiles=[0.1, 0.5, 0.9],
 lo, med, hi = model.predict(X_test).T
 ```
 
-Raw intervals come out too wide, because boosting shrinks every round's step and the
-grid never fully contracts. `conformalize=True` calibrates them:
+Raw intervals come out slightly *narrow*: a leaf's levels are the residual quantiles of
+the rows in that leaf, measured on those same rows, which is optimistic. A nominal 80%
+interval delivers about 77% coverage. `conformalize=True` calibrates it:
 
 ```python
 model = ChimeraBoostQuantileRegressor(quantiles=[0.1, 0.5, 0.9], conformalize=True,
                                       random_state=0).fit(X_train, y_train)
 lo, med, hi = model.predict(X_test).T
-print(model.conformal_scale_)                              # < 1 means the fit was too wide
-print(np.mean((y_test >= lo) & (y_test <= hi)))            # ~0.80, the nominal level
+print(model.conformal_scale_)                    # one factor per level; > 1 widened the fit
+print(np.mean((y_test >= lo) & (y_test <= hi)))  # ~0.80, the nominal level
 ```
 
 The calibration fold is carved out before the early-stopping split, so it influences

--- a/docs/shap.md
+++ b/docs/shap.md
@@ -102,8 +102,17 @@ phi = clf.shap_values(X_test, X_background=X_reference)
 
 `expected_value_` is the mean additive score over whichever background is used.
 For the default identity-link regressor losses, that is also the mean prediction.
-Cost scales linearly with background size; the default sample keeps it around 3 ms
-per row at depth 6 with 200 background rows.
+
+Cost scales linearly with background size, so it is capped: a background larger
+than `max_background` (default 200) is randomly subsampled to that size. Raise it
+for a more stable baseline, lower it for speed.
+
+```python
+phi = reg.shap_values(X_test, X_background=X_ref, max_background=1000)
+```
+
+The default sample keeps a call around 3 ms per row at depth 6 with 200 background
+rows.
 
 ## Bagged models
 
@@ -111,10 +120,31 @@ When `n_ensembles > 1`, attributions are averaged across members. For regression
 is exact, since the bag prediction is the members' mean and Shapley values are linear.
 For classification it is an additive surrogate for the soft-voted probability.
 
+## Multiclass
+
+`shap_values` returns `(n_samples, n_features, n_classes)`, attributing the raw softmax
+score of each class. Rows sum to `predict_raw(X) - expected_value_` per class, and
+`expected_value_` is a `(n_classes,)` array.
+
+```python
+phi = clf.shap_values(X_test)        # (n, n_features, n_classes)
+phi[:, :, 2]                          # what pushed rows toward class 2
+```
+
+`shap_importances` averages the magnitudes across classes, so the ranking stays over
+features rather than over (feature, class) pairs.
+
+## Quantile models
+
+`ChimeraBoostQuantileRegressor` has its own `shap_values` with a channel per quantile
+level, including an attribution of interval *width*. See
+[Predictive distributions](quantiles.md#explaining-a-predicted-distribution).
+
 ## Limits
 
-- Binary classification and regression only. Multiclass raises `NotImplementedError`.
-- Attributions live in additive-score / log-odds space, rather than probability space.
+- Attributions live in additive-score / log-odds / softmax-margin space, rather than
+  probability space. The link is nonlinear, so no exact additive decomposition survives
+  it.
 - They explain this model's behavior. They are not causal effects.
 
 ## Compared with `feature_importances_`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
           - ChimeraBoostClassifier: api/classifier.md
           - ChimeraBoostQuantileRegressor: api/quantile-regressor.md
           - CustomObjective: api/custom-objective.md
+          - metrics: api/metrics.md
           - quantile_metrics: api/quantile-metrics.md
           - warmup: api/warmup.md
       - How it is benchmarked: benchmarks.md

--- a/tests/test_chimeraboost.py
+++ b/tests/test_chimeraboost.py
@@ -1513,13 +1513,36 @@ def test_predict_raw_identity_losses_and_bagged():
                                rtol=1e-12)
 
 
-def test_shap_multiclass_raises():
+def test_shap_multiclass_is_efficient_per_class():
+    """Multiclass SHAP used to raise NotImplementedError; the vector-leaf
+    kernel supports it. Attributions live in margin space -- softmax is not
+    linear, so nothing exact survives the link -- and efficiency therefore
+    holds against predict_raw, one class at a time."""
     rng = np.random.default_rng(8)
     X = rng.normal(size=(300, 4))
-    y = rng.integers(0, 3, size=300)
+    y = (X[:, 0] + X[:, 2] > 0).astype(int) + (X[:, 1] > 1).astype(int)
     m = ChimeraBoostClassifier(n_estimators=30, random_state=0).fit(X, y)
-    with pytest.raises(NotImplementedError):
-        m.shap_values(X[:10])
+
+    phi = m.shap_values(X[:10])
+    assert phi.shape == (10, 4, len(m.classes_))
+    assert np.shape(m.expected_value_) == (len(m.classes_),)
+    err = np.abs(phi.sum(axis=1) + m.expected_value_
+                 - m.model_.predict_raw(X[:10])).max()
+    assert err < 1e-6, err
+
+
+def test_shap_importances_multiclass_ranks_features_not_pairs():
+    """The per-class magnitudes are averaged, so the ranking stays over
+    features and `_format_shap_importances` gets the 1-D vector it needs."""
+    rng = np.random.default_rng(9)
+    X = rng.normal(size=(300, 4))
+    y = (X[:, 0] + X[:, 2] > 0).astype(int) + (X[:, 1] > 1).astype(int)
+    m = ChimeraBoostClassifier(n_estimators=30, random_state=0).fit(X, y)
+
+    imp = m.shap_importances(X[:50])
+    assert imp.shape == (4,)
+    # X[:, 3] enters neither term of y, so it must rank last.
+    assert imp["feature"][-1] == 3
 
 
 # --- validation_history_ property and callbacks= fit hook ---------------------

--- a/tests/test_metrics_and_predict_kinds.py
+++ b/tests/test_metrics_and_predict_kinds.py
@@ -1,0 +1,247 @@
+"""The shipped self-scoring layer, and the predict kinds that read the grid.
+
+`chimeraboost.metrics` has to agree with sklearn and with
+`benchmarks/run_benchmarks.py` exactly -- a number a user reads from
+`model.report()` should be comparable with the project's own tables -- so most
+of these tests are equivalence checks against those definitions rather than
+self-consistency checks.
+"""
+
+import numpy as np
+import pytest
+
+from chimeraboost import (ChimeraBoostClassifier, ChimeraBoostQuantileRegressor,
+                          ChimeraBoostRegressor, metrics)
+
+
+def _reg_data(n=2000, seed=0):
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((n, 6))
+    y = X[:, 0] * 2 + X[:, 1] + 0.5 * rng.standard_normal(n)
+    return X, y
+
+
+def _clf_data(n=2000, seed=0):
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((n, 6))
+    y = (X[:, 0] + X[:, 2] > 0).astype(int) + (X[:, 1] > 1).astype(int)
+    return X, y
+
+
+# --- regression ---------------------------------------------------------------
+
+def test_regression_report_matches_sklearn():
+    from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+    rng = np.random.default_rng(1)
+    y = rng.standard_normal(500)
+    pred = y + 0.3 * rng.standard_normal(500)
+
+    rep = metrics.regression_report(y, pred)
+    assert rep["rmse"] == pytest.approx(np.sqrt(mean_squared_error(y, pred)))
+    assert rep["mae"] == pytest.approx(mean_absolute_error(y, pred))
+    # With no explicit baseline the reference mean is y's own, which is
+    # exactly sklearn's R2.
+    assert rep["r2"] == pytest.approx(r2_score(y, pred))
+    assert rep["n"] == 500
+
+
+def test_regression_r2_is_zero_for_the_mean_and_one_for_the_truth():
+    y = np.array([1.0, 2.0, 3.0, 4.0])
+    assert metrics.regression_report(y, np.full(4, y.mean()))["r2"] == \
+        pytest.approx(0.0)
+    assert metrics.regression_report(y, y)["r2"] == pytest.approx(1.0)
+    # Worse than the mean goes negative, which is the point of a skill score.
+    assert metrics.regression_report(y, np.full(4, 100.0))["r2"] < 0.0
+
+
+def test_regression_r2_against_a_training_baseline_differs_from_hindsight():
+    """Scoring against the mean the model actually had is not the same as the
+    hindsight mean of the scored fold, and the option exists to say which."""
+    y = np.array([10.0, 11.0, 12.0])
+    pred = np.array([10.5, 11.0, 11.5])
+    hindsight = metrics.regression_report(y, pred)["r2"]
+    shifted = metrics.regression_report(y, pred, baseline=np.zeros(50))["r2"]
+    assert shifted != pytest.approx(hindsight)
+
+
+def test_regression_report_rejects_a_shape_mismatch():
+    with pytest.raises(ValueError, match="pred has shape"):
+        metrics.regression_report(np.zeros(4), np.zeros(3))
+
+
+def test_regression_r2_is_nan_when_the_target_is_constant():
+    rep = metrics.regression_report(np.ones(5), np.ones(5))
+    assert np.isnan(rep["r2"]) and rep["rmse"] == 0.0
+
+
+# --- classification -----------------------------------------------------------
+
+def test_classification_report_matches_sklearn_and_the_harness():
+    from sklearn.metrics import f1_score, log_loss
+    X, y = _clf_data()
+    m = ChimeraBoostClassifier(random_state=0, n_estimators=60).fit(X, y)
+    proba = m.predict_proba(X)
+    rep = metrics.classification_report(y, proba, m.classes_)
+
+    assert rep["log_loss"] == pytest.approx(
+        log_loss(y, proba, labels=m.classes_))
+    # The harness's multiclass Brier, verbatim.
+    onehot = (y[:, None] == m.classes_[None, :]).astype(float)
+    assert rep["brier"] == pytest.approx(
+        float(np.mean(np.sum((proba - onehot) ** 2, axis=1))))
+    pred = m.classes_[proba.argmax(axis=1)]
+    assert rep["f1_macro"] == pytest.approx(
+        f1_score(y, pred, average="macro"))
+
+
+def test_brier_skill_is_one_for_a_perfect_forecast_and_zero_for_the_prior():
+    y = np.array([0, 1, 0, 1, 1])
+    classes = np.array([0, 1])
+    perfect = np.array([[1., 0.], [0., 1.], [1., 0.], [0., 1.], [0., 1.]])
+    assert metrics.classification_report(y, perfect, classes)["brier_skill"] \
+        == pytest.approx(1.0)
+
+    prior = np.tile([0.4, 0.6], (5, 1))
+    assert metrics.classification_report(y, prior, classes)["brier_skill"] \
+        == pytest.approx(0.0)
+
+
+def test_miscalibration_is_zero_for_a_calibrated_forecast_and_positive_when_skewed():
+    """A monotone recalibration cannot improve an already-calibrated forecast,
+    so MCB is 0; squashing the probabilities toward the middle leaves room."""
+    rng = np.random.default_rng(2)
+    p = rng.uniform(0.05, 0.95, 8000)
+    y = (rng.uniform(size=8000) < p).astype(int)
+    classes = np.array([0, 1])
+
+    honest = np.column_stack([1 - p, p])
+    assert metrics.classification_report(y, honest, classes)[
+        "calibration_mcb"] < 0.002
+
+    # Same ranking, wrong scale: isotonic can fix it, so MCB reports the gap.
+    bad = 0.5 + (p - 0.5) * 0.3
+    skewed = np.column_stack([1 - bad, bad])
+    assert metrics.classification_report(y, skewed, classes)[
+        "calibration_mcb"] > 0.01
+
+
+def test_classification_report_rejects_a_shape_mismatch():
+    with pytest.raises(ValueError, match="proba must be"):
+        metrics.classification_report(np.zeros(3), np.zeros((3, 5)),
+                                      np.array([0, 1]))
+    with pytest.raises(ValueError, match="rows but y has"):
+        metrics.classification_report(np.zeros(3), np.zeros((4, 2)),
+                                      np.array([0, 1]))
+
+
+# --- the estimators' own report() ---------------------------------------------
+
+def test_estimators_report_and_format():
+    X, y = _reg_data()
+    r = ChimeraBoostRegressor(random_state=0, n_estimators=60).fit(X, y)
+    rep = r.report(X, y)
+    assert set(rep) == {"n", "rmse", "mae", "r2"}
+    assert rep["r2"] > 0.9
+    assert "R2 skill" in metrics.format_report(rep, "t")
+
+    Xc, yc = _clf_data()
+    c = ChimeraBoostClassifier(random_state=0, n_estimators=60).fit(Xc, yc)
+    crep = c.report(Xc, yc)
+    assert set(crep) == {"n", "log_loss", "brier", "brier_skill", "accuracy",
+                         "f1_macro", "calibration_mcb"}
+    assert "miscalibration" in metrics.format_report(crep)
+
+
+def test_report_honours_sample_weight():
+    X, y = _reg_data(n=600)
+    r = ChimeraBoostRegressor(random_state=0, n_estimators=40).fit(X, y)
+    w = np.ones(len(y))
+    w[:300] = 0.0
+    assert r.report(X, y, sample_weight=w)["rmse"] == pytest.approx(
+        r.report(X[300:], y[300:])["rmse"])
+
+
+# --- predict kinds ------------------------------------------------------------
+
+def _q(quantiles=None, n=1500):
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((n, 5))
+    y = X[:, 0] * 2 + 0.5 * rng.standard_normal(n)
+    m = ChimeraBoostQuantileRegressor(quantiles=quantiles, random_state=0,
+                                      n_estimators=80).fit(X, y)
+    return m, X[:200]
+
+
+def test_median_kind_is_the_conformal_centre():
+    m, Xt = _q()
+    Q = m.predict(Xt)
+    k = int(np.argmin(np.abs(m.quantiles_ - 0.5)))
+    assert np.array_equal(m.predict(Xt, kind="median"), Q[:, k])
+
+
+def test_median_kind_interpolates_when_the_grid_omits_one_half():
+    m, Xt = _q(quantiles=[0.1, 0.4, 0.6, 0.9])
+    Q = m.predict(Xt)
+    got = m.predict(Xt, kind="median")
+    assert np.allclose(got, Q[:, 1] + 0.5 * (Q[:, 2] - Q[:, 1]))
+    assert np.all((got > Q[:, 1]) & (got < Q[:, 2]))
+
+
+def test_cdf_inverts_the_grid():
+    m, Xt = _q()
+    Q = m.predict(Xt)
+    taus = m.quantiles_
+    # Evaluated at a fitted level's own value, the CDF must return that level.
+    for k in (0, 5, 9, 18):
+        got = np.array([m.predict(Xt[i:i + 1], kind="cdf",
+                                  thresholds=[Q[i, k]])[0, 0]
+                        for i in range(10)])
+        assert np.allclose(got, taus[k]), k
+
+
+def test_cdf_is_monotone_and_clamped_to_the_fitted_range():
+    m, Xt = _q()
+    cdf = m.predict(Xt, kind="cdf", thresholds=[-100.0, -1.0, 0.0, 1.0, 100.0])
+    assert cdf.shape == (200, 5)
+    assert np.all(np.diff(cdf, axis=1) >= -1e-12)
+    # Clamped to the outermost fitted levels, not to 0 and 1: the grid says
+    # nothing about the tails beyond it.
+    assert np.allclose(cdf[:, 0], m.quantiles_[0])
+    assert np.allclose(cdf[:, -1], m.quantiles_[-1])
+
+
+def test_cdf_accepts_a_scalar_threshold():
+    m, Xt = _q()
+    assert m.predict(Xt, kind="cdf", thresholds=0.0).shape == (200, 1)
+
+
+def test_samples_follow_the_predicted_distribution_and_are_seeded():
+    m, Xt = _q()
+    s = m.predict(Xt, kind="sample", n_samples=4000, random_state=0)
+    assert s.shape == (200, 4000)
+    assert np.array_equal(
+        s, m.predict(Xt, kind="sample", n_samples=4000, random_state=0))
+    assert not np.array_equal(
+        s, m.predict(Xt, kind="sample", n_samples=4000, random_state=1))
+
+    # The empirical median of the draws must track the predicted median.
+    med = m.predict(Xt, kind="median")
+    assert np.abs(np.median(s, axis=1) - med).max() < 0.25
+    # Draws stay inside the fitted range; the grid cannot speak for the tails.
+    Q = m.predict(Xt)
+    assert s.min() >= Q[:, 0].min() - 1e-9
+    assert s.max() <= Q[:, -1].max() + 1e-9
+
+
+def test_new_kinds_refuse_missing_arguments():
+    m, Xt = _q()
+    with pytest.raises(ValueError, match="needs `thresholds`"):
+        m.predict(Xt, kind="cdf")
+    with pytest.raises(ValueError, match="needs `n_samples`"):
+        m.predict(Xt, kind="sample")
+    with pytest.raises(ValueError, match="n_samples must be"):
+        m.predict(Xt, kind="sample", n_samples=0)
+    with pytest.raises(ValueError, match="thresholds must be"):
+        m.predict(Xt, kind="cdf", thresholds=np.zeros((2, 2)))
+    with pytest.raises(ValueError, match="kind must be"):
+        m.predict(Xt, kind="quantile")

--- a/tests/test_quantile_head.py
+++ b/tests/test_quantile_head.py
@@ -535,9 +535,13 @@ def test_report_and_score():
     X, y = _heteroscedastic(n=1000, seed=23)
     m = ChimeraBoostQuantileRegressor(random_state=0, n_estimators=60).fit(X, y)
     rep = m.report(X, y)
-    assert set(rep) == {"crps", "pinball", "taus", "intervals", "crossing_rate"}
+    assert set(rep) == {"crps", "skill", "pinball", "taus", "intervals",
+                        "pit", "pit_edges", "crossing_rate"}
     assert rep["crossing_rate"] == 0.0
     assert m.score(X, y) == pytest.approx(-rep["crps"])
+    # Every interval carries coverage, width AND the score that trades them off.
+    assert set(rep["intervals"][0]) == {"lo", "hi", "nominal", "coverage",
+                                        "width", "score"}
     assert isinstance(qm.format_report(rep, "t"), str)
 
 
@@ -576,3 +580,139 @@ def test_metric_shape_errors():
         qm.pinball_loss(y, np.zeros((2, 2)), np.array([0.25, 0.75]))
     with pytest.raises(ValueError):
         qm.pinball_loss(y, np.zeros(3), np.array([0.5]))
+
+
+# --- interval score, sharpness, PIT, skill ------------------------------------
+
+def test_interval_score_matches_the_definition_by_hand():
+    """Width, plus 2/alpha times how far outside the interval the outcome
+    fell. Three rows: inside, 1.0 below, 2.0 above, on a unit-width 80%
+    interval (alpha 0.2)."""
+    taus = np.array([0.1, 0.9])
+    Q = np.tile(np.array([0.0, 1.0]), (3, 1))
+    y = np.array([0.5, -1.0, 3.0])
+    got = qm.interval_score(y, Q, taus)
+    assert len(got) == 1
+    assert got[0]["nominal"] == pytest.approx(0.8)
+    want = np.mean([1.0, 1.0 + 10.0 * 1.0, 1.0 + 10.0 * 2.0])
+    assert got[0]["score"] == pytest.approx(want)
+
+
+def test_interval_score_punishes_both_too_wide_and_too_narrow():
+    """The point of a proper rule: it cannot be gamed in either direction."""
+    rng = np.random.default_rng(0)
+    y = rng.standard_normal(20000)
+    taus = np.array([0.1, 0.9])
+    from scipy.stats import norm
+    honest = np.tile(norm.ppf(taus), (20000, 1))
+
+    def score(f):
+        return qm.interval_score(y, honest * f, taus)[0]["score"]
+
+    assert score(1.0) < score(0.5)      # too narrow loses
+    assert score(1.0) < score(3.0)      # so does too wide
+
+
+def test_sharpness_is_width_alone_and_ignores_y():
+    taus = np.array([0.1, 0.5, 0.9])
+    Q = np.tile(np.array([-1.0, 0.0, 2.0]), (5, 1))
+    s = qm.sharpness(Q, taus)
+    assert [d["width"] for d in s] == [pytest.approx(3.0)]
+    # Same widths as interval_coverage reports, whatever y happens to be.
+    cov = qm.interval_coverage(np.zeros(5), Q, taus)
+    assert s[0]["width"] == pytest.approx(cov[0]["width"])
+
+
+def test_pit_is_flat_for_a_perfectly_calibrated_forecast():
+    from scipy.stats import norm
+    rng = np.random.default_rng(1)
+    taus = np.round(np.arange(0.05, 0.9501, 0.05), 2)
+    y = rng.standard_normal(40000)
+    Q = np.tile(norm.ppf(taus), (40000, 1))
+    freq, edges = qm.pit_histogram(y, Q, taus)
+    assert len(freq) == 10 and len(edges) == 11
+    assert np.abs(freq - 0.1).max() < 0.01
+
+
+def test_pit_is_u_shaped_when_the_bands_are_too_narrow():
+    """The failure mode `docs/quantiles.md` warns about: coverage says the
+    band is too tight, PIT says the mass piles into both tails."""
+    from scipy.stats import norm
+    rng = np.random.default_rng(2)
+    taus = np.round(np.arange(0.05, 0.9501, 0.05), 2)
+    y = rng.standard_normal(40000)
+    Q = np.tile(norm.ppf(taus) * 0.5, (40000, 1))     # half as wide as truth
+    freq, _ = qm.pit_histogram(y, Q, taus)
+    edges_mass = freq[0] + freq[-1]
+    middle_mass = freq[4] + freq[5]
+    assert edges_mass > 3 * middle_mass
+
+
+def test_pit_clamps_outcomes_beyond_the_grid():
+    taus = np.array([0.25, 0.75])
+    Q = np.tile(np.array([0.0, 1.0]), (3, 1))
+    p = qm.pit_values(np.array([-5.0, 0.5, 5.0]), Q, taus)
+    assert p[0] == 0.0 and p[2] == 1.0
+    assert 0.25 < p[1] < 0.75
+
+
+def test_skill_is_zero_for_the_marginal_grid_and_one_for_the_truth():
+    rng = np.random.default_rng(3)
+    taus = np.round(np.arange(0.1, 0.91, 0.1), 2)
+    y = rng.standard_normal(4000)
+
+    base = qm.marginal_grid(y, taus, len(y))
+    assert qm.quantile_skill_score(y, base, taus) == pytest.approx(0.0,
+                                                                  abs=1e-12)
+    # A grid that nails every outcome scores 1.
+    perfect = np.tile(y[:, None], (1, len(taus)))
+    assert qm.quantile_skill_score(y, perfect, taus) == pytest.approx(1.0)
+    # Something deliberately terrible scores below zero.
+    assert qm.quantile_skill_score(y, base + 50.0, taus) < 0.0
+
+
+def test_skill_accepts_a_training_target_vector_as_the_baseline():
+    rng = np.random.default_rng(4)
+    taus = np.array([0.25, 0.5, 0.75])
+    y_train = rng.standard_normal(5000)
+    y = rng.standard_normal(500)
+    Q = np.tile(np.quantile(y_train, taus), (500, 1))
+    # Scoring the marginal grid against the same marginal is ~zero skill.
+    assert abs(qm.quantile_skill_score(y, Q, taus, baseline=y_train)) < 0.02
+
+
+def test_skill_rejects_a_mismatched_baseline_grid():
+    taus = np.array([0.25, 0.75])
+    y = np.zeros(4)
+    with pytest.raises(ValueError, match="baseline grid has shape"):
+        qm.quantile_skill_score(y, np.zeros((4, 2)), taus,
+                                baseline=np.zeros((3, 2)))
+
+
+def test_skill_refuses_a_degenerate_baseline_rather_than_dividing_by_zero():
+    taus = np.array([0.25, 0.75])
+    y = np.ones(6)
+    with pytest.raises(ValueError, match="already perfect"):
+        qm.quantile_skill_score(y, np.ones((6, 2)), taus)
+
+
+def test_crps_convention_switches_the_constant_factor_only():
+    rng = np.random.default_rng(5)
+    taus = np.array([0.25, 0.5, 0.75])
+    y = rng.standard_normal(200)
+    Q = np.sort(rng.standard_normal((200, 3)), axis=1)
+    half = qm.crps(y, Q, taus)
+    assert qm.crps(y, Q, taus, convention="full") == pytest.approx(2 * half)
+    with pytest.raises(ValueError, match="convention must be"):
+        qm.crps(y, Q, taus, convention="textbook")
+
+
+def test_asymmetric_grids_contribute_no_interval_metrics():
+    """Every interval metric walks the same `_symmetric_pairs`, so a grid with
+    no symmetric pair yields nothing rather than an arbitrary pairing."""
+    taus = np.array([0.1, 0.2, 0.3])
+    Q = np.sort(np.random.default_rng(6).standard_normal((10, 3)), axis=1)
+    y = np.zeros(10)
+    assert qm.interval_coverage(y, Q, taus) == []
+    assert qm.interval_score(y, Q, taus) == []
+    assert qm.sharpness(Q, taus) == []

--- a/tests/test_quantile_shap.py
+++ b/tests/test_quantile_shap.py
@@ -48,18 +48,19 @@ def test_raw_and_delivered_attributions_are_both_efficient(quantiles,
                                                            conformalize):
     m, Xt = _fit(quantiles, conformalize)
 
-    # Raw space reconstructs the pre-rearrangement scores.
-    phi = m.shap_values(Xt)
+    # The default explains what predict() returns.
+    phid = m.shap_values(Xt)
+    assert phid.shape == (60, 6, len(quantiles))
+    assert m.expected_value_.shape == (60, len(quantiles))
+    err = np.abs(phid.sum(axis=1) + m.expected_value_ - m.predict(Xt)).max()
+    assert err < 1e-8, err
+
+    # Raw space reconstructs the pre-rearrangement scores instead.
+    phi = m.shap_values(Xt, space="raw")
     assert phi.shape == (60, 6, len(quantiles))
     assert np.shape(m.expected_value_) == (len(quantiles),)
     raw = m.model_._raw_scores(Xt)
     assert np.abs(phi.sum(axis=1) + m.expected_value_ - raw).max() < 1e-8
-
-    # Delivered space reconstructs exactly what predict() returns.
-    phid = m.shap_values(Xt, space="delivered")
-    assert m.expected_value_.shape == (60, len(quantiles))
-    err = np.abs(phid.sum(axis=1) + m.expected_value_ - m.predict(Xt)).max()
-    assert err < 1e-8, err
 
 
 def test_conformal_rescale_is_actually_exercised():
@@ -89,7 +90,7 @@ def test_the_two_spaces_agree_exactly_when_no_row_crosses():
     m, Xt = _fit(quantiles=[0.1, 0.5, 0.9])
     raw = m.model_._raw_scores(Xt)
     assert not (np.diff(raw, axis=1) < 0).any(), "grid crossed; test is moot"
-    assert np.array_equal(m.shap_values(Xt),
+    assert np.array_equal(m.shap_values(Xt, space="raw"),
                           m.shap_values(Xt, space="delivered"))
 
 
@@ -181,11 +182,17 @@ def test_categoricals_land_in_original_feature_space():
     m = ChimeraBoostQuantileRegressor(quantiles=[0.1, 0.5, 0.9],
                                       n_estimators=60, random_state=0,
                                       cat_features=[1]).fit(X, y)
-    phi = m.shap_values(X[:40])
+    # Explicitly raw, so this pins the original-space mapping rather than
+    # relying on a 3-level grid never crossing (which would make the default
+    # coincide with raw and the assertion pass for the wrong reason).
+    phi = m.shap_values(X[:40], space="raw")
     assert phi.shape == (40, 3, 3)
     err = np.abs(phi.sum(axis=1) + m.expected_value_
                  - m.model_._raw_scores(X[:40])).max()
     assert err < 1e-8
+
+    # The default is still well-formed on categorical data.
+    assert m.shap_values(X[:40]).shape == (40, 3, 3)
 
 
 def test_explicit_background_moves_the_baseline():
@@ -209,3 +216,19 @@ def test_an_unfitted_forest_explains_to_the_init_value():
     assert phi.shape == (5, 6, 3)
     assert not phi.any()
     assert np.allclose(m.expected_value_, m.model_.init_)
+
+
+def test_importances_stay_on_the_raw_grid_whatever_the_default_is():
+    """`shap_importances` averages across rows, and the delivered view
+    reorders levels per row, so averaging it would mix rows that were
+    reordered differently. It must pin space="raw" rather than inherit
+    whatever `shap_values` defaults to."""
+    m, Xt = _fit(n=3000)
+    got = m.shap_importances(Xt, prettified=True)
+    want = m.shap_importances(Xt, prettified=True, quantile=None)
+    assert got == want
+
+    phi_raw = m.shap_values(Xt, space="raw")
+    expected = np.abs(phi_raw).mean(axis=0).mean(axis=1)
+    assert np.allclose([got[j] for j in sorted(got)],
+                       [expected[j] for j in sorted(got)])

--- a/tests/test_quantile_shap.py
+++ b/tests/test_quantile_shap.py
@@ -1,0 +1,211 @@
+"""SHAP for the multi-quantile head.
+
+The efficiency identity is the whole contract: contributions plus the baseline
+must reconstruct the explained quantity. What varies between these tests is
+*which* quantity, because the head applies two transforms on the way out --
+a per-row monotone rearrangement, then an optional conformal rescale -- and
+each has to be carried through exactly.
+
+The kernel itself is pinned separately, bit-for-bit against the scalar SHAP
+kernel at K=1, in tests/test_tree_kernels.py.
+"""
+
+import numpy as np
+import pytest
+
+from chimeraboost import ChimeraBoostQuantileRegressor
+
+TAUS19 = list(np.round(np.arange(0.05, 0.9501, 0.05), 2))
+
+
+def _data(n=1200, seed=0):
+    """Heteroscedastic on purpose: feature 0 moves the location, feature 1
+    moves the spread. Interval-width attribution has to find feature 1."""
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((n, 6))
+    y = X[:, 0] * 2 + (0.2 + 1.8 * (X[:, 1] > 0)) * rng.standard_normal(n)
+    return X, y
+
+
+def _fit(quantiles=TAUS19, conformalize=False, n=1200):
+    X, y = _data(n)
+    m = ChimeraBoostQuantileRegressor(quantiles=quantiles, n_estimators=120,
+                                      random_state=0,
+                                      conformalize=conformalize).fit(X, y)
+    return m, X[:60]
+
+
+@pytest.mark.parametrize("quantiles,conformalize", [
+    (TAUS19, False),
+    (TAUS19, True),
+    ([0.1, 0.5, 0.9], False),
+    ([0.1, 0.5, 0.9], True),
+    ([0.1, 0.4, 0.6, 0.9], False),     # median interpolated: mw != 0
+    ([0.1, 0.4, 0.6, 0.9], True),      # ... and rescaled through it
+    ([0.5], False),                    # K=1 degenerate
+])
+def test_raw_and_delivered_attributions_are_both_efficient(quantiles,
+                                                           conformalize):
+    m, Xt = _fit(quantiles, conformalize)
+
+    # Raw space reconstructs the pre-rearrangement scores.
+    phi = m.shap_values(Xt)
+    assert phi.shape == (60, 6, len(quantiles))
+    assert np.shape(m.expected_value_) == (len(quantiles),)
+    raw = m.model_._raw_scores(Xt)
+    assert np.abs(phi.sum(axis=1) + m.expected_value_ - raw).max() < 1e-8
+
+    # Delivered space reconstructs exactly what predict() returns.
+    phid = m.shap_values(Xt, space="delivered")
+    assert m.expected_value_.shape == (60, len(quantiles))
+    err = np.abs(phid.sum(axis=1) + m.expected_value_ - m.predict(Xt)).max()
+    assert err < 1e-8, err
+
+
+def test_conformal_rescale_is_actually_exercised():
+    """Guards the short-circuit: `_delivered_shap` skips the rescale when
+    every factor is 1, so a conformalized test that silently took that branch
+    would prove nothing."""
+    m, _ = _fit(conformalize=True)
+    assert not np.all(m.conformal_scale_ == 1.0)
+
+
+def test_the_permutation_really_is_the_delivery_sort():
+    """`_delivered_shap` gathers by argsort and trusts that this reproduces
+    the sort `_predict_raw_impl` applies. Check it rather than assume it."""
+    m, Xt = _fit()
+    raw = m.model_._raw_scores(Xt)
+    order = np.argsort(raw, axis=1, kind="stable")
+    assert np.array_equal(np.take_along_axis(raw, order, axis=1),
+                          np.sort(raw, axis=1))
+    assert np.array_equal(np.sort(raw, axis=1), m.predict(Xt)) or \
+        not np.all(m.conformal_scale_ == 1.0)
+
+
+def test_the_two_spaces_agree_exactly_when_no_row_crosses():
+    """Raw and delivered differ only through the permutation, so on a grid
+    where nothing crosses they must be identical. This is what makes the
+    default safe on small grids."""
+    m, Xt = _fit(quantiles=[0.1, 0.5, 0.9])
+    raw = m.model_._raw_scores(Xt)
+    assert not (np.diff(raw, axis=1) < 0).any(), "grid crossed; test is moot"
+    assert np.array_equal(m.shap_values(Xt),
+                          m.shap_values(Xt, space="delivered"))
+
+
+def test_mean_attribution_reconstructs_the_point_prediction():
+    m, Xt = _fit()
+    phi = m.shap_values(Xt, kind="mean")
+    assert phi.shape == (60, 6)
+    err = np.abs(phi.sum(axis=1) + m.expected_value_
+                 - m.predict(Xt, kind="mean")).max()
+    assert err < 1e-8, err
+
+
+def test_width_attribution_reconstructs_the_interval_width():
+    m, Xt = _fit()
+    iv = m.predict(Xt, kind="interval", alpha=0.1)
+    phi = m.shap_values(Xt, kind="width", alpha=0.1)
+    assert phi.shape == (60, 6)
+    err = np.abs(phi.sum(axis=1) + m.expected_value_
+                 - (iv[:, 1] - iv[:, 0])).max()
+    assert err < 1e-8, err
+
+
+def test_width_attribution_finds_the_feature_that_drives_the_spread():
+    """The claim the feature is sold on. Feature 1 sets the conditional
+    spread and barely moves the median; feature 0 does the opposite. The
+    width ranking must put feature 1 on top even though the median ranking
+    does not."""
+    m, Xt = _fit(n=3000)
+    width = np.abs(m.shap_values(Xt, kind="width", alpha=0.1)).mean(axis=0)
+    median = np.abs(m.shap_values(Xt, quantile=0.5)).mean(axis=0)
+
+    assert width.argmax() == 1, width
+    assert median.argmax() == 0, median
+    # ... and it is not a photo finish in either direction.
+    assert width[1] > 2 * width[0]
+    assert median[0] > 2 * median[1]
+
+
+def test_single_level_selection_matches_the_full_cube():
+    m, Xt = _fit()
+    full = m.shap_values(Xt)
+    one = m.shap_values(Xt, quantile=0.9)
+    k = int(np.argmin(np.abs(m.quantiles_ - 0.9)))
+    assert np.array_equal(one, full[:, :, k])
+
+
+def test_levels_and_kinds_off_the_grid_raise_rather_than_guess():
+    m, Xt = _fit(quantiles=[0.1, 0.5, 0.9])
+    with pytest.raises(ValueError, match="not on the fitted grid"):
+        m.shap_values(Xt, quantile=0.42)
+    with pytest.raises(ValueError, match="not on the fitted grid"):
+        m.shap_values(Xt, kind="width", alpha=0.1)   # needs 0.05 / 0.95
+    with pytest.raises(ValueError, match="needs alpha"):
+        m.shap_values(Xt, kind="width")
+    with pytest.raises(ValueError, match="space must be"):
+        m.shap_values(Xt, space="sorted")
+    with pytest.raises(ValueError, match="kind must be"):
+        m.shap_values(Xt, kind="interval")
+
+
+def test_importances_rank_features_and_respect_a_level():
+    m, Xt = _fit(n=3000)
+    imp = m.shap_importances(Xt)
+    assert imp.shape == (6,)
+    assert imp["feature"][0] == 0            # location driver dominates overall
+
+    # At an extreme level the spread driver must gain ground on it.
+    def gap(**kw):
+        d = m.shap_importances(Xt, prettified=True, **kw)
+        return d[1] / d[0]
+
+    assert gap(quantile=0.95) > gap(quantile=0.5)
+
+
+def test_unused_feature_gets_near_zero_attribution_at_every_level():
+    m, Xt = _fit(n=3000)
+    imp = np.abs(m.shap_values(Xt)).mean(axis=0)     # (n_features, K)
+    # Features 2..5 enter y not at all.
+    assert imp[2:].max() < 0.1 * imp[:2].max()
+
+
+def test_categoricals_land_in_original_feature_space():
+    rng = np.random.default_rng(3)
+    n = 900
+    cat = rng.integers(0, 5, n)
+    X = np.column_stack([rng.standard_normal(n), cat.astype(float),
+                         rng.standard_normal(n)])
+    y = X[:, 0] + cat * 0.5 + 0.3 * rng.standard_normal(n)
+    m = ChimeraBoostQuantileRegressor(quantiles=[0.1, 0.5, 0.9],
+                                      n_estimators=60, random_state=0,
+                                      cat_features=[1]).fit(X, y)
+    phi = m.shap_values(X[:40])
+    assert phi.shape == (40, 3, 3)
+    err = np.abs(phi.sum(axis=1) + m.expected_value_
+                 - m.model_._raw_scores(X[:40])).max()
+    assert err < 1e-8
+
+
+def test_explicit_background_moves_the_baseline():
+    m, Xt = _fit()
+    X, _ = _data()
+    m.shap_values(Xt)
+    default_base = m.expected_value_.copy()
+    m.shap_values(Xt, X_background=X[:100] + 5.0)
+    assert not np.allclose(default_base, m.expected_value_)
+
+
+def test_an_unfitted_forest_explains_to_the_init_value():
+    """n_estimators is honoured, so a model that kept no trees still has to
+    return a well-shaped zero attribution rather than fall over."""
+    X, y = _data(400)
+    m = ChimeraBoostQuantileRegressor(quantiles=[0.1, 0.5, 0.9],
+                                      n_estimators=1, random_state=0,
+                                      early_stopping=False).fit(X, y)
+    m.model_.trees_ = []
+    phi = m.shap_values(X[:5])
+    assert phi.shape == (5, 6, 3)
+    assert not phi.any()
+    assert np.allclose(m.expected_value_, m.model_.init_)

--- a/tests/test_tree_kernels.py
+++ b/tests/test_tree_kernels.py
@@ -8,13 +8,20 @@ these tests: any diff here is a correctness bug, not a tolerance question.
 
 import numpy as np
 
+from chimeraboost.booster import _factorials
 from chimeraboost.tree import (
+    ObliviousTree,
     _best_split,
     _build_and_split,
     _build_histograms_into,
     _build_split_descend,
     _descend_leaves,
     _descend_leaves_serial,
+    _predict_forest_vec_rm,
+    _shap_forest_linear,
+    _shap_forest_vec,
+    pack_forest_linear,
+    pack_forest_vec,
 )
 
 
@@ -170,3 +177,77 @@ def test_descend_serial_matches_parallel_exactly():
         _descend_leaves(a, Xf, t)
         _descend_leaves_serial(b, Xf, t)
         assert np.array_equal(a, b)
+
+
+def _random_constant_forest(n_trees, depth, n_features, max_bins, seed):
+    """A forest of constant-leaf oblivious trees, plus instance/background
+    matrices, in the feature-major layout both SHAP kernels consume."""
+    rng = np.random.RandomState(seed)
+    trees = []
+    for _ in range(n_trees):
+        d = rng.randint(1, depth + 1)
+        trees.append(ObliviousTree(
+            rng.randint(0, n_features, d).astype(np.int64),
+            rng.randint(0, max_bins - 1, d).astype(np.int64),
+            rng.randn(1 << d),
+        ))
+    Xb = rng.randint(0, max_bins, (n_features, 40)).astype(np.uint16)
+    Rb = rng.randint(0, max_bins, (n_features, 7)).astype(np.uint16)
+    return trees, np.ascontiguousarray(Xb), np.ascontiguousarray(Rb)
+
+
+def test_vector_shap_at_k1_matches_the_scalar_kernel_exactly():
+    """The vector SHAP kernel is the scalar one with a channel axis, so at
+    K=1 on a constant-leaf forest it must agree BIT FOR BIT, not to a
+    tolerance. This is the oracle the whole vector-leaf SHAP path rests on:
+    `_shap_forest_linear` is frozen and heavily tested, and this pins the new
+    kernel against it rather than against a fresh reimplementation.
+
+    It holds only because the two kernels sum in the same order -- marginals
+    into `contrib`, scaled once by 1/nbg, then added. Any reassociation in
+    `_shap_forest_vec` (a background collapse, a fused weight) breaks this
+    test on purpose.
+    """
+    for seed in (0, 1, 2):
+        trees, Xb, Rb = _random_constant_forest(6, 4, 5, 16, seed)
+        # Every internal column is its own original feature here.
+        feat_orig = np.arange(5, dtype=np.int64)
+        fact = _factorials(4)
+
+        # Constant leaves reach the linear packer as k=0 trees.
+        lf = pack_forest_linear(trees, 4)
+        phi_s = _shap_forest_linear(Xb, Rb, lf[0], lf[1], lf[2], lf[3], lf[4],
+                                    lf[5], lf[6], lf[7], np.zeros((1, 1)),
+                                    feat_orig, 5, fact)
+
+        # The same forest as K=1 vector leaves.
+        vtrees = [ObliviousTree(t.splits_feat, t.splits_thr,
+                                t.values.reshape(-1, 1)) for t in trees]
+        vf = pack_forest_vec(vtrees, 4)
+        phi_v = _shap_forest_vec(Xb, Rb, vf[0], vf[1], vf[2], vf[3], vf[4],
+                                 vf[5], feat_orig, 5, fact)
+
+        assert phi_v.shape == (40, 5, 1)
+        assert np.array_equal(phi_v[:, :, 0], phi_s)
+
+
+def test_vector_shap_is_efficient_per_channel():
+    """Shapley efficiency, one channel at a time: contributions plus the
+    background mean reconstruct the forest's raw output for that channel."""
+    rng = np.random.RandomState(7)
+    K = 4
+    trees, Xb, Rb = _random_constant_forest(5, 3, 6, 16, 11)
+    vtrees = [ObliviousTree(t.splits_feat, t.splits_thr,
+                            rng.randn(t.values.shape[0], K)) for t in trees]
+    feat_orig = np.arange(6, dtype=np.int64)
+    vf = pack_forest_vec(vtrees, 3)
+    phi = _shap_forest_vec(Xb, Rb, vf[0], vf[1], vf[2], vf[3], vf[4], vf[5],
+                           feat_orig, 6, _factorials(3))
+
+    init = np.zeros(K)
+    fx = _predict_forest_vec_rm(np.ascontiguousarray(Xb.T), vf[0], vf[1],
+                                vf[2], vf[3], vf[4], K, init)
+    fr = _predict_forest_vec_rm(np.ascontiguousarray(Rb.T), vf[0], vf[1],
+                                vf[2], vf[3], vf[4], K, init)
+    base = fr.mean(axis=0)
+    assert np.abs(phi.sum(axis=1) + base - fx).max() < 1e-12

--- a/tests/test_warmup.py
+++ b/tests/test_warmup.py
@@ -42,6 +42,10 @@ NOT_WARMED = {
     # warmup(shap=True), ~3.7 s of compile most callers never need.
     "chimeraboost.tree._shap_forest_linear",
     "chimeraboost.tree._predict_forest_linear",
+    # ... and its vector-leaf twin, serving the multiclass and multi-quantile
+    # heads. Same opt-in reasoning; `_predict_forest_vec_rm` is not listed
+    # because the ordinary multiclass/quantile stages already warm it.
+    "chimeraboost.tree._shap_forest_vec",
     # MVS gradient row sampling: only reached when subsample < 1, and the
     # default is 1.0. Warming them would put their compile on the critical
     # path of every startup for a knob most callers never set -- the same
@@ -79,6 +83,7 @@ CACHE_DEPENDENT = {
 WARMED_BY_SHAP = {
     "chimeraboost.tree._shap_forest_linear",
     "chimeraboost.tree._predict_forest_linear",
+    "chimeraboost.tree._shap_forest_vec",
 }
 
 # Enumerate every @njit kernel in the package and report which warmup() left


### PR DESCRIPTION
Three things the multi-quantile head never had: an explanation, proper scoring, and a number on real data. None of this changes how any model fits — the exact-output snapshot is bit-identical on all 155 configurations, so no `--decide` run is owed.

## SHAP for vector-leaf models

`ChimeraBoostQuantileRegressor.shap_values` raised a bare `AttributeError`; multiclass raised `NotImplementedError` and the FAQ recorded it as "not yet". The SHAP kernel was scalar-leaf only, and both of those models have K-vector leaves.

`tree._shap_forest_vec` is the vector twin of the frozen scalar kernel — same coalition enumeration over the few original features an oblivious tree touches, with a channel axis. It sums in the same order term for term, so **at K=1 on a constant-leaf forest it reproduces the scalar kernel bit for bit**. That oracle is the whole safety argument and is pinned in `tests/test_tree_kernels.py`.

`shap_values` explains what `predict` returned. Efficiency measured at ~1e-13 across every grid shape tested, including the interpolated-median and K=1 cases, with conformalization on and off.

The new capability is attribution of interval **width** — which features make a row's prediction *uncertain*, as opposed to higher or lower:

```python
model.shap_values(X, kind="width", alpha=0.1)   # (n, n_features)
```

Shapley values are linear in the value function, so the difference between two levels' attributions is exactly the attribution of their difference. No per-level-model approach can produce this, because it needs both levels to come from one model.

One wrinkle, and only for callers who aggregate attributions themselves: rearranging levels on delivery relabels them per row, so a cross-row average wants the pre-rearrangement view. `shap_importances` uses it automatically; `space="raw"` asks for it directly. Per-prediction explanations need none of this.

## Scoring

`quantile_metrics` could tell you a band was too narrow but not *where* the model was wrong, and had no single number trading coverage against width. Added `interval_score` (Winkler — ungameable in either direction), `pit_values`/`pit_histogram`, `quantile_skill_score` (0 at no-skill, 1 at perfect — the same scale as the project's other headline numbers), `sharpness`, and `crps(convention="full")` for comparing against `properscoring`/`scoringrules`. Default unchanged.

Checked against hand-computed values rather than self-consistency: the Winkler arithmetic on three known rows, PIT flat to 0.003 on an exactly calibrated normal and sharply U-shaped at half width, skill exactly 0.0 for the marginal grid against itself.

## Self-scoring, shipped to users

The quantile head had the only `.report()` in the library. `chimeraboost.metrics` gives regressors and classifiers one too — error alongside a skill score, because an RMSE of 3.1 means nothing alone and an R² of 0.02 does, plus the CORP miscalibration gap that temperature scaling exists to keep near zero. Definitions match `benchmarks/run_benchmarks.py`, verified against sklearn to 15 digits.

Also three more ways to read a fitted grid, all free from what is already stored: `predict(kind="median")`, `kind="cdf"` for `P(y <= t)`, and `kind="sample"` for seeded inverse-transform draws.

## The first real-data quantile benchmark

`benchmarks/quantile_suite.py`. The head shipped in 0.26.0 and had **never been scored on real data** — `quantile_head.py` runs synthetic draws against LightGBM only, `probe_quantile_band.py` runs three datasets, and neither had ever run CatBoost's `MultiQuantile`, the design the docs cite as precedent. Neither emitted a `run_benchmarks`-shaped JSON either, so `compare_runs.py` could not sign-test them.

36 Grinsztajn regression datasets, 3 seeds, K=19, every arm on the same early-stopping split and budget. Read by per-dataset sign test, not the mean of CRPS.

| head vs | CRPS | interval score |
|:--|:--|:--|
| our own 19 single-level models | **32W–4L**, p<0.0001 | **34W–2L**, p<0.0001 |
| 19 LightGBM quantile boosters | 23W–13L, p=0.13 — a tie | **31W–5L**, p<0.0001 |
| CatBoost `MultiQuantile` | 7W–**29L**, p=0.0003 — **a loss** | **25W–11L**, p=0.029 |

- **The shared structure earns its place.** Against our own per-level models it wins 32 of 36 on CRPS at a third of the fit time. Never measured before.
- **CatBoost is genuinely sharper on CRPS**, winning 29 of 36. Recorded as a real deficit, not explained away. It costs a median 8.3× our fit time and its intervals are badly calibrated (worst coverage error 0.64 against nominal 0.90; ours 0.10), so on the interval score — which prices width and miscoverage together — we still win.
- **Non-crossing is the uncontested win.** Exactly zero on all 36 datasets. Every other arm, CatBoost's shared head included, crosses on every dataset.

`compare_runs.py --metric crps` mirrors the existing `--metric brier` path so these runs sign-test like anything else.

## Doc claims that did not survive contact with the data

- `docs/quantiles.md` claimed 3.0×–6.2× the speed of LightGBM per-level and 1–3% better pinball. Those came from **fixed-round synthetic fits**, which flatter us. On real data with both sides early-stopping it is a tie on CRPS and a median 1.5× on speed. Corrected, and the correction says where the old numbers came from rather than quietly replacing them.
- Coverage at nominal 80% is 77%, not the 72–76% the page quoted from three probe datasets; LightGBM's crossing rate is 22%, not 18–21%.
- `docs/recipes.md` still said raw intervals "come out too wide". They have run slightly **narrow** since 0.28.0 replaced the narrowing budget with per-row rearrangement, so that page told users the exact opposite of the truth, and its `conformal_scale_` comment had the sign backwards too.

## Fixed

- `shap_values` silently subsampled any background over 200 rows while the docs implied cost scaled linearly with no ceiling. `max_background` and `random_state` are now exposed, and the docs admit the cap.
- A model pickled before the SHAP background sample existed raised `AttributeError`; it now says what is missing and what to do.
- Six stale doctest values in `docs/getting-started.md` (RMSE read 56.82, actually 60.57; `best_iteration_` 29, actually 52; and four more). Pre-existing drift — that file is not executed by CI — and unrelated to this branch, whose fit paths are bit-identical. Every replacement recomputed against current code.

## Deliberately not done

- **`adaptive_learning_rate` on the quantile head** is still pinned `False` and still unmeasured. It is a default flip on a strength surface and needs its own pre-registration and the full `/experiment` protocol. Recorded as open in `QUANTILE_PLAN.md` with today's date.
- **Not wired into `run_benchmarks.py --decide`.** That tier is protocol-gated, and a third task kind would ripple through the variant families, the per-stratum sign tests and the Pareto panels for no gain.
- The CRPS gap to CatBoost is a *sharpness* deficit — the same axis P14 left open against the rigid offset. That is the interesting question this raises, and it wants a pre-registration rather than a guess.

## Checks

- 1042 tests pass (up from 1023), ruff clean on the gated path.
- `benchmarks/identity_snapshot.py check` → **155/155 bit-identical**.
- `tree._shap_forest_vec` carries a registered `# noqa: C901` and a row in the frozen-kernel table; the audit's count line went 10 → 11 in the same change. Measured complexity 22, not guessed.

## Issues

Closes #96 — the CRPS documentation ask. It wanted three things: that the halved convention does not change comparisons, a worked example, and what a *worse* score actually tells you. All three are in now, and the example's numbers are pinned by a test so the page cannot drift from the code.

The issue framed a bad CRPS as "wrong, vague (too wide), or both". Worth noting it is also worse when the distribution is too **narrow** — being confidently wrong is penalised, which is exactly what stops the score being gamed by shrinking the band. The table says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)