### PR TITLE
Add predict_thresh: exceedance probabilities from the quantile grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to ChimeraBoost are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+### Added
+- **`predict_thresh` on the quantile regressor (#106).** Exceedance
+  probabilities read off the fitted grid: `model.predict_thresh(X, t)` returns
+  `P(y > t)`, `direction="less"` the complement — the same inversion as
+  `predict(kind="cdf")` with the `1 - cdf` step and the naming done for you.
+  Thresholds may now also vary per row: a 2-D `(n, T)` array is read row
+  against row (in `kind="cdf"` too), so every row can carry its own line to
+  beat. 1-D always means shared, 2-D always means per-row, regardless of
+  length. Probabilities clamp to the outermost fitted levels — on the default
+  grid never below 0.05 or above 0.95 — because the model never estimated the
+  tails beyond them.
+
 ## [0.32.0] - 2026-08-30
 ### Added
 - **SHAP for the quantile head and for multiclass.** The SHAP kernel was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
   beat. 1-D always means shared, 2-D always means per-row, regardless of
   length. Probabilities clamp to the outermost fitted levels — on the default
   grid never below 0.05 or above 0.95 — because the model never estimated the
-  tails beyond them.
+  tails beyond them. Both CDF readers warn when the fitted grid is too coarse
+  to carry one (any inter-level gap above 0.2, e.g. `quantiles=[0.1, 0.5,
+  0.9]`): the answer would be mostly interpolation, not an estimate.
 
 ## [0.32.0] - 2026-08-30
 ### Added

--- a/chimeraboost/quantile_api.py
+++ b/chimeraboost/quantile_api.py
@@ -490,10 +490,12 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
         neighbours when it does not. This is the centre conformalization
         rescales about.
 
-        ``kind="cdf"`` returns (n_samples, len(thresholds)): ``P(y <= t)`` for
-        each ``t`` in ``thresholds``, by inverting the grid. Clamped to the
-        outermost fitted levels rather than to 0 and 1, for the same reason
-        ``"mean"`` extends flat.
+        ``kind="cdf"`` returns (n_samples, n_thresholds): ``P(y <= t)`` for
+        each ``t`` in ``thresholds``, by inverting the grid. A 1-D
+        ``thresholds`` is shared by every row; a 2-D (n_samples, T) array is
+        read row against row -- the rule is dimensionality, never length.
+        Clamped to the outermost fitted levels rather than to 0 and 1, for
+        the same reason ``"mean"`` extends flat.
 
         ``kind="sample"`` returns (n_samples_rows, n_samples): inverse-
         transform draws from the predicted distribution, for feeding a
@@ -532,9 +534,45 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
             'kind must be "quantiles", "interval", "mean", "median", "cdf" '
             f'or "sample"; got {kind!r}.')
 
+    def predict_thresh(self, X, thresholds, direction="greater"):
+        """Probability of the target landing beyond ``thresholds``.
+
+        ``direction="greater"`` returns ``P(y > t)``; ``"less"`` returns
+        ``P(y <= t)``. Both read the same fitted quantile function as
+        ``predict(kind="cdf")``: linear between grid levels, clamped to the
+        outermost fitted levels outside them -- on the default grid no
+        probability reads below 0.05 or above 0.95, because the model never
+        estimated those tails.
+
+        ``thresholds`` may be a scalar (one probability per row, returned
+        1-D), a 1-D array of T values shared by every row (returns
+        (n_samples, T)), or a 2-D (n_samples, T) array read row against row
+        (returns (n_samples, T)). The rule is dimensionality, never length:
+        stack several per-row threshold lists with ``np.column_stack``.
+        """
+        if direction not in ("greater", "less"):
+            raise ValueError(
+                f'direction must be "greater" or "less"; got {direction!r}.')
+        if thresholds is None:
+            raise ValueError(
+                "predict_thresh needs `thresholds`: the values t to compare "
+                "the target against.")
+        Xv = _check_predict_input(self, X)
+        Q = self._conformalize(
+            self.model_.predict_raw(X if Xv is None else Xv))
+        cdf = self._cdf_from_quantiles(Q, thresholds)
+        if np.ndim(thresholds) == 0:
+            cdf = cdf[:, 0]
+        return 1.0 - cdf if direction == "greater" else cdf
+
     def _cdf_from_quantiles(self, Q, thresholds):
         """Invert the grid: P(y <= t) read off the predicted quantile
         function, one column per threshold.
+
+        A 1-D `thresholds` is shared by every row; a 2-D one holds one row of
+        thresholds per prediction row and is read row against row. The rule is
+        dimensionality, never length -- an n-long 1-D array still means n
+        shared columns.
 
         Linear between grid levels, and clamped outside it -- below the lowest
         fitted level the honest answer is "at most tau_0", not zero, but the
@@ -547,14 +585,23 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
                 'predict(kind="cdf") needs `thresholds`: the values t at '
                 "which to evaluate P(y <= t).")
         t = np.atleast_1d(np.asarray(thresholds, dtype=np.float64))
-        if t.ndim != 1:
+        if t.ndim > 2:
             raise ValueError(
-                f"thresholds must be a scalar or 1-D; got shape {t.shape}.")
+                "thresholds must be a scalar, 1-D (shared by every row) or "
+                "2-D (one row of thresholds per prediction row); got shape "
+                f"{t.shape}.")
+        if t.ndim == 2 and t.shape[0] != Q.shape[0]:
+            raise ValueError(
+                "thresholds must have one row per prediction row when 2-D: "
+                f"expected first dimension {Q.shape[0]}, got shape {t.shape}. "
+                "Thresholds shared by every row are passed 1-D.")
 
         taus = self.quantiles_
-        out = np.empty((Q.shape[0], t.shape[0]))
+        per_row = t.ndim == 2
+        out = np.empty((Q.shape[0], t.shape[-1]))
         for i in range(Q.shape[0]):
-            out[i] = np.interp(t, Q[i], taus, left=taus[0], right=taus[-1])
+            out[i] = np.interp(t[i] if per_row else t, Q[i], taus,
+                               left=taus[0], right=taus[-1])
         return out
 
     def _sample_from_quantiles(self, Q, n_samples, random_state):

--- a/chimeraboost/quantile_api.py
+++ b/chimeraboost/quantile_api.py
@@ -6,6 +6,8 @@ cross features, no bagging, no full-data refit. It imports the validation
 helpers and keeps the same flat, module-function style.
 """
 
+import warnings
+
 import numpy as np
 from sklearn.base import BaseEstimator
 
@@ -495,7 +497,8 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
         ``thresholds`` is shared by every row; a 2-D (n_samples, T) array is
         read row against row -- the rule is dimensionality, never length.
         Clamped to the outermost fitted levels rather than to 0 and 1, for
-        the same reason ``"mean"`` extends flat.
+        the same reason ``"mean"`` extends flat. Warns when the fitted grid
+        is too coarse to carry a CDF (any inter-level gap above 0.2).
 
         ``kind="sample"`` returns (n_samples_rows, n_samples): inverse-
         transform draws from the predicted distribution, for feeding a
@@ -542,7 +545,9 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
         ``predict(kind="cdf")``: linear between grid levels, clamped to the
         outermost fitted levels outside them -- on the default grid no
         probability reads below 0.05 or above 0.95, because the model never
-        estimated those tails.
+        estimated those tails. A coarse grid (any inter-level gap above 0.2,
+        e.g. ``quantiles=[0.1, 0.5, 0.9]``) warns: the probabilities would
+        be mostly interpolation, not estimates.
 
         ``thresholds`` may be a scalar (one probability per row, returned
         1-D), a 1-D array of T values shared by every row (returns
@@ -597,6 +602,23 @@ class ChimeraBoostQuantileRegressor(BaseEstimator):
                 "Thresholds shared by every row are passed 1-D.")
 
         taus = self.quantiles_
+        # A coarse grid cannot really answer a CDF question: between fitted
+        # levels the curve is linear interpolation -- an assumption, not an
+        # estimate -- and beyond the outermost ones it is clamp. Warn when
+        # the largest inter-level gap leaves interpolation doing most of the
+        # work. The 0.2 line keeps an even 9-level grid quiet and flags the
+        # three-level interval grids the docs recommend for other purposes.
+        widest = float(np.diff(taus).max()) if taus.size > 1 else 1.0
+        if widest > 0.2:
+            warnings.warn(
+                f"The fitted grid has {taus.size} quantile level(s) with "
+                f"gaps up to {widest:.2f}, so P(y <= t) is mostly linear "
+                "interpolation between distant levels, clamped to "
+                f"[{taus[0]:g}, {taus[-1]:g}] outside them. Fit a denser "
+                "grid -- the 19-level default resolves steps of 0.05 -- if "
+                "you need CDF or exceedance probabilities.",
+                UserWarning, stacklevel=3)
+
         per_row = t.ndim == 2
         out = np.empty((Q.shape[0], t.shape[-1]))
         for i in range(Q.shape[0]):

--- a/docs/quantiles.md
+++ b/docs/quantiles.md
@@ -58,6 +58,12 @@ scalar, a 1-D list applied to every row, or a 2-D `(n, T)` array read row agains
 carries over: on the default grid no probability reads below 0.05 or above 0.95,
 because the model never estimated those tails.
 
+Both CDF readers need a grid dense enough to interpolate honestly. If any gap between
+adjacent fitted levels exceeds 0.2 — `quantiles=[0.1, 0.5, 0.9]`, say — they warn,
+because the probabilities would be mostly interpolation between distant levels rather
+than estimates. A sparse grid is fine for the intervals it was fitted for; fit the
+19-level default when you want probabilities.
+
 ## Predictions never cross
 
 The 30% quantile is never returned above the 70%. Every row is sorted on its way out, so

--- a/docs/quantiles.md
+++ b/docs/quantiles.md
@@ -42,6 +42,7 @@ More worked snippets are in [Recipes](recipes.md#quantile-regression).
 model.predict(X, kind="median")                          # (n,) the centre
 model.predict(X, kind="cdf", thresholds=[0.0, 10.0])     # (n, 2) P(y <= t)
 model.predict(X, kind="sample", n_samples=500, random_state=0)   # (n, 500)
+model.predict_thresh(X, 10.0)                            # (n,) P(y > 10)
 ```
 
 `kind="cdf"` inverts the grid, and `kind="sample"` draws from it by inverse transform —
@@ -49,6 +50,13 @@ useful for feeding a downstream simulation. Both interpolate between fitted leve
 clamp outside the outermost ones, because a finite grid says nothing about the tails
 beyond it. `kind="interval"` still refuses levels you did not fit: reading a fitted
 curve at a point is a different thing from claiming a level was fitted when it was not.
+
+`predict_thresh` is the exceedance view of the same inversion: `direction="greater"`
+(the default) returns `P(y > t)`, `"less"` returns `P(y <= t)`. Thresholds may be a
+scalar, a 1-D list applied to every row, or a 2-D `(n, T)` array read row against row —
+1-D always means shared, per-row always means 2-D, regardless of length. The clamp
+carries over: on the default grid no probability reads below 0.05 or above 0.95,
+because the model never estimated those tails.
 
 ## Predictions never cross
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -132,6 +132,11 @@ print(qm.format_report(model.report(X_test, y_test)))
 # P(y <= t): the fitted grid, inverted.
 p_below = model.predict(X_test, kind="cdf", thresholds=[0.0, 100.0])
 
+# P(y > t): the exceedance view of the same inversion. A scalar returns (n,);
+# a 2-D (n, T) array gives every row its own thresholds, e.g. a per-row line
+# to beat: model.predict_thresh(X_test, lines.reshape(-1, 1)).
+p_over = model.predict_thresh(X_test, 100.0)
+
 # Draws for a downstream simulation.
 draws = model.predict(X_test, kind="sample", n_samples=1000, random_state=0)
 ```

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -128,6 +128,10 @@ print(qm.format_report(model.report(X_test, y_test)))
 
 ### Asking the distribution other questions
 
+Probability questions need a dense fitted grid (the 19-level default). A sparse
+interval grid like `quantiles=[0.1, 0.5, 0.9]` warns here: the answer would be mostly
+interpolation.
+
 ```python
 # P(y <= t): the fitted grid, inverted.
 p_below = model.predict(X_test, kind="cdf", thresholds=[0.0, 100.0])

--- a/tests/test_metrics_and_predict_kinds.py
+++ b/tests/test_metrics_and_predict_kinds.py
@@ -215,6 +215,67 @@ def test_cdf_accepts_a_scalar_threshold():
     assert m.predict(Xt, kind="cdf", thresholds=0.0).shape == (200, 1)
 
 
+def test_cdf_reads_2d_thresholds_row_against_row():
+    m, Xt = _q()
+    t = np.column_stack([np.linspace(-2.0, 2.0, 200), np.full(200, 0.5)])
+    got = m.predict(Xt, kind="cdf", thresholds=t)
+    assert got.shape == (200, 2)
+    # Row i of a 2-D thresholds array must answer exactly as row i asked with
+    # its own thresholds shared -- per-row is the same inversion, not new math.
+    for i in (0, 7, 199):
+        assert np.array_equal(
+            got[i], m.predict(Xt[i:i + 1], kind="cdf", thresholds=t[i])[0])
+
+
+def test_cdf_2d_thresholds_must_carry_one_row_per_prediction_row():
+    m, Xt = _q()
+    with pytest.raises(ValueError, match="one row per prediction row"):
+        m.predict(Xt, kind="cdf", thresholds=np.zeros((2, 2)))
+
+
+def test_predict_thresh_is_the_complement_of_the_cdf():
+    m, Xt = _q()
+    t = [-1.0, 0.0, 1.0]
+    cdf = m.predict(Xt, kind="cdf", thresholds=t)
+    assert np.array_equal(m.predict_thresh(Xt, t, direction="less"), cdf)
+    assert np.array_equal(m.predict_thresh(Xt, t), 1.0 - cdf)
+
+
+def test_predict_thresh_shapes_follow_the_thresholds():
+    m, Xt = _q()
+    assert m.predict_thresh(Xt, 0.0).shape == (200,)
+    assert m.predict_thresh(Xt, [0.0, 1.0]).shape == (200, 2)
+    assert m.predict_thresh(Xt, np.zeros((200, 3))).shape == (200, 3)
+
+
+def test_predict_thresh_reads_a_level_back_at_its_own_value():
+    m, Xt = _q()
+    Q = m.predict(Xt)
+    taus = m.quantiles_
+    # A per-row threshold sitting exactly on a fitted level must read that
+    # level back: P(y <= q_k(x)) = tau_k.
+    for k in (0, 9, 18):
+        got = m.predict_thresh(Xt, Q[:, [k]], direction="less")
+        assert np.allclose(got[:, 0], taus[k]), k
+
+
+def test_predict_thresh_clamps_to_the_fitted_levels():
+    m, Xt = _q()
+    lo, hi = m.quantiles_[0], m.quantiles_[-1]
+    # Beyond the grid the honest answer is the edge level, never 0 or 1.
+    assert np.allclose(m.predict_thresh(Xt, -100.0), 1.0 - lo)
+    assert np.allclose(m.predict_thresh(Xt, 100.0), 1.0 - hi)
+    assert np.allclose(m.predict_thresh(Xt, -100.0, direction="less"), lo)
+
+
+def test_predict_thresh_refuses_bad_arguments():
+    m, Xt = _q()
+    with pytest.raises(ValueError, match="direction must be"):
+        m.predict_thresh(Xt, 0.0, direction="above")
+    with pytest.raises(ValueError, match="needs `thresholds`"):
+        m.predict_thresh(Xt, None)
+
+
 def test_samples_follow_the_predicted_distribution_and_are_seeded():
     m, Xt = _q()
     s = m.predict(Xt, kind="sample", n_samples=4000, random_state=0)
@@ -242,6 +303,6 @@ def test_new_kinds_refuse_missing_arguments():
     with pytest.raises(ValueError, match="n_samples must be"):
         m.predict(Xt, kind="sample", n_samples=0)
     with pytest.raises(ValueError, match="thresholds must be"):
-        m.predict(Xt, kind="cdf", thresholds=np.zeros((2, 2)))
+        m.predict(Xt, kind="cdf", thresholds=np.zeros((2, 2, 2)))
     with pytest.raises(ValueError, match="kind must be"):
         m.predict(Xt, kind="quantile")

--- a/tests/test_metrics_and_predict_kinds.py
+++ b/tests/test_metrics_and_predict_kinds.py
@@ -7,6 +7,8 @@ of these tests are equivalence checks against those definitions rather than
 self-consistency checks.
 """
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -266,6 +268,23 @@ def test_predict_thresh_clamps_to_the_fitted_levels():
     assert np.allclose(m.predict_thresh(Xt, -100.0), 1.0 - lo)
     assert np.allclose(m.predict_thresh(Xt, 100.0), 1.0 - hi)
     assert np.allclose(m.predict_thresh(Xt, -100.0, direction="less"), lo)
+
+
+def test_cdf_on_a_coarse_grid_warns_and_the_default_grid_does_not():
+    # Three levels with gaps of 0.4 cannot carry a CDF: between them the
+    # answer is interpolation, not an estimate, so both CDF readers warn.
+    m3, Xt3 = _q(quantiles=[0.1, 0.5, 0.9])
+    with pytest.warns(UserWarning, match="denser grid"):
+        m3.predict(Xt3, kind="cdf", thresholds=[0.0])
+    with pytest.warns(UserWarning, match="denser grid"):
+        m3.predict_thresh(Xt3, 0.0)
+
+    # The 19-level default (gaps of 0.05) must stay quiet.
+    m, Xt = _q()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        m.predict(Xt, kind="cdf", thresholds=[0.0])
+        m.predict_thresh(Xt, 0.0)
 
 
 def test_predict_thresh_refuses_bad_arguments():


### PR DESCRIPTION
Closes #106.

`model.predict_thresh(X, thresholds, direction="greater")` returns the probability of the target landing beyond each threshold, read off the same fitted quantile grid as `predict(kind="cdf")` — `"greater"` gives `P(y > t)`, `"less"` gives `P(y <= t)`.

Threshold shapes (the rule is dimensionality, never length):
- scalar → `(n,)`, one probability per row
- 1-D length-T → `(n, T)`, thresholds shared by every row
- 2-D `(n, T)` → read row against row, so every row can carry its own thresholds; stack several per-row lists with `np.column_stack`. `predict(kind="cdf")` accepts the 2-D form too.

Probabilities clamp to the outermost fitted levels — never below 0.05 or above 0.95 on the default grid — the same honest-grid convention as `kind="mean"` and `kind="cdf"`: the model never estimated the tails beyond the grid.

**Coarse-grid warning.** Between fitted levels the CDF is linear interpolation — an assumption, not an estimate — so both CDF readers now raise a `UserWarning` when any inter-level gap exceeds 0.2 (e.g. `quantiles=[0.1, 0.5, 0.9]`), pointing at a denser grid. An even 9-level grid stays quiet, and a sparse grid remains fine for the intervals it was fitted for.

No new math: the quantile matrix is already non-crossing per row (0.28.0 rearrangement), so the CDF inversion is well-defined as-is; this generalizes the existing `_cdf_from_quantiles` loop and wraps it. Training and default predict paths untouched.

Verified: full suite green locally; hand check on 8k held-out rows shows bucketed predicted exceedance tracking empirical frequency and per-row thresholds at the predicted median reading exactly 0.5; mkdocs renders the method on the API page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)